### PR TITLE
fix(cdt): use Teammate tool for agent team spawning

### DIFF
--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: [Read, Grep, Glob, Bash, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Write, Edit, AskUserQuestion, TeamCreate, SendMessage, TeamDelete]
+allowed-tools: [Read, Grep, Glob, Bash, Task, Teammate, TaskCreate, TaskUpdate, TaskList, TaskGet, Write, Edit, AskUserQuestion, TeamCreate, SendMessage, TeamDelete]
 description: "Create an agent team for autonomous workflow: plan (Architect teammate + PM teammate) → develop (Developer teammate + Code-tester teammate + optional UX-tester teammate + Reviewer teammate) → report (no approval gate)"
 ---
 

--- a/plugins/cdt/commands/dev-task.md
+++ b/plugins/cdt/commands/dev-task.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: [Read, Grep, Glob, Bash, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Write, Edit, AskUserQuestion, TeamCreate, SendMessage, TeamDelete]
+allowed-tools: [Read, Grep, Glob, Bash, Task, Teammate, TaskCreate, TaskUpdate, TaskList, TaskGet, Write, Edit, AskUserQuestion, TeamCreate, SendMessage, TeamDelete]
 description: "Create an agent team to develop: Developer teammate + Code-tester teammate + Reviewer teammate + optional UX-tester teammate + Researcher subagent → implements plan.md in waves"
 ---
 
@@ -55,7 +55,7 @@ TaskCreate for each plan task (preserve `depends_on` via `addBlockedBy`). Also c
 
 **Developer teammate**:
 ```
-Task tool:
+Teammate tool:
   team_name: "dev-team"
   name: "developer"
   model: opus
@@ -79,7 +79,7 @@ Task tool:
 
 **Code-tester teammate** (always spawned):
 ```
-Task tool:
+Teammate tool:
   team_name: "dev-team"
   name: "code-tester"
   model: sonnet
@@ -101,7 +101,7 @@ Task tool:
 
 **UX-tester teammate** (conditional — only spawn when plan involves UI/frontend/user-facing changes):
 ```
-Task tool:
+Teammate tool:
   team_name: "dev-team"
   name: "ux-tester"
   model: sonnet
@@ -131,7 +131,7 @@ Task tool:
 
 **Reviewer teammate**:
 ```
-Task tool:
+Teammate tool:
   team_name: "dev-team"
   name: "reviewer"
   model: opus

--- a/plugins/cdt/commands/full-task.md
+++ b/plugins/cdt/commands/full-task.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: [Read, Grep, Glob, Bash, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Write, Edit, AskUserQuestion, TeamCreate, SendMessage, TeamDelete]
+allowed-tools: [Read, Grep, Glob, Bash, Task, Teammate, TaskCreate, TaskUpdate, TaskList, TaskGet, Write, Edit, AskUserQuestion, TeamCreate, SendMessage, TeamDelete]
 description: "Create an agent team for full workflow: plan (Architect teammate + PM teammate) → approve → develop (Developer teammate + Code-tester teammate + optional UX-tester teammate + Reviewer teammate) → report"
 ---
 

--- a/plugins/cdt/commands/plan-task.md
+++ b/plugins/cdt/commands/plan-task.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: [Read, Grep, Glob, Bash, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, Write, Edit, AskUserQuestion, TeamCreate, SendMessage, TeamDelete]
+allowed-tools: [Read, Grep, Glob, Bash, Task, Teammate, TaskCreate, TaskUpdate, TaskList, TaskGet, Write, Edit, AskUserQuestion, TeamCreate, SendMessage, TeamDelete]
 description: "Create an agent team to plan: Architect teammate + PM teammate + Researcher subagent → outputs plan.md"
 ---
 
@@ -55,7 +55,7 @@ Spawn all three simultaneously:
 
 **Architect teammate**:
 ```
-Task tool:
+Teammate tool:
   team_name: "plan-team"
   name: "architect"
   model: opus
@@ -75,7 +75,7 @@ Task tool:
 
 **PM teammate**:
 ```
-Task tool:
+Teammate tool:
   team_name: "plan-team"
   name: "product-manager"
   model: sonnet

--- a/plugins/cdt/skills/cdt/SKILL.md
+++ b/plugins/cdt/skills/cdt/SKILL.md
@@ -3,7 +3,7 @@ name: cdt
 description: "Multi-agent development workflow using Agent Teams. Supports four modes: plan (architect teammate + PM teammate debate → plan.md), dev (developer teammate + code-tester teammate + optional ux-tester teammate + reviewer teammate iterate → code), full (plan → approval gate → dev), and auto (plan → dev, no gate). Use when tasks benefit from collaborative agent teammates with peer messaging."
 license: MIT
 compatibility: "Requires Claude Code with CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1. Context7 MCP server is bundled via plugin .mcp.json and starts automatically."
