### PR TITLE
feat: add oasis-dev plugin for Oasis Network development

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -121,6 +121,28 @@
         "security",
         "cli"
       ]
+    },
+    {
+      "name": "oasis-dev",
+      "description": "Oasis Network development: Sapphire confidential EVM, ROFL off-chain apps, CLI operations, SDK patterns (Rust, Go, TypeScript, Python), and ParaTime development",
+      "version": "1.0.0",
+      "source": "./plugins/oasis-dev",
+      "category": "development",
+      "author": {
+        "name": "rube-de",
+        "url": "https://github.com/rube-de"
+      },
+      "keywords": [
+        "oasis",
+        "sapphire",
+        "rofl",
+        "blockchain",
+        "confidential-computing",
+        "evm",
+        "paratime",
+        "sdk",
+        "cli"
+      ]
     }
   ]
 }

--- a/plugins/oasis-dev/LICENSE
+++ b/plugins/oasis-dev/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 rube-de
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/oasis-dev/README.md
+++ b/plugins/oasis-dev/README.md
@@ -1,0 +1,42 @@
+# oasis-dev
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
+
+Oasis Network development assistant for Claude Code. Covers Sapphire confidential EVM, ROFL off-chain apps, CLI operations, and SDK patterns across Rust, Go, TypeScript, and Python.
+
+## Installation
+
+```bash
+claude plugin install oasis-dev@rube-cc-skills
+```
+
+## Usage
+
+The skill activates automatically when you mention Oasis-related topics:
+
+- Building dApps on Sapphire
+- Creating ROFL off-chain applications
+- Oasis CLI commands (wallet, account, paratime, rofl)
+- SDK development (Rust oasis-sdk, Go/JS/Python Sapphire clients)
+- Working in `oasisprotocol/sapphire-paratime`, `oasisprotocol/oasis-sdk`, or `oasisprotocol/cli` repos
+
+### Example Triggers
+
+- "How do I deploy a contract on Sapphire?"
+- "Create a ROFL app with secrets"
+- "Transfer tokens on Oasis testnet"
+- "Wrap my provider for confidential transactions"
+
+## Reference Docs
+
+| Document | Content |
+|----------|---------|
+| CLI.md | Complete CLI command reference |
+| SAPPHIRE.md | Sapphire development: EVM, SDKs, Hardhat, confidential patterns |
+| ROFL.md | ROFL framework: containers, secrets, appd API, deployment |
+| SDK-CORE.md | Oasis SDK architecture, core concepts, cryptography |
+
+## License
+
+MIT

--- a/plugins/oasis-dev/skills/oasis-dev/SKILL.md
+++ b/plugins/oasis-dev/skills/oasis-dev/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: oasis-dev
+description: >-
+  Help developers build on Oasis Network: Sapphire confidential EVM, ROFL off-chain apps,
+  CLI operations, SDK patterns (Rust, Go, TypeScript, Python), and ParaTime development.
+allowed-tools: [Read, Grep, Glob, Bash, WebSearch, WebFetch, Write, Edit]
+user-invocable: true
+metadata:
+  author: rube-de
+  version: "1.0.0"
+---
+
+# Oasis Dev
+
+Comprehensive assistance for building on the Oasis Network: Sapphire confidential EVM ParaTime, ROFL (Runtime OFfchain Logic) applications, Oasis CLI, SDK development, and ParaTime operations.
+
+## Triggers
+
+Use this skill when the user mentions: "oasis", "sapphire", "sapphire paratime", "rofl", "oasis cli", "oasis sdk", "oasis network", "confidential evm", "oasis-sdk", "sapphire-paratime", "oasisprotocol", "oasis rofl", "paratime", "emerald", "cipher", "rose token", "oasis wallet", "sapphire contracts", "oasis node", "oasis core".
+
+Also activate when the user is working in repos: `oasisprotocol/sapphire-paratime`, `oasisprotocol/oasis-sdk`, `oasisprotocol/cli`.
+
+## MCP Context
+
+If MCP Context7 is available, use it to fetch latest docs:
+- Library ID: `oasis_io_llms_txt` at `https://context7.com/llmstxt/oasis_io_llms_txt`
+
+## Quick Start
+
+### Install CLI
+
+```bash
+# Download latest release from https://github.com/oasisprotocol/cli/releases
+# Linux
+wget https://github.com/oasisprotocol/cli/releases/latest/download/oasis_cli_linux_amd64.tar.gz
+tar xf oasis_cli_linux_amd64.tar.gz
+sudo mv oasis /usr/local/bin/
+
+# macOS
+brew install oasisprotocol/tools/oasis
+```
+
+### Create a Wallet
+
+```bash
+# Ed25519 (Oasis native)
+oasis wallet create my_wallet
+
+# secp256k1 (EVM-compatible, for Sapphire/Emerald)
+oasis wallet create my_wallet --algorithm secp256k1-bip44
+```
+
+### Get Testnet Tokens
+
+Visit https://faucet.testnet.oasis.io to get TEST tokens for Sapphire Testnet.
+
+### Deploy a Sapphire dApp (Hardhat)
+
+```bash
+npx hardhat init
+npm install -D @oasisprotocol/sapphire-hardhat
+```
+
+```js
+// hardhat.config.js
+import '@oasisprotocol/sapphire-hardhat';
+
+module.exports = {
+  solidity: "0.8.24",
+  networks: {
+    sapphire_testnet: {
+      url: "https://testnet.sapphire.oasis.io",
+      chainId: 0x5aff,
+      accounts: [process.env.PRIVATE_KEY],
+    },
+    sapphire_mainnet: {
+      url: "https://sapphire.oasis.io",
+      chainId: 0x5afe,
+      accounts: [process.env.PRIVATE_KEY],
+    },
+  },
+};
+```
+
+### Build a ROFL App
+
+```bash
+oasis rofl init my-app
+oasis rofl create --network testnet --account my_wallet
+oasis rofl build
+echo -n "my-secret" | oasis rofl secret set MY_SECRET -
+oasis rofl deploy
+```
+
+## Common Tasks by Intent
+
+| Developer wants to... | Action |
+|-----------------------|--------|
+| Create a Sapphire dApp | Use Hardhat + `@oasisprotocol/sapphire-hardhat` plugin |
+| Build a ROFL app | `oasis rofl init`, `oasis rofl create`, `oasis rofl build`, `oasis rofl deploy` |
+| Check account balance | `oasis account show <name>` |
+| Transfer tokens | `oasis account transfer <amount> <to> --network testnet --paratime sapphire` |
+| Deposit to ParaTime | `oasis account deposit <amount> --network testnet --paratime sapphire` |
+| Withdraw from ParaTime | `oasis account withdraw <amount> --network testnet --paratime sapphire` |
+| Manage ROFL secrets | `oasis rofl secret set <NAME> -` (pipe value via stdin) |
+| View ROFL logs | `oasis rofl machine logs` |
+| Check ROFL status | `oasis rofl machine show` |
+| Inspect a ParaTime block | `oasis paratime show <round> --network testnet --paratime sapphire` |
+| Use Go SDK with Sapphire | Import `sapphire "github.com/oasisprotocol/sapphire-paratime/clients/go"` |
+| Use JS/TS with Sapphire | `npm install @oasisprotocol/sapphire-paratime` |
+| Verify ROFL origin on-chain | `Subcall.roflEnsureAuthorizedOrigin(roflAppID)` in Solidity |
+
+## Key Concepts
+
+### ParaTimes
+
+ParaTimes are parallel runtimes on Oasis. Key ones:
+- **Sapphire**: Confidential EVM-compatible (18 decimals, chain ID 0x5afe mainnet / 0x5aff testnet)
+- **Emerald**: Non-confidential EVM-compatible (18 decimals)
+- **Cipher**: Confidential WebAssembly (9 decimals)
+
+### Confidential Computing
+
+Sapphire provides end-to-end encryption for smart contracts:
+- Contract state is encrypted at rest
+- Transactions are encrypted end-to-end
+- Cryptographically secure randomness available on-chain
+- TEE (Trusted Execution Environment) hardware protects execution
+
+### ROFL (Runtime OFfchain Logic)
+
+Containerized off-chain applications running in TEEs, managed via Sapphire:
+- Docker Compose based container orchestration
+- Intel SGX/TDX trusted execution
+- Decentralized per-app key management
+- Built-in secret management (end-to-end encrypted)
+- Proxy with automatic TLS for published ports
+- `appd` REST API for key generation, transaction signing, and queries
+
+### Token Denominations
+
+| Network | Decimals | Symbol |
+|---------|----------|--------|
+| Consensus (Mainnet/Testnet) | 9 | ROSE / TEST |
+| Sapphire / Emerald | 18 | ROSE / TEST |
+| Cipher | 9 | ROSE / TEST |
+
+## Reference Documents
+
+For deep dives, consult these references:
+
+| Reference | Content |
+|-----------|---------|
+| [CLI.md](references/CLI.md) | Complete CLI command reference: wallet, account, network, paratime, ROFL, transactions |
+| [SAPPHIRE.md](references/SAPPHIRE.md) | Sapphire ParaTime development: EVM patterns, SDKs (Go, JS/TS, Python), Hardhat, confidential contracts |
+| [ROFL.md](references/ROFL.md) | ROFL framework: app lifecycle, containers, secrets, appd API, deployment, proxy configuration |
+| [SDK-CORE.md](references/SDK-CORE.md) | Oasis SDK and core concepts: architecture, ParaTimes, staking, consensus, cryptography |
+
+## Troubleshooting
+
+### Sapphire Transaction Sent in Plaintext
+
+If using Go SDK, always use `backend.Transactor(senderAddr)` for `TransactOpts`. Forgetting this sends transactions unencrypted.
+
+For JS/TS, ensure `@oasisprotocol/sapphire-paratime` wraps the provider before any contract interactions.
+
+### ROFL Build Failures
+
+- Ensure Docker/Podman is running
+- Use fully qualified image URLs in `compose.yaml` (e.g., `docker.io/library/python:3.12-alpine`)
+- Environment variables in entrypoint are not evaluated — inject directly
+
+### ROFL appd 422 Errors
+
+Verify request body matches expected format. Check required fields: `kind` for keys, `tx` structure for sign-submit.
+
+### Decimal Mismatch
+
+Sapphire/Emerald use 18 decimals, consensus uses 9. Wrong decimals = wrong token amounts. Always verify with `oasis paratime list`.
+
+### Rust Compilation for Oasis SDK
+
+Add to `.cargo/config.toml`:
+```toml
+[build]
+rustflags = ["-C", "target-feature=+aes,+ssse3"]
+```
+
+## External Resources
+
+- Docs: https://docs.oasis.io
+- Faucet: https://faucet.testnet.oasis.io
+- Explorer: https://explorer.oasis.io
+- GitHub: https://github.com/oasisprotocol
+- Sapphire repo: https://github.com/oasisprotocol/sapphire-paratime
+- SDK repo: https://github.com/oasisprotocol/oasis-sdk
+- CLI repo: https://github.com/oasisprotocol/cli
+
+## Workflow
+
+When helping with Oasis development:
+
+1. **Identify the task**: Sapphire dApp, ROFL app, CLI operation, SDK code, or architecture decision
+2. **Check the language**: For SDK questions, determine Rust/Go/TypeScript/Python
+3. **Consult references**: Use the reference docs for detailed patterns and commands
+4. **Verify confidentiality**: For Sapphire code, ensure encryption wrappers are used correctly
+5. **Check decimals**: Confirm correct decimal places for the target network/ParaTime

