### PR TITLE
feat(cdt): make developer model configurable with Opus default

### DIFF
--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -25,7 +25,9 @@ The team creation hook will attempt to assign and move to "In Progress" (best-ef
 
 Read the plan file from `$ARGUMENTS`. Extract tasks, dependencies, waves. Check files-per-task for conflict avoidance.
 
-Extract `developer_model` from plan metadata (the `**Developer Model**:` field). If not specified or not one of `opus`/`sonnet`, default to `opus`.
+Extract `developer_model` from plan metadata (the `**Developer Model**:` field).
+Normalize before validation: trim whitespace, lowercase, and parse only the first token after the `:`.
+If missing or not one of `opus`/`sonnet`, default to `opus`.
 
 ## 2. Generate Timestamp
 

--- a/plugins/cdt/skills/cdt/references/plan-workflow.md
+++ b/plugins/cdt/skills/cdt/references/plan-workflow.md
@@ -70,7 +70,7 @@ Teammate tool:
     4. Read all files in `docs/adrs/` (if the directory exists) to understand prior architecture decisions before designing
     5. If you need library docs, message the lead
     6. Design: components, interfaces, file changes, data flow, testing strategy
-       Set `Developer Model: sonnet` if the implementation is straightforward file modifications. Keep `opus` for complex algorithm design, intricate state management, or security-critical code.
+       Set `**Developer Model**: sonnet` if the implementation is straightforward file modifications. The default `opus` should be used for complex algorithm design, intricate state management, or security-critical code.
     7. **Task sizing**: Each task MUST touch ≤3 files and represent a single independently-verifiable concern. If a change requires >3 files, either: (a) split it into multiple tasks with explicit dependencies, or (b) justify why a single task is necessary and list all files it will touch in the task description. Exception: documentation-update tasks may touch more files.
     8. Write new Architecture Decision Records (ADRs) to `docs/adrs/adr-NNNN-<slug>.md` for each significant decision:
        - Format: title, status (proposed/accepted/rejected/superseded), context, decision, consequences
@@ -85,7 +85,7 @@ Teammate tool:
         # Plan: [Task Name]
 
         **Generated**: [Date]  **Target**: [Original request]
-        **Developer Model**: [opus|sonnet] (default: opus — use sonnet for straightforward implementation, opus for complex logic)
+        **Developer Model**: [opus|sonnet]
 
         ## Overview
         [Architecture, key decisions, research findings — 2-3 paragraphs]
@@ -190,7 +190,7 @@ The architect teammate writes the plan file. Your role is to verify it exists an
 # Plan: [Task Name]
 
 **Generated**: [Date]  **Target**: [Original request]
-**Developer Model**: [opus|sonnet] (default: opus — use sonnet for straightforward implementation, opus for complex logic)
+**Developer Model**: [opus|sonnet]
 
 ## Overview
 [Architecture, key decisions, research findings — 2-3 paragraphs]


### PR DESCRIPTION
## Summary

- Add optional `developer_model` field to plan template metadata (defaults to `opus`)
- Architect chooses `sonnet` for straightforward implementations, keeps `opus` for complex logic
- Dev workflow extracts the field when spawning the developer teammate, with fallback to `opus` for missing/invalid values

Fixes #107

## Changes

| File | Change |
|------|--------|
| `plugins/cdt/skills/cdt/references/plan-workflow.md` | Added `Developer Model` to both plan template instances + architect guidance |
| `plugins/cdt/skills/cdt/references/dev-workflow.md` | Added model extraction in Parse Plan + configurable model in developer spawn |

## Test plan

- [ ] Verify `bun scripts/validate-plugins.mjs` passes
- [ ] Verify plan template includes `Developer Model` field in metadata
- [ ] Verify dev-workflow reads `developer_model` from plan
- [ ] Verify default is `opus` when field is missing
- [ ] Verify invalid values fall back to `opus`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Developer model selection is now dynamic and configurable per plan; inputs are normalized and default to Opus when unspecified or unrecognized. Opus is recommended for complex logic/security-critical work, Sonnet for straightforward edits.

* **Documentation**
  * Workflow docs updated to show how to specify the Developer Model in plan templates and generation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->