### PR TITLE
feat(cdt): add TDD-style refactor step to developer workflow

### DIFF
--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -63,9 +63,9 @@ Teammate tool:
     3. Implement completely — no stubs, no TODOs, match existing patterns
        Implement small fixes you encounter in files you're already editing (typo, missing null check, broken condition) — code is cheap; don't defer them as "out of scope" when you're already there.
     4. Run build/lint if available
-    5. Simplify: review your implementation for unnecessary complexity,
-       redundant code, unclear naming, and logic that could be consolidated.
-       Refine without changing behavior — make it clean, not just correct.
+    5. Simplify: review your implementation for unnecessary complexity or nesting,
+       redundant code or abstractions, unclear naming, and logic that could be consolidated.
+       Refine without changing behavior. Re-run build/lint if you made changes.
     6. Message the code-tester teammate: what changed, what to test
     7. If code-tester reports failures — fix, message them to re-run
     8. If qa-tester teammate reports issues — fix, message them to re-test


### PR DESCRIPTION
## Summary
Adds a simplification step (step 5) between build/lint and test handoff in the Developer prompt, and expands the Reviewer's quality dimension with simplification heuristics flagged as non-blocking suggestions.

## Test plan
- Review the updated dev-workflow.md for clarity and structure
- Verify that the refactor step fits logically between build/lint and test phases
- Confirm reviewer heuristics are properly marked as non-blocking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development workflow documentation to enhance process clarity and quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->