### PR TITLE
feat(dlc): resolve review threads after Fixed/Answered/Dismissed replies

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -615,6 +615,21 @@ When forking a multi-phase workflow (e.g., `github-issue-work` → `plugin-dev:d
 
 > Source: [Issue #160](https://github.com/rube-de/cc-skills/issues/160) — fork of github-issue-work into `/plugin-dev:develop` with TDD extension points.
 
+### DLC reply prefixes must align with thread resolution semantics on reruns
+
+When a skill posts replies with different prefixes (`Fixed:`, `Answered:`, `Dismissed:`, `Acknowledged:`), the rerun classification logic must treat them differently based on whether the thread was resolved on GitHub:
+
+- **"Fixed:", "Dismissed:", "Answered:"** → thread was resolved via `resolveReviewThread` → classify as **Resolved** on rerun
+- **"Acknowledged:"** → thread intentionally left unresolved (work is pending) → classify as **Unresolved** on rerun
+
+If the rerun classification treats all DLC reply prefixes equally as "Resolved," threads that are still open on GitHub get silently skipped — a coverage gap invisible to both the agent and the reviewer.
+
+**Related pattern**: When a workflow adds a secondary API call after a primary one (e.g., `resolveReviewThread` after posting a reply), gate the secondary call on the primary's success. Otherwise a failed reply + successful resolve leaves the reviewer with a closed conversation and no explanation.
+
+**Related pattern**: When suppressing command output for non-fatal calls (`>/dev/null`), only redirect stdout — keep stderr visible for debugging. `>/dev/null 2>&1` hides error messages that would explain why a call failed.
+
+> Source: [PR #183](https://github.com/rube-de/cc-skills/pull/183) — Three independent reviewers (Gemini, Codex, Claude) identified these patterns across the `resolveReviewThread` addition.
+
 ### jq `==` comparisons inside object constructors require parentheses on Apple jq
 
 Apple ships `jq-1.7.1-apple` which throws `syntax error, unexpected ==` when `==` comparisons appear directly inside a jq object constructor without explicit outer parentheses. Standard jq is more permissive. Always wrap comparisons used as object field values in outer parentheses: `field: ((expr) == other)` instead of `field: (expr) == other`.

--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -95,7 +95,7 @@ Using the `.threads` array from Step 1, classify each top-level review thread:
 
 | Category | Criteria |
 |----------|----------|
-| **Resolved** | `is_resolved == true`, OR PR author replied with affirmative language, OR thread already has a DLC reply (prefixed with "Fixed:", "Dismissed:", "Acknowledged:", or "Answered:") |
+| **Resolved** | `is_resolved == true`, OR PR author replied with affirmative language, OR thread already has a DLC reply (prefixed with "Fixed:", "Dismissed:", or "Answered:"). Note: "Acknowledged:" replies do NOT count — those threads intentionally remain unresolved because the underlying work is pending (see Step 5b). |
 | **Dismissed** | Not applicable for inline threads — threads use GitHub's resolve mechanism, not dismiss. This category will typically be 0 for threads. |
 | **Unresolved** | Everything else. This includes `is_outdated` threads (the agent must re-check the current code state), and threads containing nit/optional/consider comments (these are still legitimate feedback) |
 
@@ -328,18 +328,18 @@ Use the `reply_type` field from the comment data to determine the reply mechanis
 
 ```bash
 # Post the reply (uses rest_id for the REST API)
-gh api repos/$PR_OWNER/$PR_REPO/pulls/$PR_NUMBER/comments \
+if gh api repos/$PR_OWNER/$PR_REPO/pulls/$PR_NUMBER/comments \
   --method POST \
   -f body="{reply text}" \
-  -F in_reply_to={rest_id}
-
-# Resolve the thread on GitHub (uses GraphQL node id)
-if ! gh api graphql -f query='mutation($threadId: ID!) {
-  resolveReviewThread(input: {threadId: $threadId}) {
-    thread { isResolved }
-  }
-}' -f threadId="{id}" >/dev/null 2>&1; then
-  echo "Warning: Failed to resolve thread {id} — reply was posted successfully" >&2
+  -F in_reply_to={rest_id}; then
+  # Resolve the thread on GitHub (uses GraphQL node id, only after successful reply)
+  if ! gh api graphql -f query='mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId="{id}" >/dev/null; then
+    echo "Warning: Failed to resolve thread {id} — reply was posted successfully" >&2
+  fi
 fi
 ```
 


### PR DESCRIPTION
## Summary

- Add `resolveReviewThread` GraphQL mutation after inline replies in Step 4, so Fixed/Answered/Dismissed threads show as resolved in GitHub's UI
- Clarify `id` (GraphQL node ID) vs `rest_id` (REST API integer) field usage in reply routing docs
- Explicitly document that Step 5b Acknowledged replies do NOT resolve threads (work is pending)

Closes #182

## Test plan

- [ ] Run DLC pr-check on a PR with unresolved inline threads — verify Fixed replies resolve the thread
- [ ] Verify Answered and Dismissed replies also resolve threads
- [ ] Verify Acknowledged (deferred/tracked/skipped) replies do NOT resolve threads
- [ ] Verify review body and issue comment replies are unaffected (no resolve attempt)
- [ ] Simulate a `resolveReviewThread` failure (e.g. bad thread ID) — verify warning is logged but reply still posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified reply-prefix classification: “Fixed:”, “Dismissed:”, “Answered:” → Resolved; “Acknowledged:” → intentionally Unresolved.
  * Documented routing: post inline reply first, then attempt thread-resolution and log non-blocking warnings on failure.
  * Explicitly stated only inline review threads can be resolved; review bodies and issue comments remain unresolvable.
  * Added learnings on rerun semantics, control-flow for secondary API calls, and targeted stdout/stderr suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->