### PR TITLE
fix(doppler): clean apt cache in Dockerfile pattern

### DIFF
--- a/plugins/doppler/skills/doppler/references/INTEGRATIONS.md
+++ b/plugins/doppler/skills/doppler/references/INTEGRATIONS.md
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y apt-transport-https ca-certificates cur
     gpg --dearmor -o /usr/share/keyrings/doppler-archive-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/doppler-archive-keyring.gpg] https://packages.doppler.com/public/cli/deb/debian any-version main" | \
     tee /etc/apt/sources.list.d/doppler-cli.list && \
-    apt-get update && apt-get install -y doppler
+    apt-get update && apt-get install -y doppler && rm -rf /var/lib/apt/lists/*
 
 # Use service token at runtime
 ENTRYPOINT ["doppler", "run", "--"]


### PR DESCRIPTION
## Summary
- Add `rm -rf /var/lib/apt/lists/*` to the Dockerfile pattern in the Doppler INTEGRATIONS.md reference to clean apt cache after install, reducing image size

Closes #16

## Test plan
- [x] `bun scripts/validate-plugins.mjs` passes
- [ ] Verify the Dockerfile snippet renders correctly in the skill reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)