### PR TITLE
fix: correct step reference for feature sizing

### DIFF
--- a/plugins/project-manager/skills/pm/SKILL.md
+++ b/plugins/project-manager/skills/pm/SKILL.md
@@ -220,7 +220,7 @@ Skips: Epic parent, New Project, Bug, Chore, Research.
 
 Determine the size label deterministically from analysis already gathered in earlier steps.
 
-**Features** — derive from Step 2 analysis (breadth signals and structural change detection):
+**Features** — derive from Step 2 breadth signals and Step 3 structural change detection:
 
 | Analysis result | Size label |
 |-----------------|------------|


### PR DESCRIPTION
## Summary
- Feature sizing header incorrectly referenced "Step 2 analysis" for structural change detection
- Structural change detection is in Step 3 (Requirements Challenge), not Step 2 (Type-Specific Discovery)
- Follow-up from PR #122 review feedback

## Test plan
- [ ] Verify SKILL.md step references match actual step numbering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined the Features sizing rule documentation to clarify how size labels are derived from specific analysis steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->