### PR TITLE
docs: lean down AGENTS.md by removing derivable knowledge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ See [docs/PLUGIN-AUTHORING.md](./docs/PLUGIN-AUTHORING.md) for the full authorin
 
 ## Validation & PRs
 
-- CI plan lives in `.github/workflows/` (`ci.yml` validates on PR, `release.yml` runs on merge to main)
-- Run `bun scripts/validate-plugins.mjs` before committing — CI runs the same check
-- After adding or moving plugin files, re-run validation to catch orphaned dirs or missing marketplace entries
+- CI plan lives in `.github/workflows/` (`ci.yml` validates on PR, `release.yml` runs on push to main)
+- Run `bun scripts/validate-plugins.mjs` and fix any errors before committing — CI runs the same check
+- After adding or moving plugin directories or updating marketplace entries, re-run validation to catch orphaned plugin directories or missing source paths
 - PRs target `main`; semantic-release handles versioning on merge — never edit versions by hand
 
 ## Learnings


### PR DESCRIPTION
## Summary

- Remove full directory tree (35% of file) — derivable from `marketplace.json` + filesystem
- Remove Key Files table — duplicated in `CLAUDE.md` "Claude Code Specifics"
- Remove Conventions section — restated from Git Workflow + Validation sections
- Merge Testing/Validation and PR Instructions into single "Validation & PRs" section

Reduces `AGENTS.md` from 120 to 48 lines (**-60%**). No behavioral instructions were removed — only factual/derivable knowledge that was either redundant or available from the filesystem.

## Test plan

- [ ] `bun scripts/validate-plugins.mjs` passes (no structural changes)
- [ ] Verify all behavioral instructions (Git Workflow, Validation, Learnings) are intact
- [ ] CI reference to `.github/workflows/` is preserved in merged section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured developer guidance documentation with improved workflow focus
  * Consolidated validation and PR procedures with streamlined instructions
  * Removed legacy sections and reduced documentation scope for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->