### PR TITLE
fix(project-manager): link epic sub-issues via GitHub Sub-Issues API

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -639,3 +639,13 @@ Apple ships `jq-1.7.1-apple` which throws `syntax error, unexpected ==` when `==
 **Good pattern**: `blockers_resolved: ((expr) == (.blocked_by | length)),` — works on both.
 
 > Source: [PR #179](https://github.com/rube-de/cc-skills/pull/179), fixes [#177](https://github.com/rube-de/cc-skills/issues/177) — `plugins/project-manager/scripts/open-issues.sh`
+
+### Use `-F` (not `-f`) for integer fields in `gh api` calls
+
+`gh api` has two field flags: `-f` (lowercase) always sends a string, while `-F` (uppercase) performs JSON type inference so integers stay integers. APIs that require an integer field (e.g. `sub_issue_id` in the GitHub Sub-Issues API) return a type error if the value arrives as a string. Always use `-F` for numeric fields.
+
+**Bad pattern**: `gh api ... -f sub_issue_id=123` — sends `"123"` (string), API rejects with type error.
+
+**Good pattern**: `gh api ... -F "sub_issue_id=$sub_issue_id"` — sends `123` (integer). Note the quoting: `-F "key=$var"` keeps the entire `key=value` as one shell argument.
+
+> Source: [PR #185](https://github.com/rube-de/cc-skills/pull/185) — `plugins/project-manager/skills/pm/SKILL.md`

--- a/plugins/project-manager/skills/pm/SKILL.md
+++ b/plugins/project-manager/skills/pm/SKILL.md
@@ -283,16 +283,16 @@ For epics and new projects with sub-issues: create the parent issue first, then 
 
 ```bash
 # Get the sub-issue's REST ID (integer) and link it to the parent
-sub_issue_id=$(gh api repos/OWNER/REPO/issues/SUB_NUMBER --jq .id)
-gh api repos/OWNER/REPO/issues/PARENT_NUMBER/sub_issues \
-  --method POST -F sub_issue_id="$sub_issue_id"
+sub_issue_id=$(gh api "repos/OWNER/REPO/issues/SUB_NUMBER" --jq .id)
+gh api "repos/OWNER/REPO/issues/PARENT_NUMBER/sub_issues" \
+  --method POST -F "sub_issue_id=$sub_issue_id"
 ```
 
 Use `-F` (capital F) for `sub_issue_id` — the API requires an integer, and `-F` sends it as a number while lowercase `-f` would send a string, causing a type error.
 
-If linking fails for a sub-issue (rate limit, plan doesn't support sub-issues), log the error and continue linking remaining sub-issues — don't abort the loop. The `Part of #N` markdown reference still provides a human-readable cross-reference even if the API link fails.
+If either the `sub_issue_id` lookup or the POST to `/sub_issues` fails for a sub-issue (rate limit, plan doesn't support sub-issues, permissions), log the error and continue to the next sub-issue — don't abort the loop. Skip the POST if the ID lookup failed. The `Part of #N` markdown reference still provides a human-readable cross-reference even if the API link fails.
 
-Clean up `/tmp/issue-body.md` only after **all** sub-issues are created and linked.
+Clean up `/tmp/issue-body.md` only after **all** sub-issue creation and linking attempts have completed, even if some links failed.
 
 Report all created issue URLs to the user.
 


### PR DESCRIPTION
## Summary

- Adds GitHub Sub-Issues REST API linking to Step 7 of the `/pm` Create Issue Workflow
- After creating each sub-issue for an epic or new project, the agent now formally links it to the parent via `gh api repos/OWNER/REPO/issues/PARENT/sub_issues`
- Includes error handling (continue on failure), `-F` vs `-f` type guidance, and coverage for both Epic and New Project types

Closes #147

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [x] Eval 1: Agent produces correct `gh api` commands with `-F`, `--method POST`, correct endpoint, ID retrieval for both sub-issues (5/5 assertions)
- [x] Eval 2: Agent correctly describes error handling — non-blocking loop, error logging, `Part of #N` fallback, rate limit/plan failure causes (4/4 assertions)
- [x] Eval 3: Agent confirms New Project sub-issues use the same linking flow as Epics (3/3 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised epic/new-project sub-issue procedure to perform explicit immediate linking for each sub-issue using a two-step API call sequence.
  * Clarified error handling so failed link attempts are logged and skipped while the process continues with remaining sub-issues.
  * Added guidance on sending numeric fields correctly via the CLI and updated temp-file cleanup to occur only after all create/link attempts complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->