### PR TITLE
feat(cdt): add per-wave commits after wave verification

### DIFF
--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -217,9 +217,9 @@ For each wave:
 4. If developer teammate needs docs — spawn Researcher subagent, relay results
 5. Verify wave: check build, update plan file (status, log, files_changed)
 6. Commit wave (save point):
-   - Stage files changed in this wave: `git add [files from plan task.files_changed]`
-   - Commit: `git commit -m "feat(wave-N): [brief wave description from plan]"`
-   - If no files changed in this wave (coordination-only), skip commit
+   - Stage files changed in this wave (including deletions/renames): `git add -A -- [paths from the wave's files_changed list]`
+   - If there are staged changes (`! git diff --cached --quiet`), commit: `git commit -m "feat(wave-N): [brief wave description from plan]"`
+   - If nothing is staged in this wave (coordination-only), skip the commit
 
 After all impl waves:
 7. Message code-tester teammate: "Implementation complete. Files: [list]. Begin testing. Report failures directly to the developer teammate. Only message me when all tests pass."
@@ -301,7 +301,7 @@ AskUserQuestion:
 ```
 
 If creating PR:
-1. Stage changed files (doc updates, dev report — implementation files were committed per-wave)
+1. Stage all remaining changes (doc updates, dev report, and any post-wave fixes from test/review cycles)
 2. Commit with conventional commit message based on task (this is the final wrap-up commit)
 3. Push branch (includes all per-wave commits plus this wrap-up commit)
 4. Create PR with plan summary as description. Derive `BRANCH=$(git branch --show-current | tr '/' '-')`; if `".claude/$BRANCH/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".claude/$BRANCH/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only), then include `Closes #$ISSUE_NO` in the PR body.
@@ -309,7 +309,7 @@ If creating PR:
    `"$(cat ".claude/$BRANCH/.cdt-scripts-path")/sync-github-issue.sh" review`
 
 If commit & push only:
-1. Stage changed files (doc updates, dev report — implementation files were committed per-wave)
+1. Stage all remaining changes (doc updates, dev report, and any post-wave fixes from test/review cycles)
 2. Commit with conventional commit message based on task (this is the final wrap-up commit)
 3. Push branch (includes all per-wave commits plus this wrap-up commit)
 


### PR DESCRIPTION
## Summary

- Adds per-wave commit step (step 6) to Section 6 "Execute Waves" in `dev-workflow.md` — after each wave passes build verification, stage and commit changed files as a save point
- Skips commit for coordination-only waves with no file changes
- Updates wrap-up section (Section 10) to clarify that per-wave commits already capture implementation — the final commit covers doc updates and dev report only

Closes #105

## Test plan

- [ ] Verify `bun scripts/validate-plugins.mjs` passes
- [ ] Review that step numbering in Section 6 is consistent (1-6 per-wave, 7-12 post-wave)
- [ ] Confirm wrap-up commit description accurately reflects the new per-wave commit flow
- [ ] Verify no changes to `auto-task.md` (out of scope per issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added per-wave commit save points in the development workflow to capture incremental work during each implementation wave.
  * Introduced a final wrap-up commit step that aggregates remaining changes when creating a PR.
  * Clarified sequencing and messaging around waves, testing/review, commit/push actions, and PR wrap-up.
  * Adjusted numbering and wording for clearer, more consistent workflow guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->