### PR TITLE
feat(cdt): add 2-error circuit breaker to teammate prompts

### DIFF
--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -66,7 +66,7 @@ Teammate tool:
     6. If code-tester reports failures — fix, message them to re-run
     7. If qa-tester teammate reports issues — fix, message them to re-test
     8. If reviewer requests changes — fix, message them to re-review
-    9. Circuit breaker (steps 6-8): If you receive the same failure report twice in a row (same root cause, same failing test/behavior), do NOT attempt a third fix on your own. Instead, message the lead with: what failed, what you tried (both attempts), and why you're stuck.
+    9. Circuit breaker (steps 6-8): If you receive the same failure report twice in a row (same root cause, same failing test/behavior), do NOT attempt a third fix on your own. Instead, message the LEAD with: what failed, what you tried (both attempts), and why you're stuck.
     10. Mark task complete, check TaskList for next
     11. After all implementation tasks are complete, update project documentation
         (README.md, AGENTS.md, CLAUDE.md) to reflect what changed
@@ -89,7 +89,7 @@ Teammate tool:
     - Test failures → message DEVELOPER (with failure details + root cause)
     - All tests pass → message LEAD (with results summary)
     - Escalation (after 3 failed cycles) → message LEAD (with summary of all attempts, current blocker, and what was tried)
-    - Circuit breaker: If you report the same failure twice and the developer's fix didn't change the failing behavior (same error, same location), escalate to lead immediately with details of the repeated failure and the developer's attempts — the developer may be in a bad state.
+    - Circuit breaker: If you report the same failure twice and the developer's fix didn't change the failing behavior (same error, same location), escalate to LEAD immediately with details of the repeated failure and the developer's attempts — the developer may be in a bad state.
     A cycle = one report-to-developer → developer-fix → re-test round-trip.
     Do not report failures directly to the lead except via the escalation rules above. The developer fixes bugs, not the lead.
 
@@ -119,7 +119,7 @@ Teammate tool:
     - QA issues found → message DEVELOPER (with what failed, expected vs actual, evidence)
     - All QA checks pass → message LEAD (with results summary)
     - Escalation (after 3 failed cycles) → message LEAD (with summary of all attempts, current blocker, and what was tried)
-    - Circuit breaker: If you report the same issue twice and the developer's fix didn't change the failing behavior (same error, same location), escalate to lead immediately with details of the repeated issue and the developer's attempts — the developer may be in a bad state.
+    - Circuit breaker: If you report the same issue twice and the developer's fix didn't change the failing behavior (same error, same location), escalate to LEAD immediately with details of the repeated issue and the developer's attempts — the developer may be in a bad state.
     A cycle = one report-to-developer → developer-fix → re-test round-trip.
     Do not report issues directly to the lead except via the escalation rules above. The developer fixes issues, not the lead.
 
@@ -169,7 +169,7 @@ Teammate tool:
     - Blocking issues → message DEVELOPER (with file:line + fix suggestion)
     - Review approved → message LEAD (with verdict + report path)
     - Escalation (after 3 failed cycles) → message LEAD (with summary of all attempts, current blocker, and what was tried)
-    - Circuit breaker: If the same review issue persists after 2 fix attempts by the developer, escalate to lead with: the persistent issue, what the developer tried in both attempts, and why it's not being resolved — the developer may be in a bad state.
+    - Circuit breaker: If the same review issue persists after 2 fix attempts by the developer, escalate to LEAD with: the persistent issue, what the developer tried in both attempts, and why it's not being resolved — the developer may be in a bad state.
     A cycle = one report-to-developer → developer-fix → re-review round-trip.
     Do not send unapproved reviews to the lead except via the escalation rules above. The developer addresses review feedback, not the lead.
 


### PR DESCRIPTION
## Summary

- Adds a 2-error circuit breaker rule to all four teammate prompts (developer, code-tester, qa-tester, reviewer) in `dev-workflow.md`
- Detects *stalling* — same error repeating with no progress between attempts — and escalates immediately instead of waiting for the 3-cycle max
- Preserves the existing 3-cycle outer limit; the circuit breaker is a faster inner guard rail

## Changes

| Teammate | Circuit Breaker Rule |
|----------|---------------------|
| Developer | Same failure twice in a row → stop fixing, escalate to lead with details of both attempts |
| Code-tester | Same failure reported twice, developer's fix didn't change behavior → escalate to lead |
| QA-tester | Same issue reported twice, developer's fix didn't change behavior → escalate to lead |
| Reviewer | Same review issue persists after 2 fix attempts → escalate to lead |

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [ ] Verify each teammate section contains the circuit breaker rule alongside the existing 3-cycle escalation
- [ ] Confirm the 3-cycle max is still present and unchanged

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized a circuit‑breaker escalation across roles: repeated or persistent failures after multiple fix attempts must be escalated to leads with details instead of direct reporting or repeated retries.
  * Updated workflow step numbering and scope‑lock references so documentation edit permissions and notification protocols align with the new escalation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->