--- a/plugins/oasis-dev/skills/oasis-dev/references/CLI.md
+++ b/plugins/oasis-dev/skills/oasis-dev/references/CLI.md
@@ -1,0 +1,404 @@
+# Oasis CLI Reference
+
+Complete command reference for the Oasis CLI (`oasis`).
+
+## Installation
+
+```bash
+# Linux
+wget https://github.com/oasisprotocol/cli/releases/latest/download/oasis_cli_linux_amd64.tar.gz
+tar xf oasis_cli_linux_amd64.tar.gz && sudo mv oasis /usr/local/bin/
+
+# macOS
+brew install oasisprotocol/tools/oasis
+
+# GitHub Action
+# uses: oasisprotocol/setup-cli-action
+
+# Self-update
+oasis update
+
+# Verify
+oasis --version
+```
+
+### Configuration Locations
+
+| Platform | Path |
+|----------|------|
+| Linux | `$HOME/.config/oasis/cli.toml` |
+| macOS | `~/Library/Application Support/oasis/cli.toml` |
+| Windows | `%USERPROFILE%\AppData\Local\oasis\cli.toml` |
+
+Wallet files stored as `<account_name>.wallet` (password-encrypted JSON) in the same directory.
+
+## Wallet Management
+
+### Create Wallet
+
+```bash
+# Ed25519 (Oasis native)
+oasis wallet create <name>
+
+# secp256k1 (EVM-compatible for Sapphire/Emerald)
+oasis wallet create <name> --algorithm secp256k1-bip44
+
+# Import from mnemonic
+oasis wallet import <name>
+
+# Import from private key file
+oasis wallet import <name> --secret-key <file>
+
+# Import from PEM file (validators)
+oasis wallet import-file <name> <pem-file>
+
+# Create Ledger-backed account
+oasis wallet create <name> --kind ledger
+```
+
+### Supported Algorithms
+
+| Algorithm | Usage |
+|-----------|-------|
+| `ed25519-adr8` | Default, Oasis native (consensus + Cipher) |
+| `secp256k1-bip44` | EVM-compatible (Sapphire/Emerald), BIP-44 with ETH coin type |
+| `ed25519-raw` | Direct Base64 import (validators) |
+| `ed25519-legacy` | Legacy 5-component path (Ledger) |
+| `sr25519-adr8` | Alternative ParaTime signature scheme |
+| `secp256k1-raw`, `sr25519-raw` | Direct import, no derivation |
+
+### Test Accounts (DO NOT use on public networks)
+
+`test:alice` (Ed25519), `test:bob` (Ed25519), `test:charlie` (Secp256k1), `test:dave` (Secp256k1), `test:erin` (Sr25519), `test:frank` (Sr25519)
+
+### List & Manage Wallets
+
+```bash
+oasis wallet list
+oasis wallet show <name>
+oasis wallet rename <old> <new>
+oasis wallet remove <name>
+oasis wallet export <name>         # Export private key
+oasis wallet set-default <name>
+oasis wallet remote-signer <name> <socket>  # Bind to oasis-node
+```
+
+## Account Operations
+
+### Show Account
+
+```bash
+# Show balance and details
+oasis account show <name>
+
+# Show on specific network
+oasis account show <name> --network testnet
+
+# Show with ParaTime balance
+oasis account show <name> --network testnet --paratime sapphire
+```
+
+### Transfer Tokens
+
+```bash
+# Consensus layer transfer
+oasis account transfer <amount> <to> --network testnet --no-paratime
+
+# ParaTime transfer (within Sapphire)
+oasis account transfer <amount> <to> --network testnet --paratime sapphire
+```
+
+### Deposit / Withdraw (Consensus <-> ParaTime)
+
+```bash
+# Deposit from consensus into ParaTime
+oasis account deposit <amount> --network testnet --paratime sapphire
+
+# Withdraw from ParaTime to consensus
+oasis account withdraw <amount> --network testnet --paratime sapphire
+```
+
+### Delegate / Undelegate Stake
+
+```bash
+oasis account delegate <amount> <validator> --network mainnet
+oasis account undelegate <shares> <validator> --network mainnet
+```
+
+### Allow / Withdraw from Allowance
+
+```bash
+oasis account allow <amount> <beneficiary>
+
+# Burn tokens permanently
+oasis account burn <amount>
+
+# Entity management (validators)
+oasis account entity init
+oasis account entity register <entity.json>
+oasis account entity deregister
+oasis account node-unfreeze
+
+# Convert public key to address
+oasis account from-public-key <pubkey>
+```
+
+### Output to File (Unsigned)
+
+```bash
+# Generate unsigned transaction
+oasis account transfer 1.0 <to> --output-file tx.json --unsigned
+
+# Non-interactive mode
+oasis account transfer 1.0 <to> -y
+```
+
+## Network Management
+
+```bash
+# List configured networks
+oasis network list
+
+# Show network status
+oasis network show --network testnet
+
+# Show specific entity
+oasis network show <entity-id> --network testnet
+
+# Add local network (auto-discovers ParaTimes)
+oasis network add-local <name> <unix-socket-path>
+
+# Set default network
+oasis network set-default <name>
+
+# Change RPC endpoint
+oasis network set-rpc <network> <url>
+
+# Add network with custom context
+oasis network add <name> <rpc> [chain-context]
+
+# Show network status
+oasis network status
+
+# Network inspection
+oasis network show entities               # List registered entities
+oasis network show nodes                  # List registered nodes
+oasis network show parameters             # Show consensus parameters
+oasis network show paratimes              # List registered ParaTimes
+oasis network show validators             # Show validator set
+oasis network show native-token           # Token info, supply, thresholds
+oasis network show gas-costs              # Min gas costs per tx type
+oasis network show committees             # Runtime committees
+
+# Governance
+oasis network governance list
+oasis network governance show <proposal-id>
+oasis network governance show <proposal-id> --show-votes
+oasis network governance cast-vote <proposal-id> yes|no|abstain
+```
+
+## ParaTime Management
+
+### List & Configure
+
+```bash
+# List all configured ParaTimes
+oasis paratime list
+
+# Add a ParaTime
+oasis paratime add <network> <name> <paratime-id> --num-decimals 18 --symbol TEST
+
+# Remove a ParaTime
+oasis paratime remove <network> <name>
+
+# Set default ParaTime for a network
+oasis paratime set-default <network> <name>
+```
+
+### Inspect Blocks & Transactions
+
+```bash
+# Show block details
+oasis paratime show <round> --network testnet --paratime sapphire
+
+# Show latest block
+oasis paratime show latest --network testnet --paratime sapphire
+
+# Show transaction in block (by index or hash)
+oasis paratime show <round> <tx-index-or-hash>
+
+# Show ParaTime parameters
+oasis paratime show parameters --network testnet --paratime sapphire
+
+# Show events in a block
+oasis paratime show events --round <round>
+```
+
+### Validator Statistics
+
+```bash
+# Last block statistics
+oasis paratime statistics
+
+# Last N blocks
+oasis paratime statistics -<N>
+
+# Specific range
+oasis paratime statistics <start-round> <end-round>
+
+# Export to CSV
+oasis paratime statistics -o stats.csv
+```
+
+### Denomination Management
+
+```bash
+# Set denomination info
+oasis paratime denom set <network> <paratime> <denom> <decimals> --symbol <SYM>
+
+# Set native denomination
+oasis paratime denom set-native <network> <paratime> <denom> <decimals>
+
+# Remove denomination
+oasis paratime denom remove <network> <paratime> <denom>
+```
+
+## ROFL (Runtime OFfchain Logic)
+
+### App Lifecycle
+
+```bash
+# Initialize new ROFL app
+oasis rofl init [app-name]
+
+# Create on-chain registration (requires ~100 TEST deposit)
+oasis rofl create --network testnet --account <wallet>
+
+# Build deterministic ORC bundle
+oasis rofl build
+
+# Update on-chain config (after policy/manifest changes)
+oasis rofl update
+
+# Deploy to marketplace node
+oasis rofl deploy
+oasis rofl deploy --show-offers   # See available offers first
+
+# Upgrade existing deployment
+oasis rofl upgrade
+
+# Remove app registration
+oasis rofl remove
+```
+
+### Secret Management
+
+```bash
+# Set a secret (pipe value via stdin)
+echo -n "my-secret-value" | oasis rofl secret set SECRET_NAME -
+
+# Bulk import from .env file
+oasis rofl secret import .env
+
+# Check if secret exists
+oasis rofl secret get SECRET_NAME
+
+# Remove a secret
+oasis rofl secret rm SECRET_NAME
+
+# Replace existing secret
+echo -n "new-value" | oasis rofl secret set SECRET_NAME - --force
+```
+
+### Machine Management
+
+```bash
+# Show machine status, proxy URLs, deployment info
+oasis rofl machine show
+
+# View app logs (stored unencrypted on node — don't log secrets)
+oasis rofl machine logs
+
+# Extend rental period
+oasis rofl machine top-up --term hour --term-count 4
+```
+
+### Additional ROFL Commands
+
+```bash
+# Show app identity (after build)
+oasis rofl identity
+
+# Show app info, policy, instances
+oasis rofl show
+
+# Get trust root
+oasis rofl trust-root
+
+# Restart machine
+oasis rofl machine restart
+oasis rofl machine restart --wipe-storage
+
+# Stop machine
+oasis rofl machine stop
+
+# Cancel rental permanently
+oasis rofl machine remove
+```
+
+## Transaction Tools
+
+```bash
+# Decode and verify a transaction file
+oasis transaction show <filename.json>
+
+# Sign a transaction
+oasis transaction sign <filename.json>
+
+# Submit (broadcast) a transaction
+oasis transaction submit <filename.json> --network testnet --paratime sapphire
+```
+
+## Address Book
+
+```bash
+# Add entry
+oasis addressbook add <name> <address>
+
+# List all entries
+oasis addressbook list
+
+# Show entry details
+oasis addressbook show <name>
+
+# Rename entry
+oasis addressbook rename <old> <new>
+
+# Remove entry
+oasis addressbook remove <name>
+```
+
+## Common Flags
+
+| Flag | Description |
+|------|-------------|
+| `--network <name>` | Target network (mainnet, testnet) |
+| `--paratime <name>` | Target ParaTime (sapphire, emerald, cipher) |
+| `--no-paratime` | Operate on consensus layer directly |
+| `--account <name>` | Wallet account to use |
+| `-y` | Non-interactive mode (skip confirmations) |
+| `--output-file <path>` | Save transaction to file instead of broadcasting |
+| `--unsigned` | Generate unsigned transaction |
+| `--format json` | JSON output format |
+
+## Network Endpoints
+
+### Mainnet
+- Consensus gRPC: `grpc.oasis.io:443`
+- Sapphire RPC: `https://sapphire.oasis.io` (Chain ID: 0x5afe / 23294)
+- Emerald RPC: `https://emerald.oasis.io` (Chain ID: 0xa515 / 42261)
+
+### Testnet
+- Consensus gRPC: `grpc.testnet.oasis.io:443`
+- Sapphire RPC: `https://testnet.sapphire.oasis.io` (Chain ID: 0x5aff / 23295)
+- Emerald RPC: `https://testnet.emerald.oasis.io` (Chain ID: 0xa516 / 42262)

