### PR TITLE
feat(cdt): add TDD test-first ordering rule to architect prompt

### DIFF
--- a/plugins/cdt/skills/cdt/SKILL.md
+++ b/plugins/cdt/skills/cdt/SKILL.md
@@ -75,7 +75,7 @@ Reviews changed files for completeness, correctness, security, quality, plan adh
 - Teammates debate directly (Architect teammate↔PM teammate, Developer teammate↔Code-tester teammate, Developer teammate↔QA-tester teammate, Developer teammate↔Reviewer teammate)
 - Researcher is always a subagent — Lead relays results
 - Plan.md is the single source of truth and handoff artifact
-- Every task declares `depends_on` and optionally `type` (impl|test|docs); parallel within waves, sequential between
+- Every task declares `type` (impl|test|docs) and `depends_on`; parallel within waves, sequential between
 - Verify build between waves
 - Avoid file conflicts between parallel tasks
 - Testing + review are mandatory quality gates

--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -23,7 +23,7 @@ The team creation hook will attempt to assign and move to "In Progress" (best-ef
 
 ## 1. Parse Plan
 
-Read the plan file from `$ARGUMENTS`. Extract tasks, dependencies, waves, and task `type` (impl|test|docs). Check files-per-task for conflict avoidance.
+Read the plan file from `$ARGUMENTS`. Extract tasks, dependencies, waves, and task `type` (impl|test|docs). For conflict avoidance, enforce the ≤3-files-per-task limit only for `impl` and `test` tasks; `docs` tasks may exceed this limit.
 
 Extract `developer_model` from plan metadata (the `**Developer Model**:` field).
 Normalize before validation: trim whitespace, lowercase, and parse only the first token after the `:`.

--- a/plugins/cdt/skills/cdt/references/plan-workflow.md
+++ b/plugins/cdt/skills/cdt/references/plan-workflow.md
@@ -71,14 +71,14 @@ Teammate tool:
     5. If you need library docs, message the lead
     6. Design: components, interfaces, file changes, data flow, testing strategy
        Set `**Developer Model**: sonnet` if the implementation is straightforward file modifications. The default `opus` should be used for complex algorithm design, intricate state management, or security-critical code.
-    7. **Task sizing**: Each task MUST touch ≤3 files and represent a single independently-verifiable concern. If a change requires >3 files, either: (a) split it into multiple tasks with explicit dependencies, or (b) justify why a single task is necessary and list all files it will touch in the task description. Exception: docs-type tasks may touch more files.
+    7. **Task sizing**: Each task MUST touch ≤3 files and represent a single independently-verifiable concern. If a change requires >3 files, either: (a) split it into multiple tasks with explicit dependencies, or (b) justify why a single task is necessary and list all files it will touch in the task description. Exception: docs-only tasks (type: docs) may touch more files.
     8. **TDD ordering**: Where feasible, create test-writing tasks BEFORE their corresponding implementation tasks. The developer writes a failing test first, then implements until it passes (red-green-refactor). If a test requires implementation scaffolding first (e.g., new types, interfaces), set `depends_on` on the test task to list the scaffolding task(s).
     9. Write new Architecture Decision Records (ADRs) to `docs/adrs/adr-NNNN-<slug>.md` for each significant decision:
        - Format: title, status (proposed/accepted/rejected/superseded), context, decision, consequences
        - Number sequentially from existing ADRs (start at 0001 if none exist)
        - When a new decision supersedes an old one, update the old ADR's status to `superseded` and link to the new ADR
        - Reference existing ADRs when relevant (e.g., "per ADR-0003, we use Redis for caching")
-    10. If you created ADRs in step 9, check whether `docs/adrs/` is referenced in the target project's `AGENTS.md` or `CLAUDE.md` — if not, note a documentation-update task in the plan so the developer teammate can add the reference later
+    10. If you created or referenced ADRs in step 9, check whether `docs/adrs/` is referenced in the target project's `AGENTS.md` or `CLAUDE.md` — if not, note a documentation-update task in the plan so the developer teammate can add the reference later
     11. Message your design to the lead AND the product-manager (include links to new and referenced ADRs)
     12. Iterate on PM teammate feedback
     13. Ensure the plan directory exists (`mkdir -p .claude/plans`), then write the plan to [plan-path] using this template:


### PR DESCRIPTION
## Summary

- Adds TDD ordering rule (step 8) to the architect's prompt in `plan-workflow.md` — test tasks should be created before implementation tasks where feasible (red-green-refactor)
- Adds `type` field (`impl|test|docs`) to the plan template task structure in both template copies
- Updates Testing Strategy section to reference TDD ordering with explicit escape hatch for scaffolding dependencies

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [ ] Verify architect prompt step numbering is sequential (steps 1–15)
- [ ] Verify both plan template copies (inline + standalone) have matching `type` fields
- [ ] Verify Testing Strategy sections include TDD reference in both templates

Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced explicit task type field for T1/T2 entries to classify work (impl/test/docs).
  * Inserted a TDD ordering directive encouraging test-first development (red–green–refactor).
  * Added documentation-check step to verify and plan doc/ADR references, with a plan-only doc update task if missing.
  * Clarified ADR guidance to include types and dependency notes.
  * Expanded plan template and adjusted plan creation, messaging, PM feedback, and directory-creation sequencing; renumbered steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->