### PR TITLE
feat: add pre-discovery single-story framing gate to Feature Flow

### DIFF
--- a/plugins/project-manager/skills/pm/references/WORKFLOWS.md
+++ b/plugins/project-manager/skills/pm/references/WORKFLOWS.md
@@ -74,7 +74,7 @@ Round 0: Story Framing → Round 1: Scope + Priority → Round 2: User Story →
 
 Ask this before any other Feature Flow question:
 
-**Question: "Are you describing one user story or several?"**
+**Question 1: "Are you describing one user story or several?"**
 - One story: A single "As a [user], I want to [action] so that [benefit]" → proceed with Feature Flow
 - Multiple stories: Several distinct things a user wants, even if related → route to Epic Flow now
 
@@ -88,11 +88,11 @@ Ask this before any other Feature Flow question:
 - **Unclear** — ask exactly one follow-up:
   > "Can a user get value from [story A] without [story B] being done?"
   - Yes → independent stories → Epic Flow
-  - No → one story with dependencies → Feature Flow
+  - No → dependent stories, handled as a single feature → Feature Flow
 
 - **"One story"** → continue to Round 1 questions below.
 
-### Round 1 — Scope (AskUserQuestion)
+### Round 1 — Scope + Priority (AskUserQuestion)
 
 Ask these together (2 questions):
 


### PR DESCRIPTION
## Summary

- Adds Round 0 (Story Framing) as the first interaction in Feature Request Flow, before Round 1's user type and priority questions
- Binary question ("one story or several?") routes multi-story requests to Epic Flow immediately, with one optional follow-up for unclear answers
- Complements the post-discovery Breadth Analysis (#89) — together they catch obvious scope upfront and subtle scope after discovery

## Test Plan

- [ ] VERIFY: Feature Request Flow begins with Round 0 "one story or several?" before Round 1
- [ ] VERIFY: "Multiple stories" answer → Epic Flow without beginning Feature Flow discovery
- [ ] VERIFY: Unclear answers trigger exactly one follow-up ("can a user get value from A without B?")
- [ ] VERIFY: Follow-up correctly routes: yes → Epic Flow, no → Feature Flow
- [ ] VERIFY: "One story" → continues to Round 1 (user type, priority) unchanged
- [ ] VERIFY: No other flows modified (Bug, Epic, Refactor, New Project, Chore/Research)
- [ ] VERIFY: `bun scripts/validate-plugins.mjs` passes

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Round 0 story-framing step that asks whether the request covers one or multiple stories and routes to Feature or Epic flows accordingly.
  * Explicit routing for ambiguous answers, including a single follow-up question to clarify.

* **Documentation**
  * Shifted subsequent questions to follow the new framing step and duplicated framing guidance in the Epic flow for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->