--- a/plugins/oasis-dev/skills/oasis-dev/references/ROFL.md
+++ b/plugins/oasis-dev/skills/oasis-dev/references/ROFL.md
@@ -1,0 +1,560 @@
+# ROFL (Runtime OFfchain Logic) Reference
+
+ROFL enables containerized off-chain applications running in Trusted Execution Environments (TEEs), managed through Sapphire smart contracts.
+
+## Overview
+
+ROFL apps are Docker-based applications that:
+- Execute inside Intel SGX/TDX hardware enclaves
+- Have cryptographic attestation (remote attestation proves genuine TEE execution)
+- Access decentralized per-app key management
+- Store end-to-end encrypted secrets on-chain
+- Submit authenticated transactions to Sapphire
+- Get automatic HTTPS proxy for published ports
+
+## App Lifecycle
+
+```
+oasis rofl init → oasis rofl create → oasis rofl build → oasis rofl deploy
+                                    ↓
+                            oasis rofl secret set
+                                    ↓
+                            oasis rofl update (if policy changes)
+                                    ↓
+                            oasis rofl upgrade (redeploy)
+```
+
+## Project Structure
+
+```
+my-app/
+├── compose.yaml          # Container orchestration (Docker Compose)
+├── rofl.yaml            # ROFL manifest
+├── Dockerfile           # Container image definition
+├── contracts/           # Smart contracts (optional)
+│   └── src/
+│       └── MyContract.sol
+└── src/                 # Application source
+```
+
+## rofl.yaml Manifest
+
+```yaml
+name: my-app
+version: 0.1.0
+author: my-name
+tee: tdx                    # tdx (default) or sgx
+kind: containers             # containers (default) or raw
+
+resources:
+  memory: 512                # Megabytes
+  cpus: 1
+  storage:
+    kind: disk-persistent    # See storage options below
+    size: 512                # Megabytes
+
+deployments:
+  testnet:
+    network: testnet
+    paratime: sapphire
+    app_id: rofl1...         # Filled after `oasis rofl create`
+    admin: <your-address>
+    policy:
+      enclaves:
+        - <base64-enclave-id>  # Filled after `oasis rofl build`
+      endorsements:
+        - any: {}
+      fees: endorsing_node
+      max_expiration: 3
+```
+
+### Storage Options
+
+| Kind | Description |
+|------|-------------|
+| `disk-persistent` | Encrypted via on-chain KMS, survives reboots, authenticated after attestation |
+| `disk-ephemeral` | Encrypted with random key per boot, lost on restart |
+| `ram` | Encrypted memory-based filesystem |
+| `none` | No storage provisioned |
+
+### TEE Flavors
+
+| Flavor | Description |
+|--------|-------------|
+| TDX Containers | Docker Compose, flexible, larger TCB (default) |
+| TDX Raw | Rust init process, smaller TCB, no Docker |
+| SGX Raw | Rust, fixed memory, smallest TCB, local testing via sapphire-localnet |
+
+## Docker Compose (compose.yaml)
+
+```yaml
+services:
+  app:
+    image: docker.io/username/my-app:latest    # MUST be fully qualified
+    platform: linux/amd64                       # Required
+    build:
+      context: .
+    environment:
+      - MY_SECRET=${MY_SECRET}                  # References ROFL secret
+    volumes:
+      - /run/rofl-appd.sock:/run/rofl-appd.sock  # Required for appd API
+    ports:
+      - "8080:8080"                             # Auto-proxied with TLS
+```
+
+### Important Rules
+
+- `image` must be fully qualified OCI URL (e.g., `docker.io/library/python:3.12-alpine`)
+- Environment variables in `entrypoint`/`command` are **not** evaluated — inject directly
+- `depends_on` is **ignored** — implement retry logic between services
+- Pin image digests for reproducibility: `image: docker.io/user/app@sha256:...`
+
+### Build & Push Images
+
+```bash
+docker compose build
+docker login
+docker compose push
+```
+
+## Secret Management
+
+Secrets are end-to-end encrypted and stored on-chain. Only attested ROFL app instances can decrypt them.
+
+### Setting Secrets
+
+```bash
+# From stdin
+echo -n "my-value" | oasis rofl secret set SECRET_NAME -
+
+# Multiple secrets
+echo -n "key1" | oasis rofl secret set API_KEY -
+echo -n "key2" | oasis rofl secret set DB_PASSWORD -
+```
+
+### Accessing in Containers
+
+**Via environment variables** (name capitalized, spaces become underscores):
+```yaml
+environment:
+  - TOKEN=${TOKEN}
+```
+
+**Via container secrets** (readable from `/run/secrets/<name>`):
+```yaml
+secrets:
+  mysecret:
+    external: true    # Created by ROFL during boot
+```
+
+## appd REST API
+
+The `rofl-appd` daemon provides HTTPS via Unix socket at `/run/rofl-appd.sock`.
+
+### Endpoints
+
+#### Get App ID
+```
+GET /rofl/v1/app/id
+→ "rofl1qp6..."
+```
+
+#### Generate Key
+```
+POST /rofl/v1/keys/generate
+{
+  "key_id": "my-key",
+  "kind": "secp256k1"        // raw-256, raw-384, ed25519, secp256k1
+}
+→ { "key": "0xabcd..." }     // Hex-encoded, deterministic per app
+```
+
+Keys are **deterministic** — same key ID produces same key across deployments.
+
+#### Sign & Submit Transaction (EVM)
+```
+POST /rofl/v1/tx/sign-submit
+{
+  "encrypt": true,
+  "tx": {
+    "kind": "eth",
+    "data": {
+      "gas_limit": 200000,
+      "to": "0x1234...",
+      "value": "0",
+      "data": "0xabcd..."     // ABI-encoded calldata
+    }
+  }
+}
+```
+
+#### Sign & Submit Transaction (SDK)
+```
+POST /rofl/v1/tx/sign-submit
+{
+  "encrypt": true,
+  "tx": {
+    "kind": "std",
+    "data": {
+      "call": {
+        "method": "module.Method",
+        "body": { ... }
+      }
+    }
+  }
+}
+```
+
+#### Metadata Management
+```
+GET  /rofl/v1/metadata                    → Key-value pairs
+POST /rofl/v1/metadata { "key": "value" } → Published with net.oasis.app. prefix
+```
+
+#### Query Runtime
+```
+POST /rofl/v1/query
+{
+  "method": "runtime.Method",
+  "args": "hex-encoded-cbor"
+}
+```
+
+### SDK Clients for appd
+
+All clients live in the `oasis-sdk` monorepo: https://github.com/oasisprotocol/oasis-sdk/tree/main/rofl-client
+
+| Language | Package | Install |
+|----------|---------|---------|
+| TypeScript | `@oasisprotocol/rofl-client` | `npm install @oasisprotocol/rofl-client` |
+| Python | `oasis-rofl-client` | `pip install oasis-rofl-client` |
+| Rust | `oasis-rofl-client` | `cargo add oasis-rofl-client` |
+
+All three clients expose the same core API surface:
+
+| Method | Description |
+|--------|-------------|
+| `getAppId()` / `get_app_id()` | Get bech32-encoded ROFL app ID |
+| `generateKey(keyId, kind)` / `generate_key()` | Generate deterministic key (survives redeploys) |
+| `signAndSubmit(tx, opts)` / `sign_submit()` | Sign + submit authenticated tx (EVM or SDK) |
+| `getMetadata()` / `get_metadata()` | Get metadata key-value pairs |
+| `setMetadata(metadata)` / `set_metadata()` | Set metadata (replaces all, triggers registration refresh) |
+| `query(method, args)` | Execute read-only runtime query (CBOR-encoded args) |
+
+#### Key Kinds
+
+Available for all clients:
+- `raw-256` — 256 bits of entropy
+- `raw-384` — 384 bits of entropy
+- `ed25519` — Ed25519 private key
+- `secp256k1` — Secp256k1 private key
+
+#### TypeScript Client
+
+```typescript
+import { RoflClient, KeyKind } from '@oasisprotocol/rofl-client';
+// Also exports: StdTx, EthTx, EthValue, ROFL_SOCKET_PATH
+
+// Connect via Unix Domain Socket (default: /run/rofl-appd.sock)
+const client = new RoflClient();
+
+// Or connect via HTTP (for local dev)
+const httpClient = new RoflClient({ url: 'http://localhost:8080' });
+
+// Or custom socket path with timeout
+const customClient = new RoflClient({ url: '/custom/path.sock', timeoutMs: 30000 });
+
+// Get app ID
+const appId = await client.getAppId();
+// → "rofl1qqn9xndja7e2pnxhttktmecvwzz0yqwxsquqyxdf"
+
+// Generate deterministic secp256k1 key
+const key = await client.generateKey('my-signing-key', KeyKind.SECP256K1);
+// → hex-encoded private key (no 0x prefix)
+
+// Generate Ed25519 key
+const ed25519Key = await client.generateKey('my-ed25519-key', KeyKind.ED25519);
+
+// Sign and submit EVM transaction
+const result = await client.signAndSubmit(
+  {
+    kind: 'eth',
+    gas_limit: 200000,
+    to: '0x1234...',
+    value: '0',             // string, bigint, or number (wei)
+    data: '0xabcdef...',    // ABI-encoded calldata
+  },
+  { encrypt: true },        // optional, defaults to true
+);
+// → Uint8Array (CBOR-encoded CallResult)
+
+// Sign and submit SDK transaction
+await client.signAndSubmit({
+  kind: 'std',
+  data: 'cbor-hex-encoded-transaction',
+});
+
+// Typed query with generics
+const queryResult = await client.query<MyArgs, MyResult>('module.Method', myArgs);
+
+// Metadata
+await client.setMetadata({ version: '1.0.0', status: 'active' });
+const meta = await client.getMetadata();
+```
+
+#### Python Client
+
+```python
+from oasis_rofl_client import RoflClient, AsyncRoflClient, KeyKind
+
+# Sync client (uses httpx, connects to /run/rofl-appd.sock by default)
+client = RoflClient()
+
+# Or HTTP transport
+client = RoflClient(url="http://localhost:8080")
+
+# Or custom socket
+client = RoflClient(url="/custom/path.sock")
+
+# Get app ID
+app_id = client.get_app_id()
+
+# Generate deterministic key
+key = client.generate_key("my-key", KeyKind.SECP256K1)
+
+# Sign and submit EVM transaction (uses web3.types.TxParams)
+result = client.sign_submit(
+    {
+        "gas": 200000,
+        "to": "0x1234...",
+        "value": 0,
+        "data": "0xabcdef...",
+    },
+    encrypt=True,  # optional, defaults to True
+)
+# → dict (CBOR-decoded response)
+
+# Metadata
+client.set_metadata({"version": "1.0.0"})
+meta = client.get_metadata()
+
+# Query (CBOR-encoded args)
+import cbor2
+args = cbor2.dumps({"id": app_id})
+result = client.query("rofl.App", args)
+
+# Async client also available
+async_client = AsyncRoflClient()
+app_id = await async_client.get_app_id()
+```
+
+**Python dependencies**: `httpx`, `cbor2`, `web3` (for `TxParams` type)
+
+#### Rust Client
+
+```rust
+use oasis_rofl_client::{RoflClient, KeyKind, Tx, EthCall};
+
+// Connect to default socket (/run/rofl-appd.sock)
+let client = RoflClient::new()?;
+
+// Or custom socket path
+let client = RoflClient::with_socket_path("/custom/path.sock")?;
+
+// Get app ID
+let app_id = client.get_app_id().await?;
+
+// Generate deterministic key
+let key = client.generate_key("my-key", KeyKind::Secp256k1).await?;
+
+// Sign and submit EVM transaction
+let result = client.sign_submit(
+    Tx::Eth(EthCall {
+        gas_limit: 200000,
+        to: "1234...".to_string(),      // hex without 0x
+        value: "0".to_string(),
+        data: "abcdef...".to_string(),   // hex without 0x
+    }),
+    Some(true),  // encrypt
+).await?;
+// → String (hex-encoded CBOR CallResult)
+
+// Convenience helper for ETH calls
+let result = client.sign_submit_eth(
+    200000,           // gas_limit
+    "1234...",        // to (hex)
+    "0",              // value
+    "abcdef...",      // data (hex)
+    Some(true),       // encrypt
+).await?;
+
+// Metadata
+use std::collections::HashMap;
+let mut meta = HashMap::new();
+meta.insert("version".to_string(), "1.0.0".to_string());
+client.set_metadata(&meta).await?;
+let fetched = client.get_metadata().await?;
+
+// Query (raw CBOR bytes)
+let args = b"\xa1\x64test\x65value";
+let result = client.query("module.Method", args).await?;
+// → Vec<u8> (raw CBOR response)
+```
+
+**Rust dependencies**: `serde`, `serde_json`, `tokio`, `hex`, `thiserror`, `anyhow`
+
+## On-Chain Verification (Solidity)
+
+Verify that a transaction originated from an authorized ROFL app:
+
+```solidity
+import {Subcall} from "@oasisprotocol/sapphire-contracts/contracts/Subcall.sol";
+
+contract ROFLConsumer {
+    bytes21 public roflAppID;
+
+    constructor(bytes21 _appId) {
+        roflAppID = _appId;
+    }
+
+    function submitData(uint256 data) external {
+        // Reverts if caller is not the registered ROFL app
+        Subcall.roflEnsureAuthorizedOrigin(roflAppID);
+        // Process authenticated data...
+    }
+}
+```
+
+## Port Proxy
+
+Published ports are automatically proxied with HTTPS/TLS termination inside the enclave.
+
+### Configuration
+
+```yaml
+services:
+  app:
+    ports:
+      - "8080:8080"
+    labels:
+      # Proxy annotations
+      net.oasis.proxy.ports.8080.mode: terminate-tls    # Default
+      net.oasis.proxy.ports.8080.custom_domain: myapp.example.com
+```
+
+### Proxy Modes
+
+| Mode | Description |
+|------|-------------|
+| `terminate-tls` | Proxy handles TLS, forwards plaintext to app (default) |
+| `passthrough` | Raw TCP forwarding, app handles TLS |
+| `ignore` | Port not exposed externally |
+
+### Custom Domain
+
+1. Get DNS instructions: `oasis rofl machine show`
+2. Set A record pointing to proxy IP
+3. Set TXT verification record
+4. Add annotation: `net.oasis.proxy.ports.80.custom_domain: mydomain.com`
+
+### Access URL
+
+After deployment, proxy URLs are shown by `oasis rofl machine show`:
+```
+Proxy URLs:
+  https://p8080.m1058...
+```
+
+## Deployment
+
+### Marketplace (Recommended)
+
+```bash
+# See available node offers
+oasis rofl deploy --show-offers
+
+# Deploy to marketplace node
+oasis rofl deploy
+
+# Extend rental
+oasis rofl machine top-up --term hour --term-count 4
+```
+
+### Manual Hosting
+
+Copy the `.orc` bundle to a ROFL node and configure in node settings.
+
+## Machine Management
+
+```bash
+# Status, proxy URLs, deployment info
+oasis rofl machine show
+
+# View logs (WARNING: logs are unencrypted on node)
+oasis rofl machine logs
+
+# Extend rental
+oasis rofl machine top-up --term hour --term-count 4
+```
+
+## Manifest Policy
+
+### Enclave Whitelist
+
+```yaml
+policy:
+  enclaves:
+    - <base64-id-1>     # Multiple allowed for rolling upgrades
+    - <base64-id-2>
+```
+
+### Endorsement Conditions
+
+```yaml
+endorsements:
+  - any: {}                          # Any node
+  - node: <node-id>                  # Specific node
+  - provider: <provider-address>     # Specific provider
+  - and: [condition1, condition2]    # All must match
+  - or: [condition1, condition2]     # Any must match
+```
+
+### Fee Policy
+
+```yaml
+fees: endorsing_node    # Node pays fees
+fees: instance          # App instance pays fees
+```
+
+## Use Cases
+
+### Price Oracle
+Fetch off-chain price data, aggregate, submit to Sapphire with ROFL authentication.
+
+### AI Agent (Eliza)
+Run AI agents in TEE with cryptographic proof of execution environment (ERC-8004).
+
+### Cross-Chain Key Management
+Generate keys in ROFL, derive addresses, sign transactions on external chains (e.g., Base).
+
+### Private Bots
+Run Telegram/Discord bots with secret API tokens protected by TEE.
+
+## Troubleshooting
+
+### Build Fails
+- Ensure Docker/Podman is running
+- Use fully qualified image URLs
+- Check `oasis rofl build` output for enclave hash
+
+### appd 422 Errors
+- Verify request body matches expected schema
+- Check required fields (`kind` for keys, `tx` structure for sign-submit)
+
+### Proxy Not Working
+- Update Oasis CLI: `oasis rofl upgrade`
+- Rebuild: `oasis rofl build`
+- Redeploy: `oasis rofl deploy`
+
+### Logs Contain Secrets
+Logs are stored **unencrypted** on the ROFL node — never log sensitive values.

