### PR TITLE
fix(jules-review): use backtick-wrapped @jules for AI recognition

### DIFF
--- a/plugins/jules-review/skills/jules-review/references/WORKFLOW.md
+++ b/plugins/jules-review/skills/jules-review/references/WORKFLOW.md
@@ -100,14 +100,14 @@ For each finding eligible for an inline comment, create a comment object:
 {
   "path": "src/api.ts",
   "line": 42,
-  "body": "**[critical] security** @jules\n\nSQL injection vulnerability in query builder.\n\n**Recommendation:** Use parameterized queries instead of string concatenation."
+  "body": "**[critical] security** `@jules`\n\nSQL injection vulnerability in query builder.\n\n**Recommendation:** Use parameterized queries instead of string concatenation."
 }
 ```
 
 ### Comment Body Format
 
 ```
-**[<severity>] <type>** @jules
+**[<severity>] <type>** `@jules`
 
 <description>
 
@@ -123,7 +123,7 @@ The review body includes the overall summary, verdict, and any findings that cou
 ### Body Structure
 
 ```markdown
-@jules
+`@jules`
 
 ## Council Review — <VERDICT>
 
@@ -146,7 +146,7 @@ If all findings are posted as inline comments, the "Findings (not in diff)" sect
 If there are no findings at all, the body should be:
 
 ```markdown
-@jules
+`@jules`
 
 ## Council Review — APPROVE
 


### PR DESCRIPTION
## Summary

- Jules AI requires `` `@jules` `` (with backticks) to recognize mentions in PR review comments
- Bare `@jules` renders as a GitHub user mention but Jules AI doesn't act on it
- Updated all 4 template locations in `WORKFLOW.md` that produce posted comment content (inline comment body, comment format template, review body, approve body)

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [x] Grep confirms all `@jules` in WORKFLOW.md templates are now backtick-wrapped
- [ ] Post a test Jules review on a PR and verify Jules AI picks up the mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)