### PR TITLE
fix(dlc): add git push after commit in pr-check skill

### DIFF
--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -212,7 +212,7 @@ If push fails, report the error clearly and print a manual recovery command:
 Push failed: {error message}
 Your commit is preserved locally. The most common cause is new commits on the remote branch.
 To resolve, pull and retry:
-  git pull --rebase origin {branch} && git push origin HEAD
+  git pull --rebase && git push origin HEAD
 ```
 
 Do NOT use `--force` or `--force-with-lease`. Only standard push is allowed.
@@ -224,7 +224,8 @@ PR review compliance check complete.
   - PR: #{number} ({title})
   - Total comments: {n}
   - Resolved: {n}, Fixed by DLC: {n}, Skipped (user decision): {n}, Discussion: {n}, Blocked: {n}, Dismissed: {n}
-  - Push: {Pushed to origin/{branch} | Push failed: {reason}}
+  - Push: {Pushed {sha} to origin/{branch}}  [if push succeeded]
+  - Push: Push failed: {reason}  [if push failed]
   - Follow-up issue: #{number} ({url})  [only if user approved creation]
 ```
 


### PR DESCRIPTION
## Summary

- The `pr-check` skill committed PR review fixes locally but never pushed to the remote branch, leaving the PR unchanged on GitHub
- Added explicit `git push origin HEAD` instruction after the commit step with graceful failure handling
- Recovery message guides users through the most common failure case (remote has new commits → `git pull --rebase`)
- Push status line added to the summary template
- Explicit `--force` / `--force-with-lease` prohibition to prevent history rewriting

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [x] Only Step 7 of `plugins/dlc/skills/pr-check/SKILL.md` was modified
- [ ] Manually invoke `/dlc:pr-check` on an open PR and verify push behavior

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated workflow docs to include an explicit "Commit, Push, and Report" step.
  * Added guidance for pushing commits, non‑force push recommendation, and printable recovery commands for push failures.
  * Extended final PR summary to report push results (success or failure) alongside existing commit/report messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->