### PR TITLE
feat(pm): auto-detect epic scope from requirements breadth signals

### DIFF
--- a/plugins/project-manager/skills/pm/references/WORKFLOWS.md
+++ b/plugins/project-manager/skills/pm/references/WORKFLOWS.md
@@ -97,7 +97,7 @@ Guide the user through the user story format:
 
 ### Breadth Analysis (internal PM step — not a user question)
 
-After gathering the user story, check for epic-scope signals before proceeding to Round 3:
+After gathering the user story, check for epic-scope signals before proceeding to Round 3 — Boundaries:
 
 **Signal 1 — Multiple independent stories**
 Does the request contain 3+ stories that could each ship independently?
@@ -116,17 +116,17 @@ Does implementing this require restructuring existing code AND adding new behavi
 
 **Signal 4 — Rewrite/overhaul language**
 Does the request use language like: rewrite, redesign, overhaul, migrate, replace, rebuild?
-→ Treat as epic by default
+→ Count this as one breadth signal (always)
 
 **Routing rules:**
 
 - **2+ signals present** → Route to Epic Flow automatically. Announce:
-  > "This request spans [insert applicable: number of independent stories / number of subsystems / structural + behavioral change].
+  > "This request shows signs of epic scope (detected signals: [list all applicable signals, e.g., 'multiple independent stories', 'rewrite/overhaul language']).
   > That's epic scope — a single issue would be too broad to execute atomically.
   > Routing to Epic Flow to decompose into independent sub-issues."
   Do NOT proceed to Round 3 or draft a Feature issue.
 
-- **1 signal present** → Continue Feature Flow. Note the signal in the issue body under a `**Scope note:**` field.
+- **1 signal present** → Continue Feature Flow. Note the signal in the issue body under a **Scope note:** field.
 
 - **0 signals** → Continue Feature Flow normally, no scope note added.
 


### PR DESCRIPTION
## Summary
- Removes user-facing "How big is this feature?" question from Feature Request Flow Round 1 — the upstream cause of oversized issues entering the CDT pipeline
- Adds PM-driven Breadth Analysis step (internal, not a user question) after Round 2 using 4 signals: independent stories, cross-subsystem span, structural+behavioral change, rewrite/overhaul language
- Routes to Epic Flow automatically when 2+ signals detected; annotates issue body with `Scope note:` when 1 signal; continues normally for 0 signals

Closes #89

## Test plan
- [ ] Read WORKFLOWS.md Feature Request Flow Round 1: confirm no size question present
- [ ] Read Breadth Analysis section: confirm 4 signals, 3 routing rules, Epic Flow announcement text
- [ ] Confirm Bug/Refactor/Epic/Chore/New Project flows are unchanged
- [ ] `bun scripts/validate-plugins.mjs` passes with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined initial project assessment to exactly two prioritized questions
  * Added Breadth Analysis to detect epic scope using four signals and included it in Round 1 and Round 2 flows
  * Implemented routing rules: auto-route to Epic for 2+ signals, continue Feature with scope note for 1 signal, no note for 0 signals; detected signals are disclosed
  * Expanded boundary guidance and added an "Exploratory" priority option
<!-- end of auto-generated comment: release notes by coderabbit.ai -->