### PR TITLE
fix(dlc): prevent premature replies and add PR summary in pr-check

### DIFF
--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -179,7 +179,7 @@ For each **Discussion** or **Blocked** comment, map the user's Step 6 decision:
 
 | User Decision (Step 6) | Inline Reply Text |
 |------------------------|-------------------|
-| Created follow-up issue | `Acknowledged — tracked in #{N}` (where N is the issue number from Step 6) |
+| Created follow-up issue | `Acknowledged — tracked in #ISSUE_NUMBER` |
 | Handle manually | `Acknowledged — will be addressed by the author` |
 
 For each **user-skipped Fixable** comment, always reply:
@@ -226,7 +226,7 @@ Build the summary with these sections:
 
 {Include all applicable lines below:}
 {If any follow-up issue was created:}
-Follow-up issue: #{N}
+Follow-up issue: #ISSUE_NUMBER
 
 {If any items will be handled manually by the author:}
 Author will address some remaining items manually.


### PR DESCRIPTION
## Summary

- **Step 5**: Reply to Fixed comments only — removed premature Discussion/Blocked replies that referenced a non-existent PR summary
- **Step 6**: Removed misplaced PR Comment Status table from follow-up issue body
- **Step 6b** (new): Posts decision-aware inline replies after user decision, covering Discussion, Blocked, and user-skipped Fixable items
- **Step 6c** (new): Posts PR-level summary comment with status table, per-item decisions, and follow-up link

Fixes #55

## Test plan

- [ ] Run `bun scripts/validate-plugins.mjs` — passes
- [ ] Verify Step 5 has no Discussion/Blocked reply blocks
- [ ] Verify Step 6 follow-up issue has no PR Comment Status section
- [ ] Verify Step 6b posts decision-aware replies with correct text per decision type
- [ ] Verify Step 6b/6c skip guards include user-skipped Fixable items
- [ ] Verify Step 6c posts PR summary with status table and conditional follow-up link
- [ ] Verify Step 7 is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Step 5 renamed and narrowed to post inline replies only for fixed comments; Discussion/Blocked replies deferred to a decision step.
  * Steps 6–7 reworked into a decision-driven flow with substeps for decision-aware inline replies and a PR-level summary.
  * Updated skip condition to bypass Step 6 when no applicable items remain.
  * Added guidance for creating issues, handling reply failures/drafts, committing/pushing, push-failure reporting, and posting structured PR summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->