### PR TITLE
feat(dlc): harden pr-check with reviewer enumeration and coverage verification

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -356,6 +356,23 @@ Multi-step workflows that process a list of items (comments, issues, findings) s
 
 **Pattern**: Enumerate → Process → Verify → HALT on mismatch
 
+**Bad** — totals-only check (drops can hide):
+```text
+Fetched 12 comments total; categorized 12 comments total. ✓
+# But @reviewerA had 4 comments and only 3 were categorized,
+# while @reviewerB had 3 comments and 4 were categorized (phantom).
+# Total still matches — the drop is invisible.
+```
+
+**Good** — per-source enumeration + verification:
+```text
+@reviewerA: expected 4, categorized 4 ✓
+@reviewerB: expected 3, categorized 2 ✗
+  → HALT: missing comment IDs: [2808261121]
+  → Recovery: re-processing 1 missed comment through Steps 3-5...
+  → Retry verification: @reviewerB: expected 3, categorized 3 ✓
+```
+
 - **Step N**: Enumerate items per source (reviewer, scanner, etc.) — store counts as baseline
 - **Steps N+1 through M**: Process, categorize, and act on each item
 - **Step M+1**: Assert sum-across-categories == baseline per source

--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -96,9 +96,9 @@ Include all commenters (human reviewers, bots, CI tools) — do not pre-filter. 
 Print the inventory:
 
 ```text
-Reviewer inventory ({n} reviewers, {n} total comments, {n} top-level threads):
-  - @{reviewer1}: {n} comments ({m} top-level threads)
-  - @{reviewer2}: {n} comments ({m} top-level threads)
+Reviewer inventory ({reviewer_count} reviewers, {total_comment_count} total comments, {top_level_thread_count} top-level threads):
+  - @{reviewer1}: {reviewer1_comment_count} comments ({reviewer1_top_level_thread_count} top-level threads)
+  - @{reviewer2}: {reviewer2_comment_count} comments ({reviewer2_top_level_thread_count} top-level threads)
 ```
 
 Store each reviewer's **top-level thread count** as the coverage target for Step 5b. These counts are the baseline — every top-level thread must appear in exactly one category by the end of Step 5.
@@ -194,7 +194,7 @@ Verify that every top-level thread from Step 2b has been accounted for. For each
 
 For each reviewer from Step 2b, assert:
 
-```
+```text
 covered threads (sum across all categories) == top-level thread count from Step 2b
 ```
 
@@ -386,10 +386,10 @@ PR review compliance check complete.
   - PR: #{number} ({title})
   - Total comments: {n}
   - Resolved: {n}, Fixed by DLC: {n}, Skipped (user decision): {n}, Discussion: {n}, Blocked: {n}, Dismissed: {n}
-  - Coverage: {n}/{n} threads verified (Step 5b passed)
+  - Coverage: {verified_threads}/{total_threads} threads verified (Step 5b passed)
   - Per-reviewer breakdown:
-      @{reviewer1}: Resolved={n}, Fixed={n}, Skipped={n}, Discussion={n}, Blocked={n}, Dismissed={n} — 0 missed
-      @{reviewer2}: Resolved={n}, Fixed={n}, Skipped={n}, Discussion={n}, Blocked={n}, Dismissed={n} — 0 missed
+      @{reviewer1}: Resolved={resolved_count}, Fixed={fixed_count}, Skipped={skipped_count}, Discussion={discussion_count}, Blocked={blocked_count}, Dismissed={dismissed_count} — 0 missed
+      @{reviewer2}: Resolved={resolved_count}, Fixed={fixed_count}, Skipped={skipped_count}, Discussion={discussion_count}, Blocked={blocked_count}, Dismissed={dismissed_count} — 0 missed
   - Push: {Pushed {sha} to origin/{branch}}  [if push succeeded]
   - Push: Push failed: {reason}  [if push failed]
   - Follow-up issue: #{number} ({url})  [only if user approved creation]


### PR DESCRIPTION
## Summary

- Add **Step 2b: Enumerate Reviewers** — builds per-reviewer inventory (total comments + top-level thread counts) as a coverage baseline before categorization
- Add **Step 5b: Coverage Verification** — asserts every top-level thread appears in exactly one category per reviewer, HALTs on mismatch with one retry then permanent stop
- Expand **Step 7 summary** with coverage confirmation line and per-reviewer category breakdown
- Add **Step 4c guardrail** for failed implementations — reclassifies as Blocked to prevent false-positive HALTs (council quick review finding from Gemini)
- Add learnings entry to `docs/learnings.md` — "Coverage verification as a safeguard against silent item drops" pattern

Closes #64

## Context

Claude Code Insights report (Feb 7-11) identifies missed review comments as the #1 friction point. In multiple sessions, Claude skipped inline comments from specific reviewers (Gemini, Copilot), requiring manual audit. The current `dlc:pr-check` workflow lacked explicit reviewer-level tracking, so dropped comments went undetected.

## Design Decisions

- **Step naming**: Uses letter suffixes (2b, 5b) matching existing convention (1b, 6b, 6c)
- **Coverage baseline**: Tracks top-level thread count per reviewer (not total comments), because Step 3 categorizes "each top-level review thread"
- **HALT pattern**: Matches Step 1b's style — bold prohibition, error output template, recovery path
- **Re-processing cap**: One retry for missed comments, then hard stop (prevents infinite loops)
- **Failed fix reclassification**: Gemini's council review identified that fixable items failing implementation had no terminal category — resolved by reclassifying as Blocked in Step 4c guardrails

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes clean
- [ ] Verify step numbering sequence: 1 → 1b → 2 → 2b → 3 → 4 → 5 → 5b → 6 → 6b → 6c → 7
- [ ] Verify diff is pure insertions + one guardrail line (no modifications to existing steps)
- [ ] Manually run `/dlc:pr-check` on a PR with multiple reviewers to confirm enumeration and coverage output
- [ ] Verify HALT fires correctly when a comment is artificially omitted from categorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added coverage-verification pattern to detect and prevent silent item drops with per-source tracking and HALT-on-mismatch behavior
  * Introduced per-reviewer enumeration and accountability, plus per-reviewer coverage checks and reporting in review workflows
  * Expanded common pitfalls with reviewer-level tracking guidance
  * Added branch/post-checkout verification guidance and three-way decision flow for mismatches
<!-- end of auto-generated comment: release notes by coderabbit.ai -->