### PR TITLE
fix: use GitHub App token for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v4
         with:
@@ -26,4 +32,4 @@ jobs:
       - name: Run semantic-release
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Release workflow has been failing since PR #6 because `GITHUB_TOKEN` cannot push to `main` when branch rulesets require PRs
- Uses `actions/create-github-app-token@v1` to generate a short-lived token from the GitHub App (which is in the ruleset bypass list)
- Both checkout and semantic-release use the App token

## Test plan

- [ ] Merge this PR and verify the Release workflow succeeds
- [ ] Confirm semantic-release creates a new GitHub release with version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)