### PR TITLE
feat(project-manager): add critical requirements challenge phase with -quick mode

### DIFF
--- a/plugins/project-manager/README.md
+++ b/plugins/project-manager/README.md
@@ -57,29 +57,32 @@ Before drafting, the plugin explores the repo to ensure:
 ## Workflow
 
 ```
-┌────────────────────────────────────────────────┐
-│               /project-manager                  │
-├────────────────────────────────────────────────┤
-│                                                │
-│  1. Classify — determine issue type            │
-│     (bug, feature, epic, refactor, etc.)       │
-│                                                │
-│  2. Discover — type-specific question flow     │
-│     (bounded choices + open-ended details)     │
-│                                                │
-│  3. Explore Codebase — find relevant files     │
-│     (Glob, Grep, Read for real paths)          │
-│                                                │
-│  4. Draft — generate issue from template       │
-│     (agent-optimized with VERIFY: criteria)    │
-│                                                │
-│  5. Review — present draft to user             │
-│     (approve, revise, or cancel)               │
-│                                                │
-│  6. Create — gh issue create with labels       │
-│     (title prefix, labels, body-file)          │
-│                                                │
-└────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────┐
+│            /project-manager [-quick]                 │
+├─────────────────────────────────────────────────────┤
+│                                                     │
+│  1. Classify — determine issue type                 │
+│     (bug, feature, epic, refactor, etc.)            │
+│                                                     │
+│  2. Discover — type-specific question flow          │
+│     (bounded choices + open-ended details)          │
+│                                                     │
+│  3. Challenge — probe underspecified requirements   │
+│     (critical: block on gaps, quick: smart defaults)│
+│                                                     │
+│  4. Explore Codebase — find relevant files          │
+│     (Glob, Grep, Read for real paths)               │
+│                                                     │
+│  5. Draft — generate issue from template            │
+│     (agent-optimized with VERIFY: criteria)         │
+│                                                     │
+│  6. Review — present draft to user                  │
+│     (approve, revise, or cancel)                    │
+│                                                     │
+│  7. Create — gh issue create with labels            │
+│     (title prefix, labels, body-file)               │
+│                                                     │
+└─────────────────────────────────────────────────────┘
 ```
 
 ## Issue Title Prefixes

--- a/plugins/project-manager/skills/project-manager/SKILL.md
+++ b/plugins/project-manager/skills/project-manager/SKILL.md
@@ -109,7 +109,7 @@ for the full dimension list.
 3. Present all assumptions in a single summary: "Here's what I'll assume: [list]. Confirm or correct?"
 4. Proceed after one confirmation round — only block on truly ambiguous requirements where no
    reasonable default exists
-5. Tag every assumed detail in the final issue body with `[PM-PROPOSED: rationale]`
+5. Tag every assumed detail in the final issue body with `[AGENT-DECIDED: rationale]`
 
 **Example — "add a delete button to user profiles":**
 

--- a/plugins/project-manager/skills/project-manager/references/WORKFLOWS.md
+++ b/plugins/project-manager/skills/project-manager/references/WORKFLOWS.md
@@ -383,7 +383,7 @@ Round 1: Classify → Round 2: Details → Draft
 
 ## Requirements Challenge Checklist
 
-Runs after every type-specific discovery flow (Step 3 in SKILL.md). Systematically probe for
+Runs after every type-specific discovery flow (after Step 2 (Discovery) as Step 3 (Challenge) in SKILL.md). Systematically probe for
 underspecified requirements before proceeding to codebase exploration.
 
 ### Completeness Check
@@ -401,7 +401,7 @@ Before proceeding, verify:
 Challenge requirements across these dimensions. Not all apply to every issue type — use the
 relevance guide below.
 
-#### UI / Interaction (features, bugs)
+#### UI / Interaction (features, bugs, epics, new projects)
 - **Placement / layout position** — where exactly in the UI?
 - **Visual states** — default, hover, active, focused, disabled, loading, error
 - **Conditional visibility** — when shown? when hidden? who sees it?
@@ -422,7 +422,7 @@ relevance guide below.
 - **Default values** — what's pre-filled or assumed?
 - **Required vs optional fields** — which inputs are mandatory?
 
-#### Integration (all types)
+#### Integration (bugs, features, epics, refactors, chores)
 - **Impact on existing functionality** — does this change break anything?
 - **Backwards compatibility** — must old behavior still work?
 - **Migration requirements** — do existing users/data need migration?
@@ -453,7 +453,7 @@ relevance guide below.
    > - [Gap]: [Proposed default] *(rationale)*
    > - [Gap]: [Proposed default] *(rationale)*
 4. Accept confirmation and proceed — only block if user raises concerns
-5. In the final issue body, tag each assumed detail: `[PM-PROPOSED: rationale]`
+5. In the final issue body, tag each assumed detail: `[AGENT-DECIDED: rationale]`
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a **Requirements Challenge** phase (Step 3) between Discovery and Codebase Exploration that systematically identifies and resolves ambiguities before drafting issues
- Supports two modes: **critical** (default — blocks on gaps, probes each ambiguity) and **quick** (`-quick` flag — proposes smart defaults, single confirmation round)
- Adds a comprehensive **Requirements Challenge Checklist** to WORKFLOWS.md with dimensions (UI/Interaction, Behavior, Data, Integration), relevance guide by issue type, and mode-specific behavior
- Updates workflow from 6 steps to 7 steps, renumbering all subsequent steps

Closes #20

## Test plan

- [ ] Run `bun scripts/validate-plugins.mjs` — passes clean
- [ ] Verify SKILL.md has 7-step workflow with Challenge between Discover and Explore
- [ ] Verify `-quick` flag is documented in Arguments section
- [ ] Verify WORKFLOWS.md contains Requirements Challenge Checklist with all dimensions and relevance guide
- [ ] Manual test: invoke `/project-manager` with "add a button" and verify it asks follow-up questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)