### PR TITLE
feat: split CDT tester into code-tester + conditional ux-tester

### DIFF
--- a/plugins/cdt/README.md
+++ b/plugins/cdt/README.md
@@ -8,7 +8,7 @@
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
 [![Install](https://img.shields.io/badge/Install-Plugin%20Only-critical.svg)]()
 
-Multi-agent development workflow using Claude Code Agent Teams. Four operating modes (plan, dev, full, auto) with collaborative roles — Architect, PM, Developer, Tester, Reviewer — and a Researcher subagent for documentation lookups via Context7.
+Multi-agent development workflow using Claude Code Agent Teams. Four operating modes (plan, dev, full, auto) with collaborative roles — Architect, PM, Developer, Code-Tester, UX-Tester (conditional), Reviewer — and a Researcher subagent for documentation lookups via Context7.
 
 > [!IMPORTANT]
 > **Requires Agent Teams**: This plugin requires the experimental Agent Teams feature. Set `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in your environment before use.
@@ -21,34 +21,39 @@ Teammates debate directly within teams, enabling natural collaboration:
 
 ```
 Planning Phase                    Development Phase
-┌─────────────────────┐          ┌─────────────────────┐
-│  Architect ↔ PM     │          │  Developer ↔ Tester  │
-│  (design debate)    │          │  (fix cycles, max 3) │
-│                     │          │                      │
-│  Researcher         │          │  Developer ↔ Reviewer│
-│  (subagent, relayed)│          │  (review cycles, 3)  │
-├─────────────────────┤          │                      │
-│  Output: plan.md    │───────→  │  Researcher          │
-└─────────────────────┘          │  (on-demand lookups) │
-                                 ├──────────────────────┤
-                                 │  Output: dev-report  │
-                                 └──────────────────────┘
+┌─────────────────────┐          ┌──────────────────────────┐
+│  Architect ↔ PM     │          │  Developer ↔ Code-Tester  │
+│  (design debate)    │          │  (fix cycles, max 3)      │
+│                     │          │                           │
+│  Researcher         │          │  Developer ↔ UX-Tester    │
+│  (subagent, relayed)│          │  (conditional, UI tasks)  │
+├─────────────────────┤          │                           │
+│  Output: plan.md    │───────→  │  Developer ↔ Reviewer     │
+└─────────────────────┘          │  (review cycles, max 3)   │
+                                 │                           │
+                                 │  Researcher               │
+                                 │  (on-demand lookups)      │
+                                 ├───────────────────────────┤
+                                 │  Output: dev-report       │
+                                 └───────────────────────────┘
 ```
 
 ### Roles
 
-| Role | Type | Model | Responsibility |
-|------|------|-------|----------------|
-| **Architect** | Teammate | Opus | Component design, interfaces, file changes, data flow |
-| **Product Manager** | Teammate | Sonnet | Requirements validation, architecture challenges |
-| **Developer** | Teammate | Opus | Full implementation — no stubs, no TODOs |
-| **Tester** | Teammate | Sonnet | Test writing and execution, failure reporting |
-| **Reviewer** | Teammate | Opus | Code quality, security, completeness, plan adherence |
-| **Researcher** | Subagent | Sonnet | Documentation via Context7, web research |
+| Role | Type | Model | When | Responsibility |
+|------|------|-------|------|----------------|
+| **Architect** | Teammate | Opus | Always | Component design, interfaces, file changes, data flow |
+| **Product Manager** | Teammate | Sonnet | Always | Requirements validation, architecture challenges |
+| **Developer** | Teammate | Opus | Always | Full implementation — no stubs, no TODOs |
+| **Code-Tester** | Teammate | Sonnet | Always | Unit/integration test writing and execution, failure reporting |
+| **UX-Tester** | Teammate | Sonnet | UI tasks only | Storybook stories + user flow testing via agent-browser, screenshot evidence |
+| **Reviewer** | Teammate | Opus | Always | Code quality, security, completeness, plan adherence |
+| **Researcher** | Subagent | Sonnet | Always | Documentation via Context7, web research |
 
 ### Quality Gates
 
-- **Testing**: Tester writes and runs tests, iterates with Developer (max 3 cycles)
+- **Code Testing**: Code-Tester writes and runs unit/integration tests, iterates with Developer (max 3 cycles)
+- **UX Testing** (conditional): UX-Tester writes Storybook stories + tests user flows via agent-browser, iterates with Developer (max 3 cycles)
 - **Review**: Reviewer checks quality, security, and scans for stubs (TODO/FIXME/HACK/XXX)
 - **Build Verification**: Build is verified between execution waves
 
@@ -69,7 +74,7 @@ Spawns Architect + PM + Researcher. The Architect designs the solution, the PM v
 
 ### `/cdt:dev-task` — Implementation Phase
 
-Spawns Developer + Tester + Reviewer + Researcher. Executes tasks wave-by-wave from the plan, with parallel tasks within each wave and sequential ordering between waves.
+Spawns Developer + Code-Tester + Reviewer + Researcher (+ UX-Tester if plan involves UI). Executes tasks wave-by-wave from the plan, with parallel tasks within each wave and sequential ordering between waves.
 
 **Output**: Updated plan + `.claude/files/dev-report-YYYYMMDD-HHMM.md` with execution summary, changes made, test results, and review outcomes.
 

--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: [Read, Grep, Glob, Bash, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Write, Edit, AskUserQuestion, TeamCreate, SendMessage, TeamDelete]
-description: "Create an agent team for autonomous workflow: plan (Architect teammate + PM teammate) → develop (Developer teammate + Tester teammate + Reviewer teammate) → report (no approval gate)"
+description: "Create an agent team for autonomous workflow: plan (Architect teammate + PM teammate) → develop (Developer teammate + Code-tester teammate + optional UX-tester teammate + Reviewer teammate) → report (no approval gate)"
 ---
 
 # /auto-task — Autonomous Workflow
@@ -11,13 +11,14 @@ Two-phase orchestration like `/cdt:full-task`, but without a user approval gate.
 
 ```
 Phase 1: plan-team               Phase 2: dev-team
-┌──────────────────────┐         ┌──────────────────────┐
-│  Lead (You)          │         │  Lead (You)          │
-│  ├── architect  [tm] │ plan.md │  ├── developer  [tm] │
-│  ├── prod-mgr   [tm] │──────→ │  ├── tester     [tm] │
-│  └── researcher [sa] │         │  ├── reviewer   [tm] │
-└──────────────────────┘         │  └── researcher [sa] │
-                                 └──────────────────────┘
+┌──────────────────────┐         ┌───────────────────────────┐
+│  Lead (You)          │         │  Lead (You)               │
+│  ├── architect  [tm] │ plan.md │  ├── developer   [tm]     │
+│  ├── prod-mgr   [tm] │──────→ │  ├── code-tester [tm]     │
+│  └── researcher [sa] │         │  ├── ux-tester   [tm?]    │
+└──────────────────────┘         │  ├── reviewer    [tm]     │
+                                 │  └── researcher  [sa]     │
+                                 └───────────────────────────┘
 ```
 
 `[tm]` = teammate (Agent Team)  `[sa]` = subagent
@@ -53,9 +54,9 @@ Log a brief summary of the plan to the user (task count, waves, key decisions), 
 Execute `/cdt:dev-task` workflow using the plan path from Phase 1:
 1. TeamCreate "dev-team"
 2. Parse plan, create tasks with dependencies
-3. Spawn developer teammate + tester teammate + reviewer teammate
+3. Spawn developer teammate + code-tester teammate + reviewer teammate (+ ux-tester teammate if plan involves UI)
 4. Execute waves, assign to developer teammate
-5. After impl: activate tester teammate (Developer teammate↔Tester teammate iterate via messaging)
+5. After impl: activate code-tester teammate (+ ux-tester if spawned). Both run in parallel.
 6. After tests: activate reviewer teammate (Developer teammate↔Reviewer teammate iterate via messaging)
 7. Final verification: build, tests, stub scan
 8. Shutdown teammates, TeamDelete

--- a/plugins/cdt/commands/full-task.md
+++ b/plugins/cdt/commands/full-task.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: [Read, Grep, Glob, Bash, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Write, Edit, AskUserQuestion, TeamCreate, SendMessage, TeamDelete]
-description: "Create an agent team for full workflow: plan (Architect teammate + PM teammate) → approve → develop (Developer teammate + Tester teammate + Reviewer teammate) → report"
+description: "Create an agent team for full workflow: plan (Architect teammate + PM teammate) → approve → develop (Developer teammate + Code-tester teammate + optional UX-tester teammate + Reviewer teammate) → report"
 ---
 
 # /full-task — Complete Workflow
@@ -11,14 +11,14 @@ Two-phase orchestration: plan team → user approval → dev team. One team per 
 
 ```
 Phase 1: plan-team               Phase 2: dev-team
-┌──────────────────────┐         ┌──────────────────────┐
-│  Lead (You)          │         │  Lead (You)          │
-│  ├── architect  [tm] │ plan.md │  ├── developer  [tm] │
-│  ├── prod-mgr   [tm] │──────→ │  ├── tester     [tm] │
-│  └── researcher [sa] │         │  ├── reviewer   [tm] │
-└──────────────────────┘         │  └── researcher [sa] │
-                ▲                └──────────────────────┘
-         User Approval
+┌──────────────────────┐         ┌───────────────────────────┐
+│  Lead (You)          │         │  Lead (You)               │
+│  ├── architect  [tm] │ plan.md │  ├── developer   [tm]     │
+│  ├── prod-mgr   [tm] │──────→ │  ├── code-tester [tm]     │
+│  └── researcher [sa] │         │  ├── ux-tester   [tm?]    │
+└──────────────────────┘         │  ├── reviewer    [tm]     │
+                ▲                │  └── researcher  [sa]     │
+         User Approval           └───────────────────────────┘
 ```
 
 `[tm]` = teammate (Agent Team)  `[sa]` = subagent
@@ -61,9 +61,9 @@ Do NOT proceed without approval. If revisions: update plan, re-present.
 Execute `/cdt:dev-task` workflow using the plan path from Phase 1:
 1. TeamCreate "dev-team"
 2. Parse plan, create tasks with dependencies
-3. Spawn developer teammate + tester teammate + reviewer teammate
+3. Spawn developer teammate + code-tester teammate + reviewer teammate (+ ux-tester teammate if plan involves UI)
 4. Execute waves, assign to developer teammate
-5. After impl: activate tester teammate (Developer teammate↔Tester teammate iterate via messaging)
+5. After impl: activate code-tester teammate (+ ux-tester if spawned). Both run in parallel.
 6. After tests: activate reviewer teammate (Developer teammate↔Reviewer teammate iterate via messaging)
 7. Final verification: build, tests, stub scan
 8. Shutdown teammates, TeamDelete

--- a/plugins/cdt/commands/plan-task.md
+++ b/plugins/cdt/commands/plan-task.md
@@ -155,6 +155,7 @@ Write `.claude/plans/plan-$TIMESTAMP.md`:
 
 ## Testing Strategy
 [Framework, scenarios, acceptance criteria]
+[If UI/frontend work: include UX test scenarios — user flows, interactions, navigation. This signals the Lead to spawn the UX-tester.]
 
 ## Risks & Mitigations
 


### PR DESCRIPTION
## Summary

- **Rename** tester teammate → code-tester teammate (always spawned) for unit/integration tests
- **Add** ux-tester teammate (conditionally spawned for UI/frontend tasks) — writes Storybook stories and tests user flows via `npx agent-browser`
- **Update** all 7 CDT files: dev-task, WORKFLOW, SKILL, auto-task, full-task, README, plan-task

Also includes two prior fixes on this branch:
- Use "teammate" phrasing in CDT commands for reliable Agent Teams triggering
- Add graceful shutdown wait and delegate mode tip to CDT cleanup procedures

## How conditional spawning works

No feature flags — the lead makes a judgment call based on the plan's Testing Strategy section. If it mentions UX scenarios / user flows / visual testing → spawn ux-tester. If no UI involvement → skip it.

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [x] `ux-tester` / `UX-Tester` appears in all 7 modified files
- [x] `agent-browser` appears in dev-task.md, WORKFLOW.md, SKILL.md, README.md
- [x] No bare "tester" remaining in role names or coordination instructions (only in internal spawn prompt text like "You are the code tester")
- [ ] Manual: run `/cdt:dev-task` on a UI task and verify ux-tester spawns
- [ ] Manual: run `/cdt:dev-task` on a non-UI task and verify ux-tester is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)