### PR TITLE
docs: recommend /plugin-dev:create for contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,11 +396,12 @@ Files bumped on release:
 
 ## Contributing
 
+The easiest way to create a new plugin is to use the `/plugin-dev:create` skill inside Claude Code — it scaffolds the directory structure, manifests, and marketplace registration for you.
+
 1. Fork the repository
-2. Create a plugin in `plugins/your-plugin/`
-3. Add an entry to `.claude-plugin/marketplace.json`
-4. Run `bun scripts/validate-plugins.mjs`
-5. Submit a pull request
+2. Run `/plugin-dev:create` in Claude Code to scaffold your plugin
+3. Run `bun scripts/validate-plugins.mjs` to validate
+4. Submit a pull request
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary
- Update Contributing section to recommend `/plugin-dev:create` skill for scaffolding new plugins
- Simplifies the contribution steps by removing manual directory and marketplace entry creation

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)