### PR TITLE
feat: enforce size label selection on Feature/Epic sub-issues

### DIFF
--- a/plugins/project-manager/skills/pm/SKILL.md
+++ b/plugins/project-manager/skills/pm/SKILL.md
@@ -257,7 +257,7 @@ gh issue create --repo OWNER/REPO \
   --body-file /tmp/issue-body.md \
   --label "<type-label>,<size-label>"
 
-# Without size label (Bug, Epic parent, Chore, Research):
+# Without size label (Bug, Epic parent, New Project parent, Chore, Research):
 gh issue create --repo OWNER/REPO \
   --title "<type-prefix>: <description>" \
   --body-file /tmp/issue-body.md \


### PR DESCRIPTION
## Summary

- Adds deterministic size label selection (`size/S`, `size/M`, `size/L`) to PM skill Step 7 (Create), derived from upstream analysis signals
- Three separate mapping tables for Features (breadth analysis), Refactors (target area), and Epic sub-issues (decomposition table)
- Updates `gh issue create` examples and type table with sizing info

## Details

Wires existing PM analysis into label selection so CDT architects can filter issues by scope without re-reading bodies:

| Type | Size source |
|------|------------|
| Feature | Breadth analysis signals (Step 2) |
| Refactor | Target area (Refactor Flow Round 1, Q2) |
| Epic sub-issue | Decomposition table row (subsystems + structural changes) |
| Bug, Epic parent, Chore, Research | Skipped — no size label |

`size/XL` is intentionally excluded — epic-scope work is decomposed, not labeled XL.

Closes #94

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [ ] Read Step 7 end-to-end: size block before `gh issue create`, mapping tables match issue #94
- [ ] Verify type table has `Size?` column with correct values
- [ ] Verify `gh issue create` shows both with/without size label variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a dedicated "Size label selection" section with decision tables for Features, Epics, New Project sub-issues, and Refactors
  * Updated title-prefix table with a new "Size?" column to indicate size-label applicability
  * Expanded Create Issue workflow examples to show GH CLI usage with/without size labels
  * Clarified epic creation order, sub-issue linking, post-creation cleanup, and success/failure handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->