### PR TITLE
fix: correct script path resolution in skill SKILL.md files

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -214,7 +214,7 @@ Skills that make 3–4 sequential `gh` CLI calls waste context window space on r
 - **Optional positional args** — scripts auto-detect PR number and repo when args are omitted, saving a preliminary `gh` call in the SKILL.md
 - **Cycle detection deferred to LLM** — jq lacks mutable state for DFS; scripts provide edge lists, SKILL.md steps do graph traversal
 
-**Script path resolution**: SKILL.md references scripts as `scripts/foo.sh` relative to the plugin root. Claude resolves this the same way it resolves reference file links (`../dlc/references/ISSUE-TEMPLATE.md`). No `$CLAUDE_PLUGIN_ROOT` needed (that's for hooks).
+**Script path resolution**: SKILL.md bash code blocks run relative to the **skill's base directory** (`skills/<skill-name>/`), NOT the plugin root. Use `../../scripts/foo.sh` to reach the plugin-level `scripts/` directory. This differs from markdown reference links (which are resolved by the plugin loader). A bare `scripts/foo.sh` resolves to `skills/<skill-name>/scripts/foo.sh` — which doesn't exist.
 
 **Frontmatter impact**: If a skill's `allowed-tools` restricts Bash (e.g., `Bash(gh:*)`), widen to `Bash` when adding local script execution. Acceptable trade-off since skills with Read/Grep/Glob already have filesystem access.
 

--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -15,14 +15,14 @@ Before running, **read [../dlc/references/ISSUE-TEMPLATE.md](../dlc/references/I
 
 ## Step 1: Fetch PR Data
 
-Run the `pr-comments.sh` script located in the `scripts/` directory of this plugin (same plugin containing this SKILL.md):
+Run the `pr-comments.sh` script from the plugin's `scripts/` directory (two levels up from this skill):
 
 ```bash
 # If PR number provided as argument
-sh scripts/pr-comments.sh <PR_NUMBER>
+sh ../../scripts/pr-comments.sh <PR_NUMBER>
 
 # If no argument — auto-detect from current branch
-sh scripts/pr-comments.sh
+sh ../../scripts/pr-comments.sh
 ```
 
 **Validate the response:**

--- a/plugins/project-manager/skills/next/SKILL.md
+++ b/plugins/project-manager/skills/next/SKILL.md
@@ -32,17 +32,17 @@ Analyze open GitHub issues, build a dependency graph, and recommend the highest-
 
 ### Step 1: Fetch and Pre-process Issues
 
-Run the `open-issues.sh` script located in the `scripts/` directory of this plugin (same plugin containing this SKILL.md):
+Run the `open-issues.sh` script from the plugin's `scripts/` directory (two levels up from this skill):
 
 ```bash
 # Auto-detect repository from current directory
-sh scripts/open-issues.sh
+sh ../../scripts/open-issues.sh
 
 # Or specify repository explicitly
-sh scripts/open-issues.sh OWNER/REPO
+sh ../../scripts/open-issues.sh OWNER/REPO
 
 # Include assigned issues in results
-sh scripts/open-issues.sh --include-assigned
+sh ../../scripts/open-issues.sh --include-assigned
 ```
 
 **Validate the response:**


### PR DESCRIPTION
## Summary

- Skills resolve bash code block paths relative to their **skill base directory** (`skills/<name>/`), not the plugin root
- `scripts/foo.sh` was resolving to `skills/<name>/scripts/foo.sh` — which doesn't exist
- Changed to `../../scripts/foo.sh` in both affected skills
- Corrected the false assumption in `docs/learnings.md` that claimed bash paths resolve like markdown links

## Affected skills

| Plugin | Skill | Script |
|--------|-------|--------|
| `dlc` | `pr-check` | `pr-comments.sh` |
| `project-manager` | `next` | `open-issues.sh` |

## Root cause

Markdown reference links (e.g., `[name](../dlc/references/...)`) are resolved by the Claude Code plugin loader at load time. Bash commands in code blocks are interpreted by the agent at runtime, relative to the skill's "Base directory" — which is `skills/<skill-name>/`, not the plugin root. The original `scripts/foo.sh` paths assumed plugin-root resolution.

## Repro (before fix)

```
sh /home/tom/.claude/plugins/cache/rube-cc-skills/dlc/1.19.0/skills/pr-check/scripts/pr-comments.sh 145
# → Error: Exit code 2 — No such file
```

## Test plan

- [ ] Run `/dlc:pr-check` on an open PR — verify `pr-comments.sh` executes successfully
- [ ] Run `/pm:next` — verify `open-issues.sh` executes successfully
- [ ] Run `bun scripts/validate-plugins.mjs` — passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated skill configuration documentation to clarify how script paths are resolved within skill files. Scripts referenced in skills are now located relative to the skill's base directory, requiring adjusted relative paths (e.g., `../../scripts/...`) instead of being relative to the plugin root. Updated all example commands and guidance across multiple skill documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->