### PR TITLE
fix: rename marketplace, add CI/CD, improve README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "cc-skills",
+  "name": "rube-cc-skills",
   "version": "1.1.0",
   "description": "A curated collection of Claude Code plugins",
   "owner": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun scripts/validate-plugins.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: bun install --frozen-lockfile
+      - run: bun scripts/validate-plugins.mjs
+      - name: Run semantic-release
+        run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,11 +79,10 @@ plugin-name/
 | Task | Command |
 |------|---------|
 | Validate plugins | `bun scripts/validate-plugins.mjs` |
-| Release (dry run) | `npm run release:dry` |
-| Release | `npm run release` |
 
 ## Conventions
 
 - **Marketplace SSoT**: All plugin metadata lives in `.claude-plugin/marketplace.json`
-- **Versioning**: Semantic release manages versions across all manifests
+- **Versioning**: Semantic-release via GitHub Actions on merge to `main` — do not edit versions manually
+- **Branching**: PRs against `main`, CI validates on PR, release runs on merge
 - **License**: MIT across all plugins

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "private": true,
   "description": "A curated collection of Claude Code plugins: multi-agent dev team, AI council code reviews, and project management",
   "scripts": {
-    "validate": "bun scripts/validate-plugins.mjs",
-    "release:preflight": "test -z \"$(git status --porcelain)\" || (echo 'Working directory not clean' && git status --short && exit 1)",
-    "release": "npm run release:preflight && semantic-release --no-ci",
-    "release:dry": "npm run release:preflight && semantic-release --no-ci --dry-run"
+    "validate": "bun scripts/validate-plugins.mjs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- **Marketplace rename**: `cc-skills` → `rube-cc-skills` to avoid name collision with terrylica/cc-skills
- **Fix install commands**: use marketplace name (`@rube-cc-skills`) instead of GitHub path (`@rube-de/cc-skills`) — this was the root cause of the "Plugin not found in marketplace" error
- **Add GitHub Actions CI/CD**: PR validation (`ci.yml`) and auto-release on merge to main (`release.yml`) — replaces manual `npm run release`
- **Expand README**: Quick Start one-liner, Step-by-Step installation, verify commands, updating section, developer schema docs, release workflow documentation

## Test plan

- [x] Verified `claude plugin install claude-dev-team@rube-cc-skills` works after marketplace rename
- [x] `bun scripts/validate-plugins.mjs` passes
- [ ] CI workflow validates on this PR
- [ ] Verify release workflow triggers on merge to main