### PR TITLE
feat(cdt): add workflow declaration and delegation enforcement

### DIFF
--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -54,7 +54,7 @@ Follow the planning workflow defined in @plan-workflow.md (skip Step 0 — Git C
 
 ## Phase 1: Completion Audit
 
-Before proceeding, log which teammates were actually used during Phase 1:
+Before proceeding, log which roles were actually used during Phase 1:
 
 ```
 Phase 1 complete:
@@ -65,7 +65,7 @@ Phase 1 complete:
 
 Determine "used" by whether you sent at least one `SendMessage` (teammates) or launched at least one `Task` subagent (researcher) during Phase 1.
 
-If any teammate was created but never used: **WARN** "Teammate {name} was created but never used in Phase 1"
+If any role was created but never used: **WARN** "Role {name} was created but never used in Phase 1"
 
 ## Bridge
 
@@ -77,7 +77,7 @@ Follow the development workflow defined in @dev-workflow.md using the plan path 
 
 ## Phase 2: Completion Audit
 
-Before proceeding to wrap-up, log which teammates were actually used during Phase 2:
+Before proceeding to wrap-up, log which roles were actually used during Phase 2:
 
 ```
 Phase 2 complete:
@@ -90,7 +90,7 @@ Phase 2 complete:
 
 Determine "used" by whether you sent at least one `SendMessage` (teammates) or launched at least one `Task` subagent (researcher) during Phase 2.
 
-If any teammate was created but never used: **WARN** "Teammate {name} was created but never used in Phase 2"
+If any role was created but never used: **WARN** "Role {name} was created but never used in Phase 2"
 
 ## Wrap Up (Autonomous)
 

--- a/plugins/cdt/commands/full-task.md
+++ b/plugins/cdt/commands/full-task.md
@@ -55,7 +55,7 @@ Follow the planning workflow defined in @plan-workflow.md (skip Step 0 — Git C
 
 ## Phase 1: Completion Audit
 
-Before proceeding, log which teammates were actually used during Phase 1:
+Before proceeding, log which roles were actually used during Phase 1:
 
 ```
 Phase 1 complete:
@@ -66,7 +66,7 @@ Phase 1 complete:
 
 Determine "used" by whether you sent at least one `SendMessage` (teammates) or launched at least one `Task` subagent (researcher) during Phase 1.
 
-If any teammate was created but never used: **WARN** "Teammate {name} was created but never used in Phase 1"
+If any role was created but never used: **WARN** "Role {name} was created but never used in Phase 1"
 
 ## Gate: User Approval
 
@@ -85,7 +85,7 @@ Follow the development workflow defined in @dev-workflow.md using the plan path 
 
 ## Phase 2: Completion Audit
 
-Before proceeding to wrap-up, log which teammates were actually used during Phase 2:
+Before proceeding to wrap-up, log which roles were actually used during Phase 2:
 
 ```
 Phase 2 complete:
@@ -98,7 +98,7 @@ Phase 2 complete:
 
 Determine "used" by whether you sent at least one `SendMessage` (teammates) or launched at least one `Task` subagent (researcher) during Phase 2.
 
-If any teammate was created but never used: **WARN** "Teammate {name} was created but never used in Phase 2"
+If any role was created but never used: **WARN** "Role {name} was created but never used in Phase 2"
 
 ## Wrap Up
 


### PR DESCRIPTION
## Summary

- **Strengthened ROLE instruction** in `auto-task.md` and `full-task.md` — explicitly names blocked tools (`Edit`, `Write`, `NotebookEdit`) instead of abstract "don't edit files"
- **Added Step 0.5: Workflow Declaration** — coordinator announces workflow structure (teams, roles, no-edit constraint) before starting work
- **Added Phase 1 & Phase 2 Completion Audits** — coordinator logs which teammates were actually used after each phase, with warnings for created-but-unused teammates

Council review (Gemini + Claude codebase context) caught and fixed `prod-mgr` → `product-manager` naming mismatch in audit templates and imprecise warning text.

Closes #66

## Test plan

- [ ] Run `bun scripts/validate-plugins.mjs` — passes clean
- [ ] Visually inspect both files: Step 0.5 appears between Git Check and Phase 1
- [ ] Confirm ROLE instruction names all three blocked tools
- [ ] Confirm audit sections list correct teammates for their phase
- [ ] Confirm no changes to Bridge, Wrap Up, or Rules sections
- [ ] Run `/cdt:auto-task` or `/cdt:full-task` and verify workflow declaration prints before Phase 1
- [ ] Verify completion audits appear between phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured workflow with explicit Step 0.5 workflow declaration, stricter coordinator restrictions (no direct edits, delegation via SendMessage, STOP guidance), and updated diagrams/role mappings.
  * Added Phase 1 and Phase 2 completion audits to log role usage, define “used” criteria, and WARN on unused roles.
  * Added gated user-approval step, AskUserQuestion prompts, and expanded wrap-up with staging/commit/push, PR creation/linkage, and post-PR cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->