-allowed-tools: Read Grep Glob Bash Task TaskCreate TaskUpdate TaskList TaskGet Write Edit AskUserQuestion TeamCreate SendMessage TeamDelete WebSearch WebFetch
+allowed-tools: Read Grep Glob Bash Task Teammate TaskCreate TaskUpdate TaskList TaskGet Write Edit AskUserQuestion TeamCreate SendMessage TeamDelete WebSearch WebFetch
 metadata:
   author: cdt
   version: "1.0.0"
@@ -45,27 +45,27 @@ Plan Phase (plan/full/auto)     Dev Phase (dev/full/auto)
 
 Research specialist for doc lookups. Queries Context7 for library docs, searches web for best practices, returns structured findings with code examples. Bundled as `agents/researcher.md` in this plugin — Context7 MCP is auto-configured via `.mcp.json`.
 
-### Architect (teammate — plan phase)
+### Architect (teammate — spawn via Teammate tool, plan phase)
 
 Designs architecture: components, interfaces, file changes, data flow, testing strategy. Debates tradeoffs with PM teammate. Messages design to lead and PM teammate.
 
-### Product Manager (teammate — plan phase)
+### Product Manager (teammate — spawn via Teammate tool, plan phase)
 
 Validates architecture against requirements. Challenges design with concerns. Produces verdict: APPROVED or NEEDS_REVISION with specifics.
 
-### Developer (teammate — dev phase)
+### Developer (teammate — spawn via Teammate tool, dev phase)
 
 Implements tasks from plan. No stubs, no TODOs. Matches existing patterns. Iterates with code-tester teammate on failures, ux-tester teammate on UX issues, reviewer teammate on code quality.
 
-### Code-Tester (teammate — dev phase, always)
+### Code-Tester (teammate — spawn via Teammate tool, dev phase, always)
 
 Unit/integration tests. Messages developer teammate with failures + root cause. Max 3 cycles.
 
-### UX-Tester (teammate — dev phase, conditional)
+### UX-Tester (teammate — spawn via Teammate tool, dev phase, conditional)
 
 Spawned only for UI/frontend tasks. Writes Storybook stories for new/changed components, then tests user flows via `npx agent-browser`. Messages developer teammate with UX issues + screenshot evidence. Max 3 cycles.
 
-### Reviewer (teammate — dev phase)
+### Reviewer (teammate — spawn via Teammate tool, dev phase)
 
 Reviews changed files for completeness, correctness, security, quality, plan adherence. Validates review with `/council` (`quick quality` for routine, `review security` or `review architecture` for critical concerns). Scans for stubs. Messages developer teammate with file:line + fix suggestions. Max 3 cycles.
 

--- a/plugins/cdt/skills/cdt/references/WORKFLOW.md
+++ b/plugins/cdt/skills/cdt/references/WORKFLOW.md
@@ -42,7 +42,7 @@ Produces `.claude/plans/plan-YYYYMMDD-HHMM.md`. Does NOT implement.
 
 **Architect teammate**:
 ```
-Task tool:
+Teammate tool:
   team_name: "plan-team"
   name: "architect"
   model: opus
@@ -62,7 +62,7 @@ Task tool:
 
 **PM teammate**:
 ```
-Task tool:
+Teammate tool:
   team_name: "plan-team"
   name: "product-manager"
   model: sonnet
@@ -113,7 +113,7 @@ Implements an existing plan file (passed as argument, e.g. `.claude/plans/plan-2
 
 **Developer teammate**:
 ```
-Task tool:
+Teammate tool:
   team_name: "dev-team"
   name: "developer"
   model: opus
@@ -137,7 +137,7 @@ Task tool:
 
 **Code-tester teammate** (always spawned):
 ```
-Task tool:
+Teammate tool:
   team_name: "dev-team"
   name: "code-tester"
   model: sonnet
@@ -159,7 +159,7 @@ Task tool:
 
 **UX-tester teammate** (conditional — only spawn when plan involves UI/frontend/user-facing changes):
 ```
-Task tool:
+Teammate tool:
   team_name: "dev-team"
   name: "ux-tester"
   model: sonnet
@@ -189,7 +189,7 @@ Task tool:
 
 **Reviewer teammate**:
 ```
-Task tool:
+Teammate tool:
   team_name: "dev-team"
   name: "reviewer"
   model: opus


### PR DESCRIPTION
## Summary
- Changed all teammate spawn instructions from `Task tool:` to `Teammate tool:` across CDT commands and workflow reference
- Added `Teammate` to `allowed-tools` in all command frontmatter and SKILL.md
- Researcher subagent correctly remains using `Task tool:` with `subagent_type`

Agent Teams requires the `Teammate` tool to spawn teammates — using `Task tool:` with `team_name` was preventing teams from being created.

## Test plan
- [ ] Run `/cdt:plan-task` and verify architect + PM spawn as teammates (not subagents)
- [ ] Run `/cdt:dev-task` and verify developer, code-tester, reviewer spawn as teammates
- [ ] Verify researcher still spawns as a subagent via Task tool
- [ ] Confirm `bun scripts/validate-plugins.mjs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)