--- a/plugins/oasis-dev/skills/oasis-dev/references/SAPPHIRE.md
+++ b/plugins/oasis-dev/skills/oasis-dev/references/SAPPHIRE.md
@@ -1,0 +1,298 @@
+# Sapphire ParaTime Development
+
+Sapphire is the confidential EVM-compatible ParaTime on the Oasis Network, providing end-to-end encrypted smart contract execution.
+
+## Key Properties
+
+- **EVM-compatible**: Deploy standard Solidity contracts
+- **Confidential**: Contract state encrypted at rest, transactions encrypted end-to-end
+- **6-second finality**
+- **99%+ lower fees** than Ethereum
+- **18 decimal places** (like Ethereum, unlike 9 for Oasis consensus)
+- **Secure randomness**: On-chain cryptographic RNG
+
+## Network Info
+
+| Network | Chain ID | RPC URL | Explorer |
+|---------|----------|---------|----------|
+| Mainnet | 23294 (0x5afe) | `https://sapphire.oasis.io` | explorer.oasis.io/mainnet/sapphire |
+| Testnet | 23295 (0x5aff) | `https://testnet.sapphire.oasis.io` | explorer.oasis.io/testnet/sapphire |
+
+## Hardhat Setup
+
+```bash
+npm install -D @oasisprotocol/sapphire-hardhat
+```
+
+```js
+// hardhat.config.js — MUST be imported BEFORE all other plugins
+import '@oasisprotocol/sapphire-hardhat';
+import '@nomicfoundation/hardhat-toolbox';
+
+export default {
+  solidity: "0.8.24",
+  networks: {
+    sapphire_testnet: {
+      url: "https://testnet.sapphire.oasis.io",
+      chainId: 0x5aff,
+      accounts: [process.env.PRIVATE_KEY],
+    },
+    sapphire_mainnet: {
+      url: "https://sapphire.oasis.io",
+      chainId: 0x5afe,
+      accounts: [process.env.PRIVATE_KEY],
+    },
+  },
+};
+```
+
+The `@oasisprotocol/sapphire-hardhat` plugin automatically wraps the provider to handle encryption. It **must** be imported before other plugins.
+
+## NPM Packages
+
+| Package | Name | Purpose |
+|---------|------|---------|
+| Client | `@oasisprotocol/sapphire-paratime` | Core EIP-1193 provider wrapper |
+| Contracts | `@oasisprotocol/sapphire-contracts` | Solidity privacy library |
+| Hardhat | `@oasisprotocol/sapphire-hardhat` | Hardhat plugin |
+| Ethers v6 | `@oasisprotocol/sapphire-ethers-v6` | Ethers.js v6 integration |
+| Viem v2 | `@oasisprotocol/sapphire-viem-v2` | Viem v2 integration |
+| Wagmi v2 | `@oasisprotocol/sapphire-wagmi-v2` | Wagmi v2 integration |
+| Go | `github.com/oasisprotocol/sapphire-paratime/clients/go` | Go client |
+| Python | `sapphirepy` | Python client |
+
+## JavaScript/TypeScript SDK
+
+### Installation
+
+```bash
+npm install @oasisprotocol/sapphire-paratime ethers
+```
+
+### Wrapping a Provider (ethers v6)
+
+```typescript
+import { wrap } from '@oasisprotocol/sapphire-paratime';
+import { ethers } from 'ethers';
+
+// Wrap the provider for confidential transactions
+const provider = wrap(new ethers.JsonRpcProvider('https://testnet.sapphire.oasis.io'));
+const signer = wrap(new ethers.Wallet(privateKey, provider));
+
+// Now all transactions and calls are automatically encrypted
+const contract = new ethers.Contract(address, abi, signer);
+```
+
+### Wrapping a Provider (ethers v5)
+
+```typescript
+import { wrap } from '@oasisprotocol/sapphire-paratime';
+import { ethers } from 'ethers';
+
+const provider = wrap(new ethers.providers.JsonRpcProvider('https://testnet.sapphire.oasis.io'));
+const signer = wrap(new ethers.Wallet(privateKey).connect(provider));
+```
+
+### Key Point
+
+Without wrapping, transactions are sent in **plaintext** — always wrap the provider/signer.
+
+## Go SDK
+
+### Installation
+
+```bash
+go get github.com/oasisprotocol/sapphire-paratime/clients/go
+```
+
+### Usage with go-ethereum
+
+```go
+import (
+    "context"
+
+    "github.com/ethereum/go-ethereum/accounts/abi/bind"
+    "github.com/ethereum/go-ethereum/ethclient"
+
+    sapphire "github.com/oasisprotocol/sapphire-paratime/clients/go"
+)
+
+// Connect and wrap client
+client, _ := ethclient.Dial(sapphire.Networks[sapphire.ChainIDTestnet].DefaultGateway)
+backend, _ := sapphire.WrapClient(client, func(digest [32]byte) ([]byte, error) {
+    return crypto.Sign(digest[:], privateKey)
+})
+
+// Use wrapped backend for contract interactions
+nft, _ := NewNft(contractAddr, backend)
+
+// IMPORTANT: Use backend.Transactor() for write transactions
+txOpts := backend.Transactor(senderAddr)
+tx, _ := nft.Transfer(txOpts, tokenId, recipient)
+receipt, _ := bind.WaitMined(context.Background(), client, tx)
+
+// For confidential reads, specify From address
+balance := nft.BalanceOf(&bind.CallOpts{From: senderAddr}, targetAddr)
+```
+
+**WARNING**: Forgetting to use `backend.Transactor()` sends transactions in plaintext!
+
+### Bring Your Own Signer
+
+```go
+sapphireTestnetChainId := 0x5aff
+packedTx := sapphire.PackTx(tx, sapphire.NewCipher(sapphireTestnetChainId))
+signedTx := sign(packedTx)
+_ = client.SendTransaction(ctx, signedTx)
+```
+
+### Wrapping an EIP-1193 Provider (Browser dApps)
+
+```typescript
+import { wrapEthereumProvider } from '@oasisprotocol/sapphire-paratime';
+
+// MetaMask or any injected provider
+const provider = wrapEthereumProvider(window.ethereum);
+```
+
+The wrapper automatically encrypts `eth_call`, `eth_estimateGas`, and `eth_signTransaction` JSON-RPC calls.
+
+## Python SDK
+
+### Installation
+
+```bash
+pip install sapphirepy
+```
+
+### Usage with Web3.py
+
+```python
+from sapphirepy import wrap
+from web3 import Web3
+
+# Wrap the provider
+w3 = wrap(Web3(Web3.HTTPProvider('https://testnet.sapphire.oasis.io')))
+
+# Transactions are now automatically encrypted
+```
+
+## Sapphire Contracts (Solidity)
+
+### Installation
+
+```bash
+npm install @oasisprotocol/sapphire-contracts
+```
+
+### Subcall Library
+
+The `Subcall` library provides access to Oasis-specific functionality from Solidity:
+
+```solidity
+import {Subcall} from "@oasisprotocol/sapphire-contracts/contracts/Subcall.sol";
+
+contract MyContract {
+    bytes21 private roflAppID;
+
+    // Verify a transaction came from a ROFL app
+    function processROFLData(uint256 data) external {
+        Subcall.roflEnsureAuthorizedOrigin(roflAppID);
+        // Only ROFL app can reach here
+    }
+}
+```
+
+### On-Chain Randomness
+
+Sapphire provides cryptographically secure randomness:
+
+```solidity
+// Available in Sapphire — NOT available on other EVM chains
+bytes32 random = keccak256(abi.encodePacked(block.prevrandao));
+```
+
+Or use the Sapphire precompile for better randomness:
+
+```solidity
+import {Sapphire} from "@oasisprotocol/sapphire-contracts/contracts/Sapphire.sol";
+
+bytes memory random = Sapphire.randomBytes(32, "");
+```
+
+### Confidential State Access Patterns
+
+```solidity
+contract ConfidentialVoting {
+    // Private state — encrypted at rest, only accessible to contract logic
+    mapping(address => uint256) private votes;
+    uint256 private totalVotes;
+
+    // External view functions are confidential queries (encrypted response)
+    function getMyVote() external view returns (uint256) {
+        return votes[msg.sender];
+    }
+
+    // Write functions are confidential transactions (encrypted input)
+    function castVote(uint256 choice) external {
+        votes[msg.sender] = choice;
+        totalVotes++;
+    }
+}
+```
+
+## Cross-Chain: Oasis Privacy Layer (OPL)
+
+Sapphire can serve as a privacy layer for other chains via bridges:
+
+- **Hyperlane Protocol**: Cross-chain messaging with Sapphire as confidential backend
+- **Router Protocol**: Cross-chain asset transfers with privacy
+- **Celer**: Message-based cross-chain integration
+
+## Foundry Integration
+
+```bash
+# Deploy with Foundry (basic — no auto-wrapping)
+forge create --rpc-url https://testnet.sapphire.oasis.io \
+  --private-key $PRIVATE_KEY \
+  src/MyContract.sol:MyContract
+```
+
+Note: Foundry does not automatically wrap transactions for Sapphire confidentiality. Use the JS/TS SDK or Hardhat plugin for confidential interactions.
+
+## Remix IDE
+
+Sapphire can be used with Remix by adding the network to MetaMask and connecting Remix via Injected Provider. The `@oasisprotocol/sapphire-paratime` npm package handles encryption in browser-based dApps.
+
+## Contract Verification
+
+Verify contracts on the Oasis Explorer:
+
+```bash
+# Using Hardhat
+npx hardhat verify --network sapphire_testnet <contract-address> <constructor-args>
+```
+
+## Testing
+
+### Local Development
+
+Use `@oasisprotocol/sapphire-localnet` for local testing:
+
+```bash
+docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-localnet
+```
+
+### Hardhat Tests
+
+```bash
+npx hardhat test --network sapphire_testnet
+```
+
+## Common Pitfalls
+
+1. **Forgetting to wrap provider**: Transactions go in plaintext without the Sapphire wrapper
+2. **Wrong decimal places**: Sapphire uses 18 decimals (not 9 like consensus)
+3. **Import order**: `@oasisprotocol/sapphire-hardhat` must be imported FIRST in Hardhat config
+4. **msg.sender in views**: Confidential `view` calls should specify `{from: address}` for access control
+5. **Gas estimation**: May differ from standard EVM due to encryption overhead

