### PR TITLE
feat(cdt): enforce task size ≤3 files and strengthen scope lock

### DIFF
--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -67,7 +67,7 @@ Teammate tool:
         (README.md, AGENTS.md, CLAUDE.md) to reflect what changed
     11. When done, message the lead
 
-    Scope lock: ONLY modify files listed in your task's `location` field. If you discover a needed change outside your task's files, message the lead — do NOT expand scope. Exception: Step 10 documentation updates are always in scope. Need docs? Message the lead.
+    Scope lock: Your edit scope is limited to (a) files listed in your task's `location` field and (b) for Step 10 only, the following docs: README.md, AGENTS.md, CLAUDE.md. If you discover a needed change outside this set, message the lead — do NOT expand scope. Need additional docs? Message the lead.
 ```
 
 **Code-tester teammate** (always spawned):

--- a/plugins/cdt/skills/cdt/references/plan-workflow.md
+++ b/plugins/cdt/skills/cdt/references/plan-workflow.md
@@ -70,7 +70,7 @@ Teammate tool:
     4. Read all files in `docs/adrs/` (if the directory exists) to understand prior architecture decisions before designing
     5. If you need library docs, message the lead
     6. Design: components, interfaces, file changes, data flow, testing strategy
-    7. **Task sizing**: Each task MUST touch ≤3 files and represent a single independently-verifiable concern. If a change requires >3 files, split into multiple tasks with explicit dependencies. Exception: documentation-update tasks may touch more files.
+    7. **Task sizing**: Each task MUST touch ≤3 files and represent a single independently-verifiable concern. If a change requires >3 files, either: (a) split it into multiple tasks with explicit dependencies, or (b) justify why a single task is necessary and list all files it will touch in the task description. Exception: documentation-update tasks may touch more files.
     8. Write new Architecture Decision Records (ADRs) to `docs/adrs/adr-NNNN-<slug>.md` for each significant decision:
        - Format: title, status (proposed/accepted/rejected/superseded), context, decision, consequences
        - Number sequentially from existing ADRs (start at 0001 if none exist)


### PR DESCRIPTION
## Summary

- Add task sizing rule (step 7) to architect prompt: each task MUST touch ≤3 files, single concern, independently verifiable — with split-or-justify requirement for exceptions
- Strengthen developer scope lock from soft instruction ("Stay within files") to hard rule ("ONLY modify files listed in your task's `location` field")
- Update plan template `location` fields with `[file paths — max 3 files per task]` convention in both template instances

Closes #106
Part of #104

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [ ] Verify architect agent respects ≤3 file limit during next CDT planning session
- [ ] Verify developer agent refuses to modify out-of-scope files during next CDT dev session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enforced stricter scope: edits limited to files listed in a task’s location (with a specific, limited exception for one step); changes outside require messaging the lead.
  * Added task-sizing rule: each task should modify at most 3 files (split or justify otherwise); docs exceptions noted.
  * Reordered and renumbered planning workflow steps and templates to reflect the new sizing and scoping requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->