### PR TITLE
feat(dlc): add dependency staleness check to security scan

### DIFF
--- a/plugins/dlc/skills/dlc/references/REPORT-FORMAT.md
+++ b/plugins/dlc/skills/dlc/references/REPORT-FORMAT.md
@@ -9,7 +9,7 @@ Each finding is a structured record with these fields:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `severity` | enum | yes | `critical`, `high`, `medium`, `low`, `info` |
-| `type` | string | yes | Category: `vulnerability`, `dependency`, `lint`, `complexity`, `duplication`, `dead-code`, `performance`, `coverage`, `test-failure`, `pr-comment`, `redundancy` |
+| `type` | string | yes | Category: `vulnerability`, `dependency`, `dependency-staleness`, `lint`, `complexity`, `duplication`, `dead-code`, `performance`, `coverage`, `test-failure`, `pr-comment`, `redundancy` |
 | `file` | string | yes | Relative file path from repo root (e.g. `src/auth/login.ts`) |
 | `line` | number | no | Line number where the issue occurs |
 | `message` | string | yes | Human-readable description of the finding |

--- a/plugins/dlc/skills/security/SKILL.md
+++ b/plugins/dlc/skills/security/SKILL.md
@@ -58,18 +58,24 @@ command -v govulncheck >/dev/null 2>&1 && govulncheck ./... 2>/dev/null
 
 Check for packages significantly behind the latest stable release — these accumulate security patches without formal CVEs.
 
+Select tools based on availability (`command -v`), not exit codes — staleness tools exit non-zero when outdated packages are found, which is a valid result to capture.
+
 ```bash
-# Node.js
-command -v npm >/dev/null 2>&1 && npm outdated --json 2>/dev/null
+# Node.js — prefer npm, fall back to Bun
+if command -v npm >/dev/null 2>&1; then
+  npm outdated --json 2>/dev/null
+elif command -v bun >/dev/null 2>&1; then
+  bun outdated 2>/dev/null
+fi
 
 # Python
 command -v pip >/dev/null 2>&1 && pip list --outdated --format=json 2>/dev/null
 
 # Rust
-command -v cargo-outdated >/dev/null 2>&1 && cargo outdated 2>/dev/null
+command -v cargo-outdated >/dev/null 2>&1 && cargo outdated --json 2>/dev/null
 
 # Go
-command -v go >/dev/null 2>&1 && go list -u -m all 2>/dev/null
+command -v go >/dev/null 2>&1 && go list -u -m -json all 2>/dev/null
 ```
 
 ### Static Analysis (SAST)
@@ -112,7 +118,7 @@ Map tool output to the findings format from REPORT-FORMAT.md.
 | `info` / advisory only | **Info** |
 | Dependency > 2 major versions behind latest | **Medium** — type: `dependency-staleness` |
 | Dependency > 1 major version behind | **Low** — type: `dependency-staleness` |
-| Dependency last updated > 2 years ago (unmaintained) | **Medium** — type: `dependency-staleness` |
+| Dependency last updated > 2 years ago (unmaintained, when metadata available) | **Medium** — type: `dependency-staleness` |
 | > 10 dependencies with pending updates | **Low** — type: `dependency-staleness` (aggregate) |
 
 Deduplicate findings that appear in multiple tools. Prefer the source with more detail.


### PR DESCRIPTION
## Summary

- Adds a `### Dependency Staleness` section to `dlc:security` Step 2, running `npm outdated`, `pip list --outdated`, `cargo-outdated`, and `go list -u` to surface packages significantly behind latest stable
- Extends the Step 3 severity table with four staleness thresholds tagged `dependency-staleness` (Medium for >2 major versions behind or unmaintained >2 years, Low for >1 major version behind or >10 aggregate pending updates)
- Catches silent attack surface accumulation — security patches that ship without formal CVEs

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes (schema + source paths + SKILL.md frontmatter)
- [ ] Manually invoke `dlc:security` on a Node.js project and verify `npm outdated` output appears in the scan results

Closes #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Dependency Staleness section with commands to detect outdated dependencies for Node.js, Python, Rust, and Go.
  * Documented configurable severity mappings for dependency staleness in findings/classification guidance.
  * Extended report format documentation to include "dependency-staleness" as an allowed finding type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->