--- a/plugins/oasis-dev/skills/oasis-dev/references/SDK-CORE.md
+++ b/plugins/oasis-dev/skills/oasis-dev/references/SDK-CORE.md
@@ -1,0 +1,265 @@
+# Oasis SDK & Core Concepts
+
+Architecture, core concepts, SDK patterns, and protocol-level documentation for the Oasis Network.
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────┐
+│              Applications / dApps            │
+├─────────────────────────────────────────────┤
+│         ParaTimes (Parallel Runtimes)        │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐    │
+│  │ Sapphire │ │ Emerald  │ │  Cipher  │    │
+│  │(Conf EVM)│ │  (EVM)   │ │(Conf WASM│    │
+│  └──────────┘ └──────────┘ └──────────┘    │
+├─────────────────────────────────────────────┤
+│            Consensus Layer                   │
+│  Staking · Registry · Governance · KMS       │
+├─────────────────────────────────────────────┤
+│            Oasis Core (Tendermint)            │
+└─────────────────────────────────────────────┘
+```
+
+## Key Concepts
+
+### ParaTimes
+
+ParaTimes are independent parallel runtimes sharing the Oasis consensus layer:
+- Each has its own state, transaction format, and execution environment
+- Can be confidential (TEE-backed) or non-confidential
+- Share security from the consensus layer validators
+
+| ParaTime | Type | EVM | Confidential | Decimals |
+|----------|------|-----|--------------|----------|
+| Sapphire | Production | Yes | Yes (TEE) | 18 |
+| Emerald | Production | Yes | No | 18 |
+| Cipher | Production | No (WASM) | Yes (TEE) | 9 |
+
+### Consensus Layer
+
+The consensus layer provides:
+- **Staking**: ROSE token delegation and rewards
+- **Registry**: Entity, node, and runtime registration
+- **Governance**: On-chain proposals and voting
+- **Key Manager**: Runtime key management for confidential ParaTimes
+- **Roothash**: ParaTime state commitment and verification
+
+### Entities & Nodes
+
+- **Entity**: An organization or individual operating nodes (identified by Ed25519 public key)
+- **Validator Node**: Participates in consensus (BFT)
+- **ParaTime Node**: Executes ParaTime logic (compute, storage, key manager)
+- **Seed Node**: Helps with peer discovery
+- **Archive Node**: Full history, no consensus participation
+
+### Tokens & Staking
+
+- **ROSE**: Native token (9 decimal places on consensus)
+- **Staking**: Validators must stake ROSE; delegators earn rewards
+- **Minimum stake**: Varies by role (validator, compute, key manager)
+- **Escrow**: Staked tokens held in escrow accounts
+- **Slashing**: Penalties for misbehavior (double-signing, unavailability)
+
+## Oasis SDK (Rust)
+
+The `oasis-sdk` crate is used for building custom ParaTime runtimes and ROFL applications in Rust.
+
+### Repository
+
+https://github.com/oasisprotocol/oasis-sdk
+
+### Key Crates
+
+| Crate | Purpose |
+|-------|---------|
+| `oasis-runtime-sdk` | Core SDK for building runtimes |
+| `oasis-runtime-sdk-macros` | Derive macros for modules |
+| `oasis-contract-sdk` | Smart contract SDK (for WASM contracts) |
+| `oasis-cbor` | CBOR encoding/decoding |
+
+### Building a Runtime Module
+
+```rust
+use oasis_runtime_sdk::{
+    self as sdk,
+    modules::{accounts, core},
+};
+
+/// My custom module.
+#[derive(Default)]
+pub struct Module;
+
+#[sdk::module(name = "my_module")]
+impl Module {
+    #[handler(call = "my_module.MyMethod")]
+    fn my_method(ctx: &Context, body: MyMethodRequest) -> Result<MyMethodResponse, Error> {
+        // Implementation
+    }
+
+    #[handler(query = "my_module.MyQuery")]
+    fn my_query(ctx: &Context, args: MyQueryArgs) -> Result<MyQueryResponse, Error> {
+        // Implementation
+    }
+}
+```
+
+### ROFL App in Rust (Raw Mode)
+
+```rust
+use oasis_runtime_sdk::rofl;
+
+struct MyApp;
+
+#[rofl::app]
+impl rofl::App for MyApp {
+    const VERSION: rofl::Version = rofl::Version::new(0, 1, 0);
+
+    async fn run(self: Arc<Self>, env: Environment) -> Result<()> {
+        // App logic here
+        // env provides access to consensus, key manager, etc.
+        Ok(())
+    }
+}
+```
+
+### Build Configuration
+
+Add to `.cargo/config.toml`:
+```toml
+[build]
+rustflags = ["-C", "target-feature=+aes,+ssse3"]
+```
+
+## Cryptography
+
+### Supported Algorithms
+
+| Algorithm | Usage |
+|-----------|-------|
+| Ed25519 | Consensus signatures, entity keys |
+| secp256k1 | EVM-compatible accounts |
+| sr25519 | Substrate-compatible (limited) |
+| SHA-512/256 | Hashing |
+| X25519 | Key exchange (Deoxys-II encryption) |
+| Deoxys-II | Authenticated encryption for confidential state |
+
+### Chain Domain Separation
+
+Transactions are signed with a chain-specific context:
+```
+oasis-core/consensus: tx for chain <chain-id>
+```
+
+This prevents replay attacks across networks.
+
+### Key Derivation (BIP-44)
+
+Oasis uses BIP-44 derivation path:
+```
+m/44'/474'/0'    (Oasis native, Ed25519)
+m/44'/60'/0'     (EVM-compatible, secp256k1)
+```
+
+## Encoding
+
+### CBOR
+
+Oasis uses CBOR (Concise Binary Object Representation) for:
+- Transaction encoding
+- State storage
+- RPC messages
+
+### Address Formats
+
+- **Oasis native**: Bech32-encoded (`oasis1...`)
+- **Ethereum-compatible**: Hex-encoded (`0x...`) — used in Sapphire/Emerald
+- **Conversion**: CLI handles automatic conversion between formats
+
+## Consensus Services
+
+### Staking
+
+```
+oasis account delegate <amount> <validator>
+oasis account undelegate <shares> <validator>
+```
+
+Delegation parameters:
+- **Commission rate**: Set by validator (0-100%)
+- **Unbonding period**: ~14 days for undelegation
+- **Minimum delegation**: Varies by validator
+
+### Governance
+
+```
+oasis network governance list
+oasis network governance show <proposal-id>
+oasis network governance vote <proposal-id> <yes|no|abstain>
+```
+
+### Registry
+
+Entities and nodes register via the registry service:
+- Entity registration (staking account)
+- Node registration (compute, validator, key manager)
+- Runtime registration (ParaTimes)
+
+## State Management
+
+### Merklized Key-Value Store (MKVS)
+
+ParaTime state is stored in a Merklized AVL tree:
+- Provides cryptographic proofs of state
+- Supports efficient state sync
+- Used for light client verification
+
+### State Sync
+
+Nodes can fast-sync state:
+```bash
+# Enable state sync in node config
+oasis-node --consensus.state_sync.enabled
+```
+
+### Pruning
+
+Reduce storage by pruning old state:
+- Keep last N versions
+- Keep checkpoints at intervals
+
+## Node Operations
+
+### Validator Requirements
+
+- **Minimum stake**: Check current requirements at https://docs.oasis.io
+- **Hardware**: 2+ CPU cores, 4+ GB RAM, 100+ GB SSD
+- **Network**: Stable connection, ports 26656 (P2P), 9001 (gRPC)
+
+### ParaTime Node Requirements
+
+- **TEE**: Intel SGX/TDX for confidential ParaTimes
+- **Additional stake**: ParaTime-specific requirements
+- **Runtime binary**: Specific to each ParaTime
+
+### Key Manager Node
+
+- Manages encryption keys for confidential ParaTimes
+- Requires TEE hardware
+- Critical for Sapphire and Cipher operation
+
+## Network Upgrades
+
+Oasis has undergone major upgrades:
+- **Cobalt**: Network stability improvements
+- **Damask**: Performance and governance enhancements
+- **Eden**: Latest upgrade with ROFL support
+
+Upgrades are coordinated via governance proposals.
+
+## External References
+
+- Oasis SDK: https://github.com/oasisprotocol/oasis-sdk
+- Oasis Core: https://github.com/oasisprotocol/oasis-core
+- Docs: https://docs.oasis.io
+- ADRs: https://github.com/oasisprotocol/adrs


### PR DESCRIPTION
## Summary

- Add **oasis-dev** plugin with skill + 4 reference documents for Oasis Network development
- Covers Sapphire confidential EVM, ROFL off-chain apps, CLI operations, and SDK patterns (Rust, Go, TypeScript, Python)
- Registered in marketplace.json under `development` category

### Plugin Structure

```
plugins/oasis-dev/
├── skills/oasis-dev/
│   ├── SKILL.md                ← Triggers, quick start, common tasks
│   └── references/
│       ├── CLI.md              ← Full CLI reference (wallet, account, network, paratime, ROFL, governance)
│       ├── SAPPHIRE.md         ← EVM dev: 8 SDK packages, Hardhat, Go/JS/Python, confidential patterns
│       ├── ROFL.md             ← App lifecycle, containers, secrets, appd API, 3 client SDKs
│       └── SDK-CORE.md         ← Architecture, Rust SDK, ParaTimes, staking, cryptography
├── README.md
└── LICENSE
```

### Triggers

Activates on: `oasis`, `sapphire`, `rofl`, `oasis cli`, `oasis sdk`, `paratime`, `emerald`, `cipher`, and when working in `oasisprotocol/*` repos.

### Sources

- https://docs.oasis.io/llms.txt / llms-full.txt
- https://github.com/oasisprotocol/sapphire-paratime
- https://github.com/oasisprotocol/oasis-sdk (including rofl-client TS/Python/Rust)
- https://github.com/oasisprotocol/cli

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes (schema, source paths, frontmatter)
- [ ] Install plugin and verify trigger activation on Oasis-related prompts
- [ ] Verify reference doc accuracy against latest Oasis docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)