### PR TITLE
refactor(cdt): sequence researcher before architect in plan phase

### DIFF
--- a/plugins/cdt/skills/cdt/references/plan-workflow.md
+++ b/plugins/cdt/skills/cdt/references/plan-workflow.md
@@ -34,7 +34,7 @@ Generate a timestamp in `YYYYMMDD-HHMM` format (e.g. `20260207-1430`). Use this 
 Read project context files (`CLAUDE.md`, `AGENTS.md`) to understand conventions and stack.
 If requirements are ambiguous — ask the user via AskUserQuestion with recommendations.
 
-Do NOT explore the codebase with Glob/Grep — that is the architect's job in Step 5.
+Do NOT explore the codebase with Glob/Grep — that is the architect's job in Step 5b.
 
 ## 3. Create Team
 


### PR DESCRIPTION
## Summary

- Split plan-workflow Step 5 into **5a** (Research) and **5b** (Launch Architect + PM) so research completes before design begins
- Inject `$RESEARCH_CONTEXT` directly into architect and PM spawn prompts, eliminating the async relay in Step 6
- Add skip path: if no research needed, proceed immediately to 5b
- Update Step 4 task annotations to reflect the new sequencing
- Remove "When Researcher returns" from Step 6 coordination (now redundant)

Fixes #112
Part of #104

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [ ] Manual: run `/cdt` plan phase on a task requiring external research — verify researcher fires before architect
- [ ] Manual: run `/cdt` plan phase on a pure refactor — verify architect + PM launch immediately (no researcher)
- [ ] Verify architect prompt contains pre-loaded research findings
- [ ] Verify PM prompt contains research context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a two-stage launch flow: a dedicated Research phase (if needed) that produces a shared Research Context, followed by parallel Architect + PM launch stages that receive that context.

* **Documentation**
  * Reworked plan workflow and prompts to include pre-loaded research context, updated coordination steps, revised PM/Architect guidance, and aligned plan verification and templates to the new flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->