### PR TITLE
feat(dlc,cdt): add implementation-bias reminders to pr-check and CDT developer

### DIFF
--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -61,7 +61,7 @@ Teammate tool:
     1. Check TaskList, claim unblocked tasks (lowest ID first)
     2. Read plan section for your task — architecture, interfaces, dependencies
     3. Implement completely — no stubs, no TODOs, match existing patterns
-       Code is cheap — if you spot a small fix in a file you're already editing (typo, missing null check, broken condition), implement it directly. Don't defer it as "out of scope" when you're already there.
+       Implement small fixes you encounter in files you're already editing (typo, missing null check, broken condition) — code is cheap; don't defer them as "out of scope" when you're already there.
     4. Run build/lint if available
     5. Message the code-tester teammate: what changed, what to test
     6. If code-tester reports failures — fix, message them to re-run

--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -164,7 +164,7 @@ Assign a confidence level:
   - Options: "Implement as suggested" / "Skip this comment" / "Implement with modification"
   - If "Implement with modification" is chosen, ask for guidance before proceeding
 
-> **Bias toward implementation**: Code is cheap — generating a fix costs less than deliberating about whether to. If a fix is technically correct and the change is straightforward (rename, add a check, fix a typo, adjust formatting, add missing validation), default to **High confidence** and implement it directly. Do not inflate uncertainty to avoid work or defer small fixes as "out of scope." The confidence gate exists for genuinely ambiguous suggestions where reasonable engineers would disagree — not as an escape hatch for effort avoidance.
+> **Bias toward implementation**: Default to **High confidence** and implement fixes directly when a change is technically correct and straightforward (rename, add a check, fix a typo, adjust formatting, add missing validation) — code is cheap; generating a fix costs less than deliberating about whether to. Do not inflate uncertainty to avoid work or defer small fixes as "out of scope." The confidence gate exists for genuinely ambiguous suggestions where reasonable engineers would disagree — not as an escape hatch for effort avoidance.
 
 **Guardrails:**
 - Only modify files that are part of the PR's diff


### PR DESCRIPTION
## Summary

- Add "bias toward implementation" blockquote to `/dlc:pr-check` Step 3c — straightforward fixes (renames, null checks, typos, formatting, missing validation) default to **High confidence** and get implemented directly instead of deferred via `AskUserQuestion`
- Add "code is cheap" reminder to CDT developer teammate prompt — small fixes in files already being edited should be done inline, not deferred as "out of scope"
- No changes to report-only skills, review-only skills, or CDT scope lock rules

## Sanity Test

Ran a parallel A/B classification test (5 reviewer comments, modified vs original skill):

| Comment | Original | Modified | 
|---------|----------|----------|
| Rename function | Medium (defer) | **High (implement)** |
| Add null check | High | High |
| "Consider" architecture change | Low (defer) | Medium (defer) |
| Fix typo | High | High |
| Exponential backoff (underspecified) | Medium (defer) | Medium (defer) |

The callout shifted straightforward renames from defer→implement without over-correcting on genuinely ambiguous suggestions.

## Test plan

- [ ] Verify `bun scripts/validate-plugins.mjs` passes in CI
- [ ] Verify blockquote placement in `pr-check/SKILL.md` Step 3c (between confidence gate and Guardrails)
- [ ] Verify CDT reminder is scoped to "files you're already editing" (doesn't conflict with scope lock)

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified development workflow to encourage making straightforward fixes (typos, small renames, formatting, missing/null checks, simple validations) directly when already editing related code rather than deferring them.
  * Added guidance to default to high confidence and implement clear, low-risk fixes immediately, while preserving existing guardrails and overall workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->