### PR TITLE
feat: add plugin-dev plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,6 +64,23 @@
         "issue-creation",
         "task-planning"
       ]
+    },
+    {
+      "name": "plugin-dev",
+      "description": "Plugin development tools: scaffold new plugins, validate SKILL.md frontmatter, audit hooks for silent failures",
+      "version": "1.0.0",
+      "source": "./plugins/plugin-dev",
+      "category": "development",
+      "author": {
+        "name": "rube-de",
+        "url": "https://github.com/rube-de"
+      },
+      "keywords": [
+        "plugin-development",
+        "scaffolding",
+        "validation",
+        "skill-authoring"
+      ]
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Claude Code skills marketplace: **3 plugins** for multi-agent development, AI council reviews, and project management.
+Claude Code skills marketplace: **4 plugins** for multi-agent development, AI council reviews, project management, and plugin development.
 
 ## Navigation
 
@@ -17,6 +17,7 @@ Claude Code skills marketplace: **3 plugins** for multi-agent development, AI co
 | [council](./plugins/council/) | Code Review | 1.1.0 | `/council` |
 | [claude-dev-team](./plugins/claude-dev-team/) | Development | 1.0.0 | `/claude-dev-team` |
 | [project-manager](./plugins/project-manager/) | Productivity | `/project-manager` |
+| [plugin-dev](./plugins/plugin-dev/) | Development | 1.0.0 | `/plugin-dev`, `/plugin-dev:create` |
 
 ## Directory Structure
 
@@ -37,8 +38,12 @@ cc-skills/
 │   │   ├── hooks/               # Session start validation
 │   │   ├── scripts/             # Agent teams prerequisite check
 │   │   └── skills/              # claude-dev-team
-│   └── project-manager/         ← GitHub issue creation
-│       └── skills/              # project-manager
+│   ├── project-manager/         ← GitHub issue creation
+│   │   └── skills/              # project-manager
+│   └── plugin-dev/              ← Plugin development tools
+│       ├── commands/            # create (scaffolding)
+│       ├── scripts/             # audit-hooks.sh
+│       └── skills/              # plugin-dev
 ├── scripts/
 │   ├── validate-plugins.mjs     ← Plugin validation
 │   └── marketplace.schema.json  ← JSON Schema for marketplace.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A monorepo of [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins and [agent skills](https://agentskills.io).
 
-[![Plugins](https://img.shields.io/badge/plugins-3-green.svg)](#plugins)
+[![Plugins](https://img.shields.io/badge/plugins-4-green.svg)](#plugins)
 [![License](https://img.shields.io/badge/license-MIT-yellow.svg)](./LICENSE)
 
 ## Plugins
@@ -12,6 +12,7 @@ A monorepo of [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plug
 | [council](./plugins/council/) | Code Review | Plugin or Skill | Orchestrate Gemini, Codex, Qwen, GLM-4.7, and Kimi K2.5 for consensus-driven reviews |
 | [claude-dev-team](./plugins/claude-dev-team/) | Development | Plugin only | Multi-agent dev team with four modes: plan, dev, full, and auto via Agent Teams |
 | [project-manager](./plugins/project-manager/) | Productivity | Plugin or Skill | Interactive issue creation optimized for LLM agent teams |
+| [plugin-dev](./plugins/plugin-dev/) | Development | Plugin or Skill | Scaffold plugins, validate SKILL.md frontmatter, audit hooks |
 
 > **Plugin vs Skill**: Plugins use the full Claude Code plugin system (hooks, agents, commands, scripts). Skills install only SKILL.md definitions via [skills.sh](https://skills.sh). Plugins that rely on hooks, commands, or agent definitions need plugin install. See each plugin's README for details.
 
@@ -32,7 +33,7 @@ Run these commands in your **terminal** (not inside Claude Code):
 claude plugin marketplace add rube-de/cc-skills
 
 # 2. Install all plugins
-for p in council claude-dev-team project-manager; do claude plugin install "$p@rube-cc-skills"; done
+for p in council claude-dev-team project-manager plugin-dev; do claude plugin install "$p@rube-cc-skills"; done
 
 # 3. Restart Claude Code to activate
 claude
@@ -62,6 +63,7 @@ claude plugin marketplace list
 claude plugin install council@rube-cc-skills
 claude plugin install claude-dev-team@rube-cc-skills
 claude plugin install project-manager@rube-cc-skills
+claude plugin install plugin-dev@rube-cc-skills
 ```
 
 #### Step 3: Restart Claude Code
@@ -79,7 +81,7 @@ claude
 claude plugin list | grep rube-cc-skills
 
 # Inside Claude Code, type "/" and look for:
-#   /council, /claude-dev-team, /project-manager
+#   /council, /claude-dev-team, /project-manager, /plugin-dev
 ```
 
 ### Skills (via [skills.sh](https://skills.sh))
@@ -120,8 +122,12 @@ cc-skills/
 │   │   ├── hooks/           # Session start hooks
 │   │   ├── scripts/         # Agent team checks
 │   │   └── skills/          # claude-dev-team
-│   └── project-manager/     # Issue creation
-│       └── skills/          # project-manager
+│   ├── project-manager/     # Issue creation
+│   │   └── skills/          # project-manager
+│   └── plugin-dev/          # Plugin development tools
+│       ├── commands/        # Scaffolding command
+│       ├── scripts/         # Hook audit script
+│       └── skills/          # plugin-dev
 ├── scripts/
 │   └── validate-plugins.mjs # Plugin validation
 ├── CLAUDE.md                # Claude Code context

--- a/plugins/plugin-dev/LICENSE
+++ b/plugins/plugin-dev/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 rube-de
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/plugin-dev/README.md
+++ b/plugins/plugin-dev/README.md
@@ -1,0 +1,73 @@
+# plugin-dev
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Skills](https://img.shields.io/badge/Skills-1-blue.svg)]()
+[![Commands](https://img.shields.io/badge/Commands-1-green.svg)]()
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
+[![Install](https://img.shields.io/badge/Install-Plugin%20%7C%20Skill-informational.svg)]()
+
+Plugin development tools for the cc-skills marketplace: scaffold new plugins, validate SKILL.md frontmatter, and audit hooks for silent failures.
+
+## Features
+
+| Tool | Type | What it does |
+|------|------|-------------|
+| `/plugin-dev:create` | Command | Interactive scaffolding — creates directory structure, SKILL.md, marketplace entry |
+| `bun scripts/validate-plugins.mjs` | Script | Validates schema, source paths, orphans, and SKILL.md frontmatter |
+| `bash plugins/plugin-dev/scripts/audit-hooks.sh` | Script | Detects silent failure patterns in hook/script files |
+
+## Installation
+
+### As Plugin (recommended)
+
+```bash
+claude plugin install plugin-dev@rube-cc-skills
+```
+
+### As Skill (validation + audit only, no `/plugin-dev:create` command)
+
+```bash
+npx skills add rube-de/cc-skills --skill plugin-dev
+```
+
+## Usage
+
+### Scaffold a New Plugin
+
+```
+/plugin-dev:create my-new-plugin
+```
+
+Walks you through category selection, component choice, and generates the full directory structure with marketplace registration.
+
+### Validate All Plugins
+
+Inside Claude Code, say "validate plugins" or run directly:
+
+```bash
+bun scripts/validate-plugins.mjs
+```
+
+Checks:
+- marketplace.json schema conformance
+- Source paths exist
+- No orphaned directories
+- SKILL.md frontmatter: `name` (kebab-case), `description` (non-empty)
+- Every plugin has at least one component dir
+
+### Audit Hooks
+
+Inside Claude Code, say "hook audit" or run directly:
+
+```bash
+bash plugins/plugin-dev/scripts/audit-hooks.sh
+```
+
+Detects:
+- Shell: `mkdir`/`cp`/`mv`/`rm` without error handling (no `set -e`)
+- Python: bare `except: pass` or `except Exception: pass`
+- Optional ShellCheck integration
+
+## License
+
+MIT

--- a/plugins/plugin-dev/commands/create.md
+++ b/plugins/plugin-dev/commands/create.md
@@ -1,0 +1,194 @@
+---
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion]
+description: "Scaffold a new plugin with directory structure, manifests, and marketplace registration"
+---
+
+# /plugin-dev:create — Plugin Scaffolding
+
+Scaffold a new Claude Code plugin in the cc-skills marketplace.
+
+## Step 1: Plugin Name
+
+If `$ARGUMENTS` is provided and matches kebab-case (`^[a-z0-9-]+$`), use it as the plugin name.
+
+Otherwise, ask the user:
+
+```
+AskUserQuestion: "What should the plugin be named? (kebab-case, e.g. my-plugin)"
+```
+
+Validate:
+- Must match `^[a-z0-9-]+$`
+- Must NOT already exist in `.claude-plugin/marketplace.json` (check `plugins[].name`)
+- Must NOT have an existing directory at `plugins/<name>/`
+
+If invalid, explain why and ask again.
+
+## Step 2: Category
+
+Ask the user to pick a category from the marketplace schema enum:
+
+```
+AskUserQuestion: "Which category?"
+Options: code-review, development, productivity, quality, automation, documentation, devops, utilities
+```
+
+## Step 3: Components
+
+Ask the user which components to include (multi-select):
+
+```
+AskUserQuestion: "Which components does your plugin need?" (multiSelect: true)
+Options:
+- skills — SKILL.md definitions (triggers, allowed-tools)
+- hooks — Pre/PostToolUse, SessionStart hooks
+- commands — Slash commands (/plugin:command)
+- agents — Agent/subagent definitions
+```
+
+At least one must be selected. If none selected, default to `skills`.
+
+## Step 4: Create Directory Structure
+
+Create the plugin directory with selected components:
+
+```
+plugins/<name>/
+├── skills/<name>/SKILL.md    (if skills selected)
+├── hooks/hooks.json           (if hooks selected)
+├── hooks/placeholder.sh       (if hooks selected)
+├── commands/                   (if commands selected — empty, user fills in)
+├── agents/                     (if agents selected — empty, user fills in)
+├── README.md
+└── LICENSE
+```
+
+### Generated SKILL.md (if skills selected)
+
+```markdown
+---
+name: <plugin-name>
+description: "<one-line description — user should update>"
+allowed-tools: [Read, Bash, Grep, Glob]
+user-invocable: true
+---
+
+# <Plugin Name>
+
+TODO: Describe what this skill does and when it triggers.
+```
+
+### Generated hooks.json (if hooks selected)
+
+```json
+{
+  "hooks": [
+    {
+      "type": "SessionStart",
+      "command": "bash plugins/<name>/hooks/placeholder.sh"
+    }
+  ]
+}
+```
+
+### Generated placeholder.sh (if hooks selected)
+
+```bash
+#!/bin/bash
+# <name> plugin — SessionStart hook
+# Replace this with your actual hook logic
+
+set -e
+echo "<name> plugin loaded."
+exit 0
+```
+
+Make it executable: `chmod +x plugins/<name>/hooks/placeholder.sh`
+
+### Generated README.md
+
+```markdown
+# <name>
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
+
+TODO: Describe your plugin here.
+
+## Installation
+
+```bash
+claude plugin install <name>@rube-cc-skills
+```
+
+## Usage
+
+TODO: Document usage.
+
+## License
+
+MIT
+```
+
+### Generated LICENSE
+
+Use the standard MIT license text with `Copyright (c) 2025 rube-de`.
+
+## Step 5: Register in Marketplace
+
+Read `.claude-plugin/marketplace.json`, add a new entry to the `plugins` array:
+
+```json
+{
+  "name": "<name>",
+  "description": "TODO: Update plugin description (min 10 chars)",
+  "version": "1.0.0",
+  "source": "./plugins/<name>",
+  "category": "<selected-category>",
+  "author": {
+    "name": "rube-de",
+    "url": "https://github.com/rube-de"
+  },
+  "keywords": ["<name>"]
+}
+```
+
+**Important**: Remind the user to update the `description` field — the placeholder won't pass schema validation (needs to be meaningful).
+
+## Step 6: Validate
+
+Run the validation script to confirm the new plugin passes all checks:
+
+```bash
+bun scripts/validate-plugins.mjs
+```
+
+If validation fails, diagnose and fix automatically if possible. Common issues:
+- Description too short (< 10 chars) — ask user for a real description
+- Name not kebab-case — should have been caught in Step 1
+
+## Step 7: Summary
+
+Present a summary of what was created:
+
+```
+✓ Created plugins/<name>/
+  ├── skills/<name>/SKILL.md
+  ├── hooks/hooks.json + placeholder.sh
+  ├── README.md
+  └── LICENSE
+✓ Registered in .claude-plugin/marketplace.json
+✓ Validation passed
+
+Next steps:
+1. Edit SKILL.md to define your skill's triggers and behavior
+2. Update README.md with documentation
+3. Update the description in marketplace.json
+4. Run: bun scripts/validate-plugins.mjs
+```
+
+## Important Notes
+
+- Do NOT create a per-plugin `plugin.json` — marketplace.json is the SSoT
+- Do NOT modify CLAUDE.md or root README.md — those are updated manually or via separate PR
+- If the user provides a description during scaffolding, use it in both SKILL.md and marketplace.json

--- a/plugins/plugin-dev/scripts/audit-hooks.sh
+++ b/plugins/plugin-dev/scripts/audit-hooks.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# audit-hooks.sh — Scan plugin hook/script files for silent failure patterns
+# Exit 0 = clean, Exit 1 = findings
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+PLUGINS_DIR="$ROOT_DIR/plugins"
+
+findings=0
+checked=0
+
+# Colors (disable if not a terminal)
+if [ -t 1 ]; then
+  RED='\033[0;31m'
+  YELLOW='\033[0;33m'
+  GREEN='\033[0;32m'
+  NC='\033[0m'
+else
+  RED='' YELLOW='' GREEN='' NC=''
+fi
+
+log_finding() {
+  local file="$1" line="$2" msg="$3"
+  local rel_path="${file#"$ROOT_DIR/"}"
+  printf "  ${RED}✗${NC} %s:%s — %s\n" "$rel_path" "$line" "$msg"
+  findings=$((findings + 1))
+}
+
+echo "Auditing hook and script files..."
+
+# --- Shell scripts ---
+while IFS= read -r -d '' file; do
+  checked=$((checked + 1))
+
+  # Check if set -e is present (makes error handling implicit)
+  has_set_e=false
+  if grep -qE '^\s*set\s+-[a-zA-Z]*e' "$file"; then
+    has_set_e=true
+  fi
+
+  if [ "$has_set_e" = false ]; then
+    # Look for destructive commands without error handling
+    while IFS=: read -r lineno line_content; do
+      # Skip comments
+      [[ "$line_content" =~ ^[[:space:]]*# ]] && continue
+      # Skip lines that already have || or && error handling
+      echo "$line_content" | grep -qE '\|\||&&' && continue
+      # Skip lines inside if/while conditions
+      [[ "$line_content" =~ ^[[:space:]]*(if|while|elif) ]] && continue
+
+      log_finding "$file" "$lineno" "unguarded command without 'set -e': $(echo "$line_content" | sed 's/^[[:space:]]*//' | head -c 80)"
+    done < <(grep -nE '\b(mkdir|cp|mv|rm)\b' "$file" || true)
+  fi
+done < <(find "$PLUGINS_DIR" -type f -name '*.sh' \( -path '*/hooks/*' -o -path '*/scripts/*' \) -print0 2>/dev/null)
+
+# --- Python scripts ---
+while IFS= read -r -d '' file; do
+  checked=$((checked + 1))
+
+  while IFS=: read -r lineno line_content; do
+    log_finding "$file" "$lineno" "bare except with pass suppresses all errors"
+  done < <(grep -nE '^\s*except(\s+Exception)?\s*:\s*pass\s*$' "$file" || true)
+done < <(find "$PLUGINS_DIR" -type f -name '*.py' \( -path '*/hooks/*' -o -path '*/scripts/*' \) -print0 2>/dev/null)
+
+# --- Optional: ShellCheck ---
+echo ""
+if command -v shellcheck >/dev/null 2>&1; then
+  echo "Running ShellCheck..."
+  sc_findings=0
+  while IFS= read -r -d '' file; do
+    if ! shellcheck -S warning "$file" >/dev/null 2>&1; then
+      rel_path="${file#"$ROOT_DIR/"}"
+      printf "  ${YELLOW}⚠${NC} %s has ShellCheck warnings (run: shellcheck %s)\n" "$rel_path" "$rel_path"
+      sc_findings=$((sc_findings + 1))
+    fi
+  done < <(find "$PLUGINS_DIR" -type f -name '*.sh' \( -path '*/hooks/*' -o -path '*/scripts/*' \) -print0 2>/dev/null)
+
+  if [ "$sc_findings" -eq 0 ]; then
+    printf "  ${GREEN}✓${NC} ShellCheck: all scripts clean\n"
+  fi
+else
+  printf "  ${YELLOW}ℹ${NC} ShellCheck not installed — skipping (install: brew install shellcheck)\n"
+fi
+
+# --- Summary ---
+echo ""
+echo "Scanned $checked files."
+if [ "$findings" -eq 0 ]; then
+  printf "${GREEN}✓ No silent failure patterns found.${NC}\n"
+  exit 0
+else
+  printf "${RED}✗ Found %d finding(s).${NC}\n" "$findings"
+  exit 1
+fi

--- a/plugins/plugin-dev/skills/plugin-dev/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-dev/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: plugin-dev
+description: "Validate plugin SKILL.md frontmatter and audit hook scripts for silent failures. Run validation to check all plugins pass schema, source path, and frontmatter checks. Run hook audit to detect unhandled errors in shell and Python scripts."
+allowed-tools: [Read, Bash, Grep, Glob]
+user-invocable: true
+---
+
+# Plugin Development Tools
+
+On-demand validation and hook auditing for the cc-skills marketplace.
+
+## Triggers
+
+Use this skill when the user says: "validate plugins", "check plugin", "hook audit", "validate skills", "audit hooks", "check skill frontmatter", "plugin validation".
+
+## Available Tools
+
+### 1. Plugin Validation
+
+Validates all registered plugins: JSON Schema, source paths, orphan detection, and SKILL.md frontmatter.
+
+```bash
+bun scripts/validate-plugins.mjs
+```
+
+**What it checks:**
+- marketplace.json conforms to JSON Schema
+- All plugin `source` paths exist on disk
+- No orphaned plugin directories (dirs without marketplace entries)
+- SKILL.md frontmatter has valid `name` (kebab-case) and non-empty `description`
+- Every plugin has at least one component directory (skills/, hooks/, commands/, agents/)
+
+### 2. Hook Audit
+
+Scans hook and script files for silent failure patterns.
+
+```bash
+bash plugins/plugin-dev/scripts/audit-hooks.sh
+```
+
+**What it checks:**
+- Shell scripts (`.sh`): `mkdir`/`cp`/`mv`/`rm` without error handling (unless `set -e` is active)
+- Python scripts (`.py`): bare `except: pass` or `except Exception: pass`
+- Optional: ShellCheck integration (skipped with message if not installed)
+
+**Exit codes:** 0 = clean, 1 = findings
+
+## Workflow
+
+When the user asks to validate or audit:
+
+1. Run `bun scripts/validate-plugins.mjs` for plugin validation
+2. Run `bash plugins/plugin-dev/scripts/audit-hooks.sh` for hook auditing
+3. Report results clearly — separate passing checks from failures
+4. For failures, suggest specific fixes
+
+## Scaffolding
+
+To scaffold a new plugin interactively, use the command:
+
+```
+/plugin-dev:create [plugin-name]
+```
+
+This is a separate slash command — not part of this skill.


### PR DESCRIPTION
## Summary

- **New plugin**: `plugin-dev` — plugin development tools for the cc-skills marketplace
- **`/plugin-dev:create`** command: interactive scaffolding (name, category, components → full directory structure + marketplace registration)
- **SKILL.md validation**: extended `validate-plugins.mjs` with step 4 — checks frontmatter `name` (kebab-case), `description` (non-empty, handles `>-` block scalars), and at least one component directory per plugin
- **`audit-hooks.sh`**: scans `plugins/*/hooks/*.sh` and `plugins/*/scripts/*.sh` for `mkdir`/`cp`/`mv`/`rm` without error handling, Python bare `except: pass`, optional ShellCheck integration

## Files

### New (5)
| File | Purpose |
|------|---------|
| `plugins/plugin-dev/skills/plugin-dev/SKILL.md` | Main skill — validation and audit triggers |
| `plugins/plugin-dev/commands/create.md` | `/plugin-dev:create` scaffolding command |
| `plugins/plugin-dev/scripts/audit-hooks.sh` | Hook silent failure audit |
| `plugins/plugin-dev/README.md` | Plugin docs |
| `plugins/plugin-dev/LICENSE` | MIT |

### Modified (4)
| File | Change |
|------|--------|
| `scripts/validate-plugins.mjs` | +97 lines — SKILL.md frontmatter validation |
| `.claude-plugin/marketplace.json` | Added plugin-dev entry |
| `CLAUDE.md` | 3→4 plugins, table + tree |
| `README.md` | Badge 3→4, table, install commands, tree |

## Test plan

- [x] `bun scripts/validate-plugins.mjs` — all 4 plugins pass (schema, paths, orphans, frontmatter)
- [x] `bash plugins/plugin-dev/scripts/audit-hooks.sh` — runs clean on existing scripts (4 files scanned)
- [x] Directory structure matches plan: `plugins/plugin-dev/{commands,scripts,skills}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)