### PR TITLE
fix(pm): clean up /tmp/issue-body.md after successful issue creation

### DIFF
--- a/plugins/project-manager/skills/pm/SKILL.md
+++ b/plugins/project-manager/skills/pm/SKILL.md
@@ -234,8 +234,9 @@ gh issue create --repo OWNER/REPO \
 | Research | `spike:` | `research` |
 
 **On failure:** Save draft to `/tmp/issue-draft-{timestamp}.md`, report error.
+**On success:** Remove the temp file: `rm -f /tmp/issue-body.md`
 
-For epics: create the parent issue first, then sub-issues with `Part of #EPIC_NUMBER` references.
+For epics: create the parent issue first, then sub-issues with `Part of #EPIC_NUMBER` references. Clean up `/tmp/issue-body.md` only after **all** sub-issues are created successfully.
 
 Report all created issue URLs to the user.
 


### PR DESCRIPTION
## Summary

- Add success-path cleanup of temp file after issue creation
- Defer cleanup for epics until **all** sub-issues are created successfully
- Failure-path timestamped draft remains untouched

Closes #56

## Test plan

- [ ] Run `bun scripts/validate-plugins.mjs` — passes cleanly
- [ ] Create a single issue via `/pm` — verify temp file is removed after success
- [ ] Create an epic via `/pm` — verify temp file persists until all sub-issues succeed
- [ ] Simulate a failure — verify timestamped draft is saved and working file is **not** cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the cleanup behavior when creating epics and sub-issues. Temporary files are now removed only after all sub-issues are created successfully, rather than being removed immediately, ensuring proper functionality throughout the creation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->