### PR TITLE
fix(project-manager): portable jq variable bindings for cross-platform compat

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -639,16 +639,16 @@ jq's parser handles `==` inside object constructors `{ key: expr == val }` incon
 **Bad** — comparison inside object constructor (fragile):
 ```jq
 [ .[] | . + {
-  blockers_resolved: ((expr) == (.blocked_by | length)),
-  unblocked: ((expr) == 0)
+  blockers_resolved: ((expr1) == (.blocked_by | length)),
+  unblocked: ((expr2) == 0)
 }]
 ```
 
 **Good** — comparison as variable binding outside `{}` (portable):
 ```jq
 [ .[] |
-  ((expr) == (.blocked_by | length)) as $resolved |
-  ((expr) == 0) as $is_unblocked |
+  ((expr1) == (.blocked_by | length)) as $resolved |
+  ((expr2) == 0) as $is_unblocked |
   . + {
     blockers_resolved: $resolved,
     unblocked: $is_unblocked

--- a/plugins/project-manager/scripts/open-issues.sh
+++ b/plugins/project-manager/scripts/open-issues.sh
@@ -102,13 +102,13 @@ printf '%s\n' "$RAW" | jq --arg now "$NOW" --argjson include_assigned "$INCLUDE_
   # NOTE: Comparisons computed as variables outside {} to avoid jq parser
   # fragmentation — some builds (Apple jq, older Linux jq) choke on == inside
   # object constructors. See docs/learnings.md.
+  # Both fields are logically equivalent (no open blockers ↔ all blockers resolved),
+  # so we compute once and assign to both.
   [ .[] |
-    (([.blocked_by[] | select(. as $b | $open_set | index($b) | not)] | length)
-      == (.blocked_by | length)) as $resolved |
     (([.blocked_by[] | select(. as $b | $open_set | index($b))] | length)
       == 0) as $is_unblocked |
     . + {
-      blockers_resolved: $resolved,
+      blockers_resolved: $is_unblocked,
       unblocked: $is_unblocked
     }
   ] as $augmented_issues |


### PR DESCRIPTION
## Summary

- Move `==` comparisons out of jq object constructors into `as $var` bindings in `open-issues.sh` to fix parser fragmentation across jq builds (Apple jq, standard Linux jq, older 1.5/1.6)
- The prior double-parenthesization fix (PR #179) resolved Apple jq but still broke on Linux — this fix sidesteps the ambiguity entirely
- Update `docs/learnings.md` to document the cross-platform-safe pattern

## Test plan

- [x] `bash -n open-issues.sh` passes (no shell syntax errors)
- [x] `bun scripts/validate-plugins.mjs` passes
- [x] jq expression tested with mock data on `jq-1.7.1-apple` — correct output
- [x] JSON output structure unchanged (`blockers_resolved`, `unblocked` boolean fields preserved)
- [ ] Verify on Linux with standard `jq 1.7.x`
- [ ] Verify on Linux with `jq 1.6` (common in CI/Docker images)

Fixes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified best-practice guidance for portable jq queries and updated example comparisons and attribution.

* **Bug Fixes**
  * Improved cross-platform compatibility and reliability of issue-tracking computations by consolidating boolean evaluation outside inline object constructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->