### PR TITLE
docs: add AGENTS.md, slim down CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# AGENTS.md
+
+Claude Code skills marketplace: **4 plugins** for multi-agent development, AI council reviews, project management, and plugin development.
+
+## Directory Structure
+
+```
+cc-skills/
+├── .claude-plugin/
+│   └── marketplace.json         ← Plugin registry (SSoT)
+├── plugin.json                  ← Root plugin metadata
+├── plugins/
+│   ├── council/                 ← AI council code reviews
+│   │   ├── agents/              # External AI consultants + internal Claude subagents
+│   │   ├── hooks/               # Pre/post tool-use hooks
+│   │   ├── scripts/             # Preflight, JSON validation
+│   │   └── skills/              # council, council-reference
+│   ├── claude-dev-team/         ← Multi-agent dev team (Agent Teams)
+│   │   ├── agents/              # Researcher subagent (Context7)
+│   │   ├── commands/            # plan-task, dev-task, full-task, auto-task
+│   │   ├── hooks/               # Session start validation
+│   │   ├── scripts/             # Agent teams prerequisite check
+│   │   └── skills/              # claude-dev-team
+│   ├── project-manager/         ← GitHub issue creation
+│   │   └── skills/              # project-manager
+│   └── plugin-dev/              ← Plugin development tools
+│       ├── commands/            # create (scaffolding)
+│       ├── scripts/             # audit-hooks.sh
+│       └── skills/              # plugin-dev
+├── scripts/
+│   ├── validate-plugins.mjs     ← Plugin validation
+│   └── marketplace.schema.json  ← JSON Schema for marketplace.json
+├── docs/
+│   └── PLUGIN-AUTHORING.md      ← How to create plugins
+├── AGENTS.md                    ← Universal agent instructions (this file)
+├── CLAUDE.md                    ← Claude Code-specific instructions
+├── README.md                    ← Installation & overview
+├── LICENSE                      ← MIT
+├── .releaserc.yml               ← Semantic release config
+└── package.json                 ← Dependencies & scripts
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `.claude-plugin/marketplace.json` | Plugin registry — single source of truth for all plugin metadata |
+| `plugin.json` | Root plugin metadata (name, version, description) |
+| `plugins/*/skills/*/SKILL.md` | Skill activation definitions |
+| `plugins/*/hooks/hooks.json` | Hook definitions per plugin |
+| `plugins/*/agents/*.md` | Agent/subagent definitions |
+
+## Plugin Architecture
+
+Each plugin follows this structure:
+
+```
+plugin-name/
+├── agents/       → Agent definitions (subagents, teammates)
+├── commands/     → Slash commands (/plugin:command)
+├── hooks/        → hooks.json (PreToolUse, PostToolUse, SessionStart)
+├── scripts/      → Shell scripts for hooks and validation
+└── skills/       → Bundled skills with SKILL.md + references/
+```
+
+See [docs/PLUGIN-AUTHORING.md](./docs/PLUGIN-AUTHORING.md) for the full authoring guide.
+
+## Dev Environment
+
+- Run `bun install` to install dependencies
+- Check the `name` field in `package.json` to confirm the correct package identity — skip the top-level one when looking at plugins
+- Plugin directories live under `plugins/` — each is self-contained
+- Refer to `.claude-plugin/marketplace.json` as the single source of truth for all plugin metadata
+
+## Git Workflow
+
+- Always run `git fetch origin && git pull origin main` before planning or starting any work
+- Always create a fresh branch off remote main before editing: `git checkout -b <branch-name> origin/main`
+- Never commit directly to `main`
+- Use conventional commits (`feat:`, `fix:`, `docs:`, `chore:`, etc.) — semantic-release picks these up
+
+## Testing / Validation
+
+- Find the CI plan in `.github/workflows/` (`ci.yml` validates on PR, `release.yml` runs on merge to main)
+- Run `bun scripts/validate-plugins.mjs` to validate all plugins locally
+- Fix any validation errors until the suite is clean before committing
+- After adding or moving plugin files, re-run validation to catch orphaned dirs or missing marketplace entries
+
+## PR Instructions
+
+- PRs target `main`
+- Always run `bun scripts/validate-plugins.mjs` before committing
+- CI will run the same validation — make sure it passes locally first
+- Semantic-release handles versioning on merge — do not edit version numbers manually
+
+## Conventions
+
+- **Marketplace SSoT**: All plugin metadata lives in `.claude-plugin/marketplace.json`
+- **Versioning**: Semantic-release via GitHub Actions — never edit versions by hand
+- **Branching**: PRs against `main`, CI validates on PR, release on merge
+- **License**: MIT across all plugins

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,93 +1,28 @@
 # CLAUDE.md
 
-Claude Code skills marketplace: **4 plugins** for multi-agent development, AI council reviews, project management, and plugin development.
+@AGENTS.md
+
+## Plugins (Claude Code skills)
+
+| Plugin | Category | Version | Skill Triggers |
+|--------|----------|---------|----------------|
+| council | Code Review | 1.1.0 | `/council` |
+| claude-dev-team | Development | 1.0.0 | `/claude-dev-team` |
+| project-manager | Productivity | — | `/project-manager` |
+| plugin-dev | Development | 1.0.0 | `/plugin-dev`, `/plugin-dev:create` |
 
 ## Navigation
 
 | Topic | Document |
 |-------|----------|
-| Installation | [README.md](./README.md) |
-| Marketplace Registry | [.claude-plugin/marketplace.json](./.claude-plugin/marketplace.json) |
-| Plugin Authoring | [docs/PLUGIN-AUTHORING.md](./docs/PLUGIN-AUTHORING.md) |
+| Installation | README.md |
+| Marketplace Registry | .claude-plugin/marketplace.json |
+| Plugin Authoring | docs/PLUGIN-AUTHORING.md |
 
-## Plugins
+## Claude Code Specifics
 
-| Plugin | Category | Version | Skill Triggers |
-|--------|----------|---------|----------------|
-| [council](./plugins/council/) | Code Review | 1.1.0 | `/council` |
-| [claude-dev-team](./plugins/claude-dev-team/) | Development | 1.0.0 | `/claude-dev-team` |
-| [project-manager](./plugins/project-manager/) | Productivity | `/project-manager` |
-| [plugin-dev](./plugins/plugin-dev/) | Development | 1.0.0 | `/plugin-dev`, `/plugin-dev:create` |
-
-## Directory Structure
-
-```
-cc-skills/
-├── .claude-plugin/
-│   └── marketplace.json         ← Plugin registry (SSoT)
-├── plugin.json                  ← Root plugin metadata
-├── plugins/
-│   ├── council/                 ← AI council code reviews
-│   │   ├── agents/              # External AI consultants + internal Claude subagents
-│   │   ├── hooks/               # Pre/post tool-use hooks
-│   │   ├── scripts/             # Preflight, JSON validation
-│   │   └── skills/              # council, council-reference
-│   ├── claude-dev-team/         ← Multi-agent dev team (Agent Teams)
-│   │   ├── agents/              # Researcher subagent (Context7)
-│   │   ├── commands/            # plan-task, dev-task, full-task, auto-task
-│   │   ├── hooks/               # Session start validation
-│   │   ├── scripts/             # Agent teams prerequisite check
-│   │   └── skills/              # claude-dev-team
-│   ├── project-manager/         ← GitHub issue creation
-│   │   └── skills/              # project-manager
-│   └── plugin-dev/              ← Plugin development tools
-│       ├── commands/            # create (scaffolding)
-│       ├── scripts/             # audit-hooks.sh
-│       └── skills/              # plugin-dev
-├── scripts/
-│   ├── validate-plugins.mjs     ← Plugin validation
-│   └── marketplace.schema.json  ← JSON Schema for marketplace.json
-├── docs/
-│   └── PLUGIN-AUTHORING.md      ← How to create plugins
-├── CLAUDE.md                    ← This file
-├── README.md                    ← Installation & overview
-├── LICENSE                      ← MIT
-├── .releaserc.yml               ← Semantic release config
-└── package.json                 ← Dependencies & scripts
-```
-
-## Key Files
-
-| File | Purpose |
-|------|---------|
-| `.claude-plugin/marketplace.json` | Plugin registry — single source of truth for all plugin metadata |
-| `plugin.json` | Root plugin metadata (name, version, description) |
-| `plugins/*/skills/*/SKILL.md` | Skill activation definitions |
-| `plugins/*/hooks/hooks.json` | Hook definitions per plugin |
-| `plugins/*/agents/*.md` | Agent/subagent definitions |
-
-## Plugin Architecture
-
-Each plugin follows the Claude Code plugin structure:
-
-```
-plugin-name/
-├── agents/       → Agent definitions (subagents, teammates)
-├── commands/     → Slash commands (/plugin:command)
-├── hooks/        → hooks.json (PreToolUse, PostToolUse, SessionStart)
-├── scripts/      → Shell scripts for hooks and validation
-└── skills/       → Bundled skills with SKILL.md + references/
-```
-
-## Essential Commands
-
-| Task | Command |
-|------|---------|
-| Validate plugins | `bun scripts/validate-plugins.mjs` |
-
-## Conventions
-
-- **Marketplace SSoT**: All plugin metadata lives in `.claude-plugin/marketplace.json`
-- **Versioning**: Semantic-release via GitHub Actions on merge to `main` — do not edit versions manually
-- **Branching**: PRs against `main`, CI validates on PR, release runs on merge
-- **License**: MIT across all plugins
+- Skills activate via slash commands (see table above)
+- `plugins/*/skills/*/SKILL.md` — skill activation definitions (YAML frontmatter + instructions)
+- `plugins/*/hooks/hooks.json` — hook definitions (PreToolUse, PostToolUse, SessionStart)
+- `plugins/*/agents/*.md` — agent/subagent definitions with YAML frontmatter
+- Validate with: `bun scripts/validate-plugins.mjs`


### PR DESCRIPTION
## Summary

- **Create `AGENTS.md`** following the [agents.md](https://agents.md/) open standard with universal agent instructions: directory structure, key files, plugin architecture, dev environment (bun), git workflow, testing/validation, PR instructions, and conventions
- **Rewrite `CLAUDE.md`** as a thin wrapper that references `@AGENTS.md` and adds Claude Code-specific details (skill triggers, hooks, agent definitions)
- Add git hygiene rules: always fetch/pull main, always branch off remote main, conventional commits

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes locally
- [ ] CI validation passes on PR
- [ ] Confirm all sections from old CLAUDE.md are present in either AGENTS.md or new CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)