### PR TITLE
feat(dlc): add PR babysitter skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
 | doppler | DevOps | `/doppler` |
 | oasis-dev | Development | `/oasis-dev` |
 | jules-review | Code Review | `/jules-review` |
-| dlc | Quality | `/dlc`, `/dlc:security`, `/dlc:quality`, `/dlc:perf`, `/dlc:test`, `/dlc:pr-check`, `/dlc:pr-validity`, `/dlc:git-ops` |
+| dlc | Quality | `/dlc`, `/dlc:security`, `/dlc:quality`, `/dlc:perf`, `/dlc:test`, `/dlc:pr-check`, `/dlc:pr-validity`, `/dlc:git-ops`, `/dlc:babysit` |
 
 ## Navigation
 

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: babysit
+description: >-
+  PR babysitter: monitors CI status, auto-rebases when behind, auto-fixes CI
+  where possible, runs pr-check for review comments, and re-requests review
+  after fixes. Designed for /loop usage with Remote Control.
+allowed-tools: [Bash, Read, Edit, Write, Grep, Glob, Skill, CronList, CronDelete]
+---
+
+# DLC: PR Babysitter
+
+Monitor a PR on a loop: check CI, auto-rebase, auto-fix CI failures, run pr-check for review comments, and re-request review after pushing fixes. Use with Remote Control to monitor from your phone.
+
+**Usage:** `/loop 10m /dlc:babysit` (auto-detect PR) or `/loop 10m /dlc:babysit 253`
+
+## Notification Rules
+
+Only print status messages for **errors that need human attention** and **completion** (PR ready to merge). Routine actions (rebase, lint fix, CI retry, re-request review) are silent.
+
+When the skill says "Notify" — print the message to stdout. The user sees it via Remote Control or the terminal.
+
+### Deduplication
+
+Track the last notification state to avoid printing the same message every cycle:
+
+```
+.dev/dlc/babysit-<PR_NUMBER>.state
+```
+
+Before printing a notification, read the state file. If it contains the same status key (e.g., `ci_failing:check1,check2`, `needs_review`, `ready`), skip — only notify when the state changes. Write the new status key after notifying.
+
+Create `.dev/dlc/` if it does not exist. Delete the state file when self-cancelling.
+
+## Step 0: Detect PR
+
+If `$ARGUMENTS` contains a number, use it as PR_NUMBER. Otherwise auto-detect from the current branch:
+
+```bash
+gh pr view --json number,title,headRefName,baseRefName,state,url,reviewDecision,mergeable
+```
+
+If no PR exists for the current branch, print "No PR found for current branch." and stop. Do NOT notify — the user may not have pushed yet.
+
+Extract and store: PR_NUMBER, PR_TITLE, PR_BRANCH, BASE_BRANCH, PR_STATE, PR_URL, REVIEW_DECISION, MERGEABLE.
+
+Also extract owner/repo for the GraphQL query in Step 3:
+
+```bash
+gh repo view --json nameWithOwner --jq '.nameWithOwner'
+```
+
+Split into OWNER and REPO.
+
+**State gate:** If PR_STATE is not `OPEN`:
+- Notify: `PR #<number> is <state>. Babysit cancelled.`
+- Self-cancel (see Cancellation Pattern below) and stop.
+
+## Step 1: Check CI Status
+
+```bash
+gh pr checks $PR_NUMBER --json name,state,conclusion
+```
+
+Categorize each check:
+- **Running**: state is IN_PROGRESS, QUEUED, or PENDING, or conclusion is empty/null
+- **Failed**: conclusion is FAILURE, ERROR, TIMED_OUT, or CANCELLED
+- **Passed**: conclusion is SUCCESS, SKIPPED, or NEUTRAL
+
+**If any checks are still running:**
+Print: `CI running (<count> of <total>) — waiting for next cycle.`
+Stop. Do NOT notify — this is the normal waiting state.
+
+**If any checks failed:** Continue to Step 1b (attempt auto-fix).
+
+**If ALL checks passed or NO checks exist:** Continue to Step 2.
+
+## Step 1b: Attempt CI Auto-Fix
+
+Do not just notify and stop when CI fails. Attempt to diagnose and fix the failure first.
+
+### Read CI logs
+
+Get the failing run ID and download the failed logs:
+
+```bash
+gh run list --branch $PR_BRANCH --status failure --limit 1 --json databaseId --jq '.[0].databaseId'
+```
+
+Then read the failed job logs:
+
+```bash
+gh run view <RUN_ID> --log-failed 2>&1 | tail -200
+```
+
+### Classify and fix
+
+Analyze the log output and classify the failure:
+
+**Lint / format errors** (eslint, prettier, ruff, clippy, etc.):
+1. Run the project's lint-fix command (look for it in `package.json` scripts, `Makefile`, `justfile`, or CI config)
+2. Stage, commit with message: `fix: auto-fix lint errors`, and push
+3. Stop — CI will re-run. Next cycle checks the result.
+
+**Type errors** (tsc, mypy, pyright, etc.):
+1. Read the erroring files and fix the type issues
+2. Stage, commit with message: `fix: resolve type errors`, and push
+3. Stop — CI will re-run.
+
+**Test failures**:
+1. Read the failing test output to identify which tests and why
+2. Read the test files and the source files they exercise
+3. Determine if the fix belongs in the source code (bug) or the test (outdated assertion)
+4. Apply the fix, stage, commit with message: `fix: resolve test failures`, and push
+5. Stop — CI will re-run.
+
+**Infrastructure / flaky failures** (timeout, network, OOM, rate limit):
+1. Attempt to re-run the failed jobs:
+   ```bash
+   gh run rerun <RUN_ID> --failed
+   ```
+2. Stop — next cycle checks the result.
+
+**Unknown / cannot diagnose:**
+Notify: `🔴 CI failing on PR #<number>: <title> — Failed: <check_names> — could not auto-fix. <url>/checks`
+Stop.
+
+Do not notify after a successful fix attempt — this is routine automation. Stop silently and let the next cycle check the result.
+
+## Step 2: Auto-Rebase
+
+Check if the branch is behind the base branch:
+
+```bash
+git fetch origin $BASE_BRANCH --quiet
+BEHIND=$(git rev-list --count HEAD..origin/$BASE_BRANCH)
+```
+
+**If BEHIND is 0:** Branch is up to date. Continue to Step 3.
+
+**If BEHIND > 0:**
+
+Attempt rebase:
+
+```bash
+git rebase origin/$BASE_BRANCH
+```
+
+**If rebase succeeds cleanly:**
+
+```bash
+git push --force-with-lease
+```
+
+Stop silently — CI needs to re-run. Next cycle will check the results.
+
+**If rebase hits conflicts — resolve them:**
+
+Do NOT abort immediately. For each conflicting commit in the rebase sequence:
+
+1. List conflicting files:
+   ```bash
+   git diff --name-only --diff-filter=U
+   ```
+
+2. For each conflicting file, read the full file content and examine the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`). Understand both sides:
+   - **Ours** (above `=======`): the PR branch's changes
+   - **Theirs** (below `=======`): the base branch's incoming changes
+
+3. Resolve the conflict by editing the file to integrate both sides correctly. Preserve the intent of both changes. Remove all conflict markers.
+
+4. Stage the resolved file:
+   ```bash
+   git add <file>
+   ```
+
+5. After all files in the current commit are resolved:
+   ```bash
+   git rebase --continue
+   ```
+
+6. Repeat for any subsequent conflicting commits in the rebase.
+
+**After all conflicts resolved and rebase completes:**
+
+```bash
+git push --force-with-lease
+```
+
+Stop silently — CI needs to re-run.
+
+**If a conflict is genuinely ambiguous** (architectural clash, both sides rewrote the same logic differently, or semantic conflict where the correct resolution is unclear):
+
+```bash
+git rebase --abort
+```
+
+Notify: `⚠️ Rebase conflict on PR #<number> — could not auto-resolve. File(s): <conflicting_files>. <url>`
+Stop.
+
+## Step 3: Quick Readiness Check
+
+Before running the heavyweight pr-check, check if the PR is already ready — or if there's nothing pr-check can do.
+
+Count unresolved review threads:
+
+```bash
+gh api graphql -f query='
+  query($owner:String!,$repo:String!,$pr:Int!) {
+    repository(owner:$owner,name:$repo) {
+      pullRequest(number:$pr) {
+        reviewThreads(first:100) {
+          nodes { isResolved isOutdated }
+        }
+      }
+    }
+  }' -f owner="$OWNER" -f repo="$REPO" -F pr=$PR_NUMBER \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+         | select(.isResolved==false and .isOutdated==false)] | length'
+```
+
+Store as UNRESOLVED.
+
+Re-fetch current state:
+
+```bash
+gh pr view $PR_NUMBER --json reviewDecision,mergeable --jq '{reviewDecision,mergeable}'
+```
+
+### No reviews submitted yet
+
+If reviewDecision is `REVIEW_REQUIRED` and UNRESOLVED is 0 (no threads at all — nobody has reviewed):
+- Notify: `👀 PR #<number> is waiting for review. No reviewers have submitted yet. <url>`
+- Stop. Do NOT run pr-check — there are no comments to process. Next cycle will re-check.
+
+### Ready to merge
+
+ALL of these are true:
+1. All CI passed (confirmed in Step 1)
+2. UNRESOLVED is 0
+3. reviewDecision is APPROVED or empty (no review policy)
+4. mergeable is MERGEABLE
+
+If ready:
+- Notify: `✅ PR #<number> ready to merge! — <title> — <url>`
+- Self-cancel and stop. The user merges when they choose to.
+
+### Has unresolved threads
+
+Continue to Step 4.
+
+## Step 4: Run PR Review Check
+
+Invoke the pr-check skill to handle review comments:
+
+```
+Skill("dlc:pr-check", "<PR_NUMBER>")
+```
+
+Let pr-check run its full cycle: fetch comments, categorize, fix what it can, reply inline, commit, push.
+
+## Step 5: Re-Request Review
+
+After pr-check pushes fixes, re-request review from reviewers who requested changes. This signals that their feedback has been addressed.
+
+Get the list of reviewers who submitted reviews:
+
+```bash
+gh pr view $PR_NUMBER --json reviews --jq '[.reviews[].author.login] | unique | join(",")'
+```
+
+Re-request review:
+
+```bash
+gh pr edit $PR_NUMBER --add-reviewer <REVIEWER_CSV>
+```
+
+Do not notify about re-request — this is routine automation.
+
+## Step 6: Final Assessment
+
+After pr-check and re-review request, re-check the PR state. Re-run the unresolved threads query and reviewDecision check from Step 3.
+
+**Ready to merge** (same criteria as Step 3):
+- Notify: `✅ PR #<number> ready to merge! — <title> — <url>`
+- Self-cancel and stop.
+
+**Unresolved comments remain (UNRESOLVED > 0):**
+- Notify: `💬 PR #<number> has <count> unresolved threads after auto-fix. Review needed. <url>`
+- Stop. Next cycle will re-check.
+
+**Changes requested, awaiting re-review (reviewDecision is CHANGES_REQUESTED):**
+- Stop silently. Re-review was already requested in Step 5. Next cycle will re-check.
+
+**Not mergeable (mergeable is CONFLICTING):**
+- Notify: `⚠️ PR #<number> has merge conflicts. <url>`
+- Stop. Next cycle will attempt rebase in Step 2.
+
+## Cancellation Pattern
+
+To self-cancel the babysit loop:
+
+1. Call `CronList` to list all scheduled tasks.
+2. Find the task whose prompt contains "babysit" or "dlc:babysit".
+3. Call `CronDelete` with that task's ID.
+4. Delete the state file: `.dev/dlc/babysit-<PR_NUMBER>.state`
+5. If no matching task is found, this was a manual invocation — skip cancellation.

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -23,7 +23,7 @@ Notifications are deduplicated via a state file at `.dev/dlc/babysit-<PR_NUMBER>
 
 - `ci_failing:<sorted_check_names>` (e.g., `ci_failing:build,lint`)
 - `ci_unfixable:<sorted_check_names>`
-- `rebase_conflict:<file_list>`
+- `rebase_conflict:<sorted_file_list>`
 - `needs_review`
 - `unresolved:<count>`
 - `ready`
@@ -84,7 +84,7 @@ gh pr checks $PR_NUMBER --json name,state,conclusion
 
 Categorize each check:
 - **Running**: state is IN_PROGRESS, QUEUED, or PENDING, or conclusion is empty/null
-- **Failed**: conclusion is FAILURE, ERROR, TIMED_OUT, or CANCELLED
+- **Failed**: conclusion is FAILURE, ERROR, TIMED_OUT, CANCELLED, ACTION_REQUIRED, STALE, or any other non-success value
 - **Passed**: conclusion is SUCCESS, SKIPPED, or NEUTRAL
 
 **If any checks are still running:**
@@ -231,17 +231,19 @@ Skill("dlc:pr-check", "<PR_NUMBER>")
 ```
 
 After pr-check completes, parse its output summary to extract these values:
-- Total unresolved items remaining (Fixed + Answered + Resolved = done; anything else = remaining)
-- Whether pr-check pushed any commits
+- Total unresolved items remaining: items marked Fixed, Answered, Resolved, or Dismissed are **done**. Remaining = Total - (Fixed + Answered + Resolved + Dismissed).
+- Whether pr-check pushed any commits (look for "Pushed" in the summary or a non-empty git diff from before)
 
-If pr-check pushed commits, re-request review from all prior reviewers:
+If pr-check pushed commits, re-request review from all prior reviewers. Filter out bot accounts (logins ending in `[bot]`):
 
 ```bash
-REVIEWERS=$(gh pr view $PR_NUMBER --json reviews --jq '[.reviews[].author.login] | unique | join(",")')
+REVIEWERS=$(gh pr view $PR_NUMBER --json reviews --jq '[.reviews[].author.login | select(endswith("[bot]") | not)] | unique | join(",")')
 if [ -n "$REVIEWERS" ]; then
   gh pr edit $PR_NUMBER --add-reviewer "$REVIEWERS"
 fi
 ```
+
+If pr-check did NOT push commits, skip the re-request — there's nothing new to review.
 
 ## Step 4: Assess and Notify
 
@@ -275,7 +277,7 @@ Stop silently. Re-review was already requested in Step 3. Next cycle will re-che
 To self-cancel the babysit loop:
 
 1. Call `CronList` to list all scheduled tasks.
-2. Find the task whose prompt contains "babysit" AND the current PR_NUMBER (to avoid cancelling babysit loops for other PRs).
+2. Find the task whose prompt contains "babysit". If multiple babysit tasks exist, prefer the one containing the current PR_NUMBER. If none contain a PR number (auto-detect mode), cancel the one matching `dlc:babysit` without a number argument.
 3. Call `CronDelete` with that task's ID.
 4. Delete the state file: `.dev/dlc/babysit-<PR_NUMBER>.state`
 5. If no matching task is found, this was a manual invocation — skip cancellation.

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -102,11 +102,11 @@ Do not just notify and stop when CI fails. Attempt to diagnose and fix the failu
 
 ### Read CI logs
 
-Get the HEAD SHA, then fetch ALL failing runs scoped to that specific commit:
+Get the HEAD SHA, then fetch ALL non-success runs scoped to that specific commit:
 
 ```bash
 HEAD_SHA=$(git rev-parse HEAD)
-gh run list --commit $HEAD_SHA --status failure --json databaseId --jq '.[].databaseId'
+gh run list --commit $HEAD_SHA --json databaseId,conclusion --jq '[.[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral" and .conclusion != "")] | .[].databaseId'
 ```
 
 For each failing run, read its logs:
@@ -188,8 +188,8 @@ Do NOT abort immediately. For each conflicting commit in the rebase sequence:
    ```
 
 2. For each conflicting file, read the full file content and examine the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`). Understand both sides:
-   - **Ours** (above `=======`): the PR branch's changes
-   - **Theirs** (below `=======`): the base branch's incoming changes
+   - **HEAD** (above `=======`): the base branch you are rebasing onto
+   - **Incoming** (below `=======`): the PR commit being replayed
 
 3. Resolve the conflict by editing the file to integrate both sides correctly. Preserve the intent of both changes. Remove all conflict markers.
 
@@ -296,7 +296,7 @@ Let pr-check run its full cycle: fetch comments, categorize, fix what it can, re
 
 ## Step 5: Re-Request Review
 
-After pr-check pushes fixes, re-request review from reviewers who requested changes. This signals that their feedback has been addressed.
+After pr-check pushes fixes, re-request review from all prior reviewers. This signals that feedback has been addressed and prompts a fresh look.
 
 Get the list of reviewers who submitted reviews:
 

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -102,10 +102,11 @@ Do not just notify and stop when CI fails. Attempt to diagnose and fix the failu
 
 ### Read CI logs
 
-Get ALL failing run IDs for the current HEAD and download their logs:
+Get the HEAD SHA, then fetch ALL failing runs scoped to that specific commit:
 
 ```bash
-gh run list --branch $PR_BRANCH --status failure --json databaseId --jq '.[].databaseId'
+HEAD_SHA=$(git rev-parse HEAD)
+gh run list --commit $HEAD_SHA --status failure --json databaseId --jq '.[].databaseId'
 ```
 
 For each failing run, read its logs:
@@ -317,15 +318,17 @@ Do not notify about re-request — this is routine automation.
 
 After pr-check and re-review request, re-check the PR state.
 
-First, check if pr-check pushed new commits. If so, CI will be re-running — stop silently and let the next cycle pick up the results:
+First, re-check CI status — pr-check may have pushed new commits:
 
 ```bash
-gh pr checks $PR_NUMBER --json state --jq '[.[] | select(.state != "COMPLETED")] | length'
+gh pr checks $PR_NUMBER --json name,state,conclusion
 ```
 
-If any checks are not completed, stop silently — CI needs to finish before declaring readiness.
+If any checks are not completed (state != COMPLETED), stop silently — CI needs to finish.
 
-If all CI is still green, re-run the unresolved threads query and reviewDecision check from Step 3.
+If any checks completed with a failing conclusion (FAILURE, ERROR, TIMED_OUT, CANCELLED), stop silently — the next cycle will pick these up in Step 1.
+
+Only proceed if ALL checks are completed with passing conclusions (SUCCESS, SKIPPED, NEUTRAL). Re-run the unresolved threads query and reviewDecision check from Step 3.
 
 **Ready to merge** (same criteria as Step 3):
 - Notify: `✅ PR #<number> ready to merge! — <title> — <url>`

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -2,14 +2,14 @@
 name: babysit
 description: >-
   PR babysitter: monitors CI status, auto-rebases when behind, auto-fixes CI
-  where possible, runs pr-check for review comments, and re-requests review
-  after fixes. Designed for /loop usage with Remote Control.
+  where possible, delegates review comment handling to dlc:pr-check, and
+  re-requests review after fixes. Designed for /loop usage with Remote Control.
 allowed-tools: [Bash, Read, Edit, Write, Grep, Glob, Skill, CronList, CronDelete]
 ---
 
 # DLC: PR Babysitter
 
-Monitor a PR on a loop: check CI, auto-rebase, auto-fix CI failures, run pr-check for review comments, and re-request review after pushing fixes. Use with Remote Control to monitor from your phone.
+Monitor a PR on a loop: check CI, auto-rebase, auto-fix CI failures, and delegate review comment handling to `dlc:pr-check`. Use with Remote Control to monitor from your phone.
 
 **Usage:** `/loop 10m /dlc:babysit` (auto-detect PR) or `/loop 10m /dlc:babysit 253`
 
@@ -17,19 +17,10 @@ Monitor a PR on a loop: check CI, auto-rebase, auto-fix CI failures, run pr-chec
 
 Only print status messages for **errors that need human attention** and **completion** (PR ready to merge). Routine actions (rebase, lint fix, CI retry, re-request review) are silent.
 
-When the skill says "Notify" — print the message to stdout. The user sees it via Remote Control or the terminal.
-
 ### Deduplication
 
-Notifications are deduplicated via a state file at `.dev/dlc/babysit-<PR_NUMBER>.state`. Same state across cycles produces no output. Details are in the notification steps below.
+Notifications are deduplicated via a state file at `.dev/dlc/babysit-<PR_NUMBER>.state`. The file contains a single-line **status key**:
 
-## Step 0: Setup
-
-### Initialize state tracking
-
-Create `.dev/dlc/` if it does not exist. Read the state file `.dev/dlc/babysit-<PR_NUMBER>.state` if it exists — it contains a single-line **status key** from the last notification.
-
-**Status key format** — one of these stable strings:
 - `ci_failing:<sorted_check_names>` (e.g., `ci_failing:build,lint`)
 - `ci_unfixable:<sorted_check_names>`
 - `rebase_conflict:<file_list>`
@@ -38,7 +29,13 @@ Create `.dev/dlc/` if it does not exist. Read the state file `.dev/dlc/babysit-<
 - `ready`
 - `closed:<state>`
 
-Before sending any notification, compare the current status key against the file. If identical, skip. After sending, write the new key. Delete the state file when self-cancelling.
+Same key across cycles = no output. Write the new key after notifying. Delete the state file when self-cancelling.
+
+## Step 0: Setup
+
+### Initialize state tracking
+
+Create `.dev/dlc/` if it does not exist. Read the state file if it exists.
 
 ### Detect PR
 
@@ -54,17 +51,9 @@ If no number is provided, auto-detect from the current branch:
 gh pr view --json number,title,headRefName,baseRefName,state,url,reviewDecision,mergeable
 ```
 
-If no PR exists for the current branch, stop silently. The user may not have pushed yet.
+If no PR exists for the current branch, stop silently.
 
 Extract and store: PR_NUMBER, PR_TITLE, PR_BRANCH, BASE_BRANCH, PR_STATE, PR_URL, REVIEW_DECISION, MERGEABLE.
-
-Also extract owner/repo for the GraphQL query in Step 3:
-
-```bash
-gh repo view --json nameWithOwner --jq '.nameWithOwner'
-```
-
-Split into OWNER and REPO.
 
 **State gate:** If PR_STATE is not `OPEN`:
 - Notify: `PR #<number> is <state>. Babysit cancelled.`
@@ -103,7 +92,7 @@ Stop without printing anything. This is the normal waiting state.
 
 **If any checks failed:** Continue to Step 1b (attempt auto-fix).
 
-**If NO checks exist:** Continue to Step 2. The repo may not have CI configured — do not stall indefinitely.
+**If NO checks exist:** Continue to Step 2. The repo may not have CI configured.
 
 **If ALL checks passed:** Continue to Step 2.
 
@@ -233,150 +222,51 @@ git rebase --abort
 Notify: `⚠️ Rebase conflict on PR #<number> — could not auto-resolve. File(s): <conflicting_files>. <url>`
 Stop.
 
-## Step 3: Quick Readiness Check
+## Step 3: Run PR Review Check
 
-Before running the heavyweight pr-check, check if the PR is already ready — or if there's nothing pr-check can do.
-
-Count unresolved review threads:
-
-```bash
-gh api graphql -f query='
-  query($owner:String!,$repo:String!,$pr:Int!) {
-    repository(owner:$owner,name:$repo) {
-      pullRequest(number:$pr) {
-        reviewThreads(first:100) {
-          totalCount
-          nodes { isResolved isOutdated }
-        }
-      }
-    }
-  }' -f "owner=$OWNER" -f "repo=$REPO" -F "pr=$PR_NUMBER" \
-  --jq '.data.repository.pullRequest.reviewThreads as $rt
-        | ($rt.nodes | map(select(.isResolved==false)) | length) as $unresolved
-        | if $rt.totalCount > 100 and $unresolved == 0
-          then 1
-          else $unresolved
-          end'
-```
-
-Store as UNRESOLVED. Note: outdated threads are NOT filtered out — they may still contain valid feedback that `dlc:pr-check` needs to re-check. If totalCount > 100 and the fetched page shows 0 unresolved, treat as 1 (safety net for truncation).
-
-Re-fetch current state:
-
-```bash
-gh pr view $PR_NUMBER --json reviewDecision,mergeable --jq '{reviewDecision,mergeable}'
-```
-
-### No reviews submitted yet
-
-Check whether any reviews exist:
-
-```bash
-REVIEW_COUNT=$(gh pr view $PR_NUMBER --json reviews --jq '.reviews | length')
-```
-
-If reviewDecision is `REVIEW_REQUIRED` and REVIEW_COUNT is 0 (no reviews submitted at all):
-- Notify: `👀 PR #<number> is waiting for review. No reviewers have submitted yet. <url>`
-- Stop. Do NOT run pr-check — there are no comments to process. Next cycle will re-check.
-
-### Check for unresolved review bodies and issue comments
-
-Run the pr-comments.sh script to get structured data on all feedback types:
-
-```bash
-PR_DATA=$(sh ../../scripts/pr-comments.sh $PR_NUMBER 2>/dev/null)
-```
-
-Count unresolved review bodies (state is COMMENTED or CHANGES_REQUESTED, body has actionable content, no DLC sentinel reply in issue comments):
-
-```bash
-UNRESOLVED_BODIES=$(echo "$PR_DATA" | jq '[.review_bodies[] | select(.state == "COMMENTED" or .state == "CHANGES_REQUESTED")] | length')
-```
-
-Count unresolved issue comments (actionable reviewer comments without a DLC sentinel reply):
-
-```bash
-UNRESOLVED_ISSUE_COMMENTS=$(echo "$PR_DATA" | jq '[.reviewer_issue_comments[] | select(.body | test("^<h3>|^<!-- |^> \\[!NOTE\\]") | not)] | length')
-```
-
-Note: The jq filters above are approximations — informational comments (HTML summaries, status notes, auto-generated content) are excluded. Err on the side of inclusion: if uncertain whether a comment is actionable, count it as unresolved and let pr-check handle classification.
-
-### Ready to merge
-
-ALL of these are true:
-1. All CI passed (confirmed in Step 1)
-2. UNRESOLVED is 0 (no unresolved threads)
-3. UNRESOLVED_BODIES is 0 (no unresolved review bodies)
-4. UNRESOLVED_ISSUE_COMMENTS is 0 (no unresolved issue comments)
-5. reviewDecision is APPROVED or empty (no review policy)
-6. mergeable is MERGEABLE
-
-If ready:
-- Notify: `✅ PR #<number> ready to merge! — <title> — <url>`
-- Self-cancel and stop. The user merges when they choose to.
-
-### Has unresolved feedback
-
-Continue to Step 4.
-
-## Step 4: Run PR Review Check
-
-Invoke the pr-check skill to handle review comments:
+Delegate all review comment handling to `dlc:pr-check`. It handles: fetching comments, categorizing, fixing what it can, replying inline, committing, and pushing.
 
 ```text
 Skill("dlc:pr-check", "<PR_NUMBER>")
 ```
 
-Let pr-check run its full cycle: fetch comments, categorize, fix what it can, reply inline, commit, push.
+After pr-check completes, parse its output summary to extract these values:
+- Total unresolved items remaining (Fixed + Answered + Resolved = done; anything else = remaining)
+- Whether pr-check pushed any commits
 
-## Step 5: Re-Request Review
-
-After pr-check pushes fixes, re-request review from all prior reviewers. This signals that feedback has been addressed and prompts a fresh look.
-
-Get the list of reviewers who submitted reviews:
+If pr-check pushed commits, re-request review from all prior reviewers:
 
 ```bash
 REVIEWERS=$(gh pr view $PR_NUMBER --json reviews --jq '[.reviews[].author.login] | unique | join(",")')
-```
-
-Re-request review only if the list is non-empty:
-
-```bash
 if [ -n "$REVIEWERS" ]; then
   gh pr edit $PR_NUMBER --add-reviewer "$REVIEWERS"
 fi
 ```
 
-Do not notify about re-request — this is routine automation.
+## Step 4: Assess and Notify
 
-## Step 6: Final Assessment
-
-After pr-check and re-review request, re-check the PR state.
-
-First, re-check CI status — pr-check may have pushed new commits:
+After pr-check completes, re-check the PR state:
 
 ```bash
 gh pr checks $PR_NUMBER --json name,state,conclusion
+gh pr view $PR_NUMBER --json reviewDecision,mergeable
 ```
 
-If any checks are not completed (state != COMPLETED), stop silently — CI needs to finish.
+**If CI is not fully passing** (any check running or failed):
+Stop silently — next cycle will handle it in Step 1.
 
-If any checks completed with a failing conclusion (FAILURE, ERROR, TIMED_OUT, CANCELLED), stop silently — the next cycle will pick these up in Step 1.
-
-Only proceed if ALL checks are completed with passing conclusions (SUCCESS, SKIPPED, NEUTRAL). Re-run the unresolved threads query, review bodies/issue comments check, and reviewDecision check from Step 3.
-
-**Ready to merge** (same criteria as Step 3):
+**If pr-check reported 0 remaining unresolved items AND reviewDecision is APPROVED (or empty) AND mergeable is MERGEABLE:**
 - Notify: `✅ PR #<number> ready to merge! — <title> — <url>`
 - Self-cancel and stop.
 
-**Unresolved feedback remains:**
-- Notify: `💬 PR #<number> has unresolved feedback after auto-fix (<threads> threads, <bodies> review bodies, <comments> issue comments). Review needed. <url>`
+**If pr-check reported remaining unresolved items:**
+- Notify: `💬 PR #<number> has <count> unresolved items after auto-fix. Review needed. <url>`
 - Stop. Next cycle will re-check.
 
-**Changes requested, awaiting re-review (reviewDecision is CHANGES_REQUESTED):**
-- Stop silently. Re-review was already requested in Step 5. Next cycle will re-check.
+**If reviewDecision is CHANGES_REQUESTED:**
+Stop silently. Re-review was already requested in Step 3. Next cycle will re-check.
 
-**Not mergeable (mergeable is CONFLICTING):**
+**If mergeable is CONFLICTING:**
 - Notify: `⚠️ PR #<number> has merge conflicts. <url>`
 - Stop. Next cycle will attempt rebase in Step 2.
 

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -27,7 +27,18 @@ Notifications are deduplicated via a state file at `.dev/dlc/babysit-<PR_NUMBER>
 
 ### Initialize state tracking
 
-Create `.dev/dlc/` if it does not exist. Read the state file `.dev/dlc/babysit-<PR_NUMBER>.state` if it exists — it contains the status key from the last notification. Before sending any notification, compare the current status key against this file. If identical, skip the notification. After sending, write the new key. Delete the state file when self-cancelling.
+Create `.dev/dlc/` if it does not exist. Read the state file `.dev/dlc/babysit-<PR_NUMBER>.state` if it exists — it contains a single-line **status key** from the last notification.
+
+**Status key format** — one of these stable strings:
+- `ci_failing:<sorted_check_names>` (e.g., `ci_failing:build,lint`)
+- `ci_unfixable:<sorted_check_names>`
+- `rebase_conflict:<file_list>`
+- `needs_review`
+- `unresolved:<count>`
+- `ready`
+- `closed:<state>`
+
+Before sending any notification, compare the current status key against the file. If identical, skip. After sending, write the new key. Delete the state file when self-cancelling.
 
 ### Detect PR
 
@@ -43,7 +54,7 @@ If no number is provided, auto-detect from the current branch:
 gh pr view --json number,title,headRefName,baseRefName,state,url,reviewDecision,mergeable
 ```
 
-If no PR exists for the current branch, print "No PR found for current branch." and stop. Do NOT notify — the user may not have pushed yet.
+If no PR exists for the current branch, stop silently. The user may not have pushed yet.
 
 Extract and store: PR_NUMBER, PR_TITLE, PR_BRANCH, BASE_BRANCH, PR_STATE, PR_URL, REVIEW_DECISION, MERGEABLE.
 
@@ -92,7 +103,7 @@ Stop without printing anything. This is the normal waiting state.
 
 **If any checks failed:** Continue to Step 1b (attempt auto-fix).
 
-**If NO checks exist:** Stop without printing. Checks may be delayed or not configured. Wait for the next cycle.
+**If NO checks exist:** Continue to Step 2. The repo may not have CI configured — do not stall indefinitely.
 
 **If ALL checks passed:** Continue to Step 2.
 
@@ -270,11 +281,25 @@ If reviewDecision is `REVIEW_REQUIRED` and REVIEW_COUNT is 0 (no reviews submitt
 
 ### Check for unresolved review bodies and issue comments
 
-In addition to threads, check for actionable review bodies and issue comments that `pr-check` would process. Use the pr-comments.sh script output (or `gh api`) to count:
-- Unresolved review bodies: state is COMMENTED or CHANGES_REQUESTED with actionable content, and no DLC sentinel reply exists
-- Unresolved issue comments: actionable reviewer comments with no DLC sentinel reply
+Run the pr-comments.sh script to get structured data on all feedback types:
 
-Store as UNRESOLVED_BODIES and UNRESOLVED_ISSUE_COMMENTS.
+```bash
+PR_DATA=$(sh ../../scripts/pr-comments.sh $PR_NUMBER 2>/dev/null)
+```
+
+Count unresolved review bodies (state is COMMENTED or CHANGES_REQUESTED, body has actionable content, no DLC sentinel reply in issue comments):
+
+```bash
+UNRESOLVED_BODIES=$(echo "$PR_DATA" | jq '[.review_bodies[] | select(.state == "COMMENTED" or .state == "CHANGES_REQUESTED")] | length')
+```
+
+Count unresolved issue comments (actionable reviewer comments without a DLC sentinel reply):
+
+```bash
+UNRESOLVED_ISSUE_COMMENTS=$(echo "$PR_DATA" | jq '[.reviewer_issue_comments[] | select(.body | test("^<h3>|^<!-- |^> \\[!NOTE\\]") | not)] | length')
+```
+
+Note: The jq filters above are approximations — informational comments (HTML summaries, status notes, auto-generated content) are excluded. Err on the side of inclusion: if uncertain whether a comment is actionable, count it as unresolved and let pr-check handle classification.
 
 ### Ready to merge
 
@@ -360,7 +385,7 @@ Only proceed if ALL checks are completed with passing conclusions (SUCCESS, SKIP
 To self-cancel the babysit loop:
 
 1. Call `CronList` to list all scheduled tasks.
-2. Find the task whose prompt contains "babysit" or "dlc:babysit".
+2. Find the task whose prompt contains "babysit" AND the current PR_NUMBER (to avoid cancelling babysit loops for other PRs).
 3. Call `CronDelete` with that task's ID.
 4. Delete the state file: `.dev/dlc/babysit-<PR_NUMBER>.state`
 5. If no matching task is found, this was a manual invocation — skip cancellation.

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -33,7 +33,13 @@ Create `.dev/dlc/` if it does not exist. Delete the state file when self-cancell
 
 ## Step 0: Detect PR
 
-If `$ARGUMENTS` contains a number, use it as PR_NUMBER. Otherwise auto-detect from the current branch:
+If `$ARGUMENTS` contains a number, use it as PR_NUMBER and fetch that PR explicitly:
+
+```bash
+gh pr view $PR_NUMBER --json number,title,headRefName,baseRefName,state,url,reviewDecision,mergeable
+```
+
+If no number is provided, auto-detect from the current branch:
 
 ```bash
 gh pr view --json number,title,headRefName,baseRefName,state,url,reviewDecision,mergeable
@@ -55,6 +61,23 @@ Split into OWNER and REPO.
 - Notify: `PR #<number> is <state>. Babysit cancelled.`
 - Self-cancel (see Cancellation Pattern below) and stop.
 
+### Verify and checkout PR branch
+
+Before any git operations, verify you are on PR_BRANCH:
+
+```bash
+CURRENT=$(git branch --show-current)
+if [ "$CURRENT" != "$PR_BRANCH" ]; then
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "ERROR: Not on PR branch ($PR_BRANCH) and worktree is dirty. Stash or commit first."
+    exit 1
+  fi
+  gh pr checkout $PR_NUMBER
+fi
+```
+
+If checkout fails, stop. Do not proceed with git operations on the wrong branch.
+
 ## Step 1: Check CI Status
 
 ```bash
@@ -67,8 +90,7 @@ Categorize each check:
 - **Passed**: conclusion is SUCCESS, SKIPPED, or NEUTRAL
 
 **If any checks are still running:**
-Print: `CI running (<count> of <total>) — waiting for next cycle.`
-Stop. Do NOT notify — this is the normal waiting state.
+Stop without printing anything. This is the normal waiting state.
 
 **If any checks failed:** Continue to Step 1b (attempt auto-fix).
 
@@ -80,17 +102,19 @@ Do not just notify and stop when CI fails. Attempt to diagnose and fix the failu
 
 ### Read CI logs
 
-Get the failing run ID and download the failed logs:
+Get ALL failing run IDs for the current HEAD and download their logs:
 
 ```bash
-gh run list --branch $PR_BRANCH --status failure --limit 1 --json databaseId --jq '.[0].databaseId'
+gh run list --branch $PR_BRANCH --status failure --json databaseId --jq '.[].databaseId'
 ```
 
-Then read the failed job logs:
+For each failing run, read its logs:
 
 ```bash
 gh run view <RUN_ID> --log-failed 2>&1 | tail -200
 ```
+
+Collect and combine log output from all failing runs before classifying.
 
 ### Classify and fix
 
@@ -131,7 +155,7 @@ Do not notify after a successful fix attempt — this is routine automation. Sto
 Check if the branch is behind the base branch:
 
 ```bash
-git fetch origin $BASE_BRANCH --quiet
+git fetch origin $BASE_BRANCH > /dev/null
 BEHIND=$(git rev-list --count HEAD..origin/$BASE_BRANCH)
 ```
 
@@ -209,16 +233,21 @@ gh api graphql -f query='
     repository(owner:$owner,name:$repo) {
       pullRequest(number:$pr) {
         reviewThreads(first:100) {
+          totalCount
           nodes { isResolved isOutdated }
         }
       }
     }
-  }' -f owner="$OWNER" -f repo="$REPO" -F pr=$PR_NUMBER \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
-         | select(.isResolved==false and .isOutdated==false)] | length'
+  }' -f "owner=$OWNER" -f "repo=$REPO" -F "pr=$PR_NUMBER" \
+  --jq '.data.repository.pullRequest.reviewThreads as $rt
+        | ($rt.nodes | map(select(.isResolved==false)) | length) as $unresolved
+        | if $rt.totalCount > 100 and $unresolved == 0
+          then 1
+          else $unresolved
+          end'
 ```
 
-Store as UNRESOLVED.
+Store as UNRESOLVED. Note: outdated threads are NOT filtered out — they may still contain valid feedback that `dlc:pr-check` needs to re-check. If totalCount > 100 and the fetched page shows 0 unresolved, treat as 1 (safety net for truncation).
 
 Re-fetch current state:
 
@@ -228,7 +257,13 @@ gh pr view $PR_NUMBER --json reviewDecision,mergeable --jq '{reviewDecision,merg
 
 ### No reviews submitted yet
 
-If reviewDecision is `REVIEW_REQUIRED` and UNRESOLVED is 0 (no threads at all — nobody has reviewed):
+Check whether any reviews exist:
+
+```bash
+REVIEW_COUNT=$(gh pr view $PR_NUMBER --json reviews --jq '.reviews | length')
+```
+
+If reviewDecision is `REVIEW_REQUIRED` and REVIEW_COUNT is 0 (no reviews submitted at all):
 - Notify: `👀 PR #<number> is waiting for review. No reviewers have submitted yet. <url>`
 - Stop. Do NOT run pr-check — there are no comments to process. Next cycle will re-check.
 
@@ -265,20 +300,32 @@ After pr-check pushes fixes, re-request review from reviewers who requested chan
 Get the list of reviewers who submitted reviews:
 
 ```bash
-gh pr view $PR_NUMBER --json reviews --jq '[.reviews[].author.login] | unique | join(",")'
+REVIEWERS=$(gh pr view $PR_NUMBER --json reviews --jq '[.reviews[].author.login] | unique | join(",")')
 ```
 
-Re-request review:
+Re-request review only if the list is non-empty:
 
 ```bash
-gh pr edit $PR_NUMBER --add-reviewer <REVIEWER_CSV>
+if [ -n "$REVIEWERS" ]; then
+  gh pr edit $PR_NUMBER --add-reviewer "$REVIEWERS"
+fi
 ```
 
 Do not notify about re-request — this is routine automation.
 
 ## Step 6: Final Assessment
 
-After pr-check and re-review request, re-check the PR state. Re-run the unresolved threads query and reviewDecision check from Step 3.
+After pr-check and re-review request, re-check the PR state.
+
+First, check if pr-check pushed new commits. If so, CI will be re-running — stop silently and let the next cycle pick up the results:
+
+```bash
+gh pr checks $PR_NUMBER --json state --jq '[.[] | select(.state != "COMPLETED")] | length'
+```
+
+If any checks are not completed, stop silently — CI needs to finish before declaring readiness.
+
+If all CI is still green, re-run the unresolved threads query and reviewDecision check from Step 3.
 
 **Ready to merge** (same criteria as Step 3):
 - Notify: `✅ PR #<number> ready to merge! — <title> — <url>`

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -21,17 +21,15 @@ When the skill says "Notify" — print the message to stdout. The user sees it v
 
 ### Deduplication
 
-Track the last notification state to avoid printing the same message every cycle:
+Notifications are deduplicated via a state file at `.dev/dlc/babysit-<PR_NUMBER>.state`. Same state across cycles produces no output. Details are in the notification steps below.
 
-```
-.dev/dlc/babysit-<PR_NUMBER>.state
-```
+## Step 0: Setup
 
-Before printing a notification, read the state file. If it contains the same status key (e.g., `ci_failing:check1,check2`, `needs_review`, `ready`), skip — only notify when the state changes. Write the new status key after notifying.
+### Initialize state tracking
 
-Create `.dev/dlc/` if it does not exist. Delete the state file when self-cancelling.
+Create `.dev/dlc/` if it does not exist. Read the state file `.dev/dlc/babysit-<PR_NUMBER>.state` if it exists — it contains the status key from the last notification. Before sending any notification, compare the current status key against this file. If identical, skip the notification. After sending, write the new key. Delete the state file when self-cancelling.
 
-## Step 0: Detect PR
+### Detect PR
 
 If `$ARGUMENTS` contains a number, use it as PR_NUMBER and fetch that PR explicitly:
 
@@ -94,7 +92,9 @@ Stop without printing anything. This is the normal waiting state.
 
 **If any checks failed:** Continue to Step 1b (attempt auto-fix).
 
-**If ALL checks passed or NO checks exist:** Continue to Step 2.
+**If NO checks exist:** Stop without printing. Checks may be delayed or not configured. Wait for the next cycle.
+
+**If ALL checks passed:** Continue to Step 2.
 
 ## Step 1b: Attempt CI Auto-Fix
 
@@ -287,7 +287,7 @@ Continue to Step 4.
 
 Invoke the pr-check skill to handle review comments:
 
-```
+```text
 Skill("dlc:pr-check", "<PR_NUMBER>")
 ```
 

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -268,19 +268,29 @@ If reviewDecision is `REVIEW_REQUIRED` and REVIEW_COUNT is 0 (no reviews submitt
 - Notify: `👀 PR #<number> is waiting for review. No reviewers have submitted yet. <url>`
 - Stop. Do NOT run pr-check — there are no comments to process. Next cycle will re-check.
 
+### Check for unresolved review bodies and issue comments
+
+In addition to threads, check for actionable review bodies and issue comments that `pr-check` would process. Use the pr-comments.sh script output (or `gh api`) to count:
+- Unresolved review bodies: state is COMMENTED or CHANGES_REQUESTED with actionable content, and no DLC sentinel reply exists
+- Unresolved issue comments: actionable reviewer comments with no DLC sentinel reply
+
+Store as UNRESOLVED_BODIES and UNRESOLVED_ISSUE_COMMENTS.
+
 ### Ready to merge
 
 ALL of these are true:
 1. All CI passed (confirmed in Step 1)
-2. UNRESOLVED is 0
-3. reviewDecision is APPROVED or empty (no review policy)
-4. mergeable is MERGEABLE
+2. UNRESOLVED is 0 (no unresolved threads)
+3. UNRESOLVED_BODIES is 0 (no unresolved review bodies)
+4. UNRESOLVED_ISSUE_COMMENTS is 0 (no unresolved issue comments)
+5. reviewDecision is APPROVED or empty (no review policy)
+6. mergeable is MERGEABLE
 
 If ready:
 - Notify: `✅ PR #<number> ready to merge! — <title> — <url>`
 - Self-cancel and stop. The user merges when they choose to.
 
-### Has unresolved threads
+### Has unresolved feedback
 
 Continue to Step 4.
 
@@ -328,14 +338,14 @@ If any checks are not completed (state != COMPLETED), stop silently — CI needs
 
 If any checks completed with a failing conclusion (FAILURE, ERROR, TIMED_OUT, CANCELLED), stop silently — the next cycle will pick these up in Step 1.
 
-Only proceed if ALL checks are completed with passing conclusions (SUCCESS, SKIPPED, NEUTRAL). Re-run the unresolved threads query and reviewDecision check from Step 3.
+Only proceed if ALL checks are completed with passing conclusions (SUCCESS, SKIPPED, NEUTRAL). Re-run the unresolved threads query, review bodies/issue comments check, and reviewDecision check from Step 3.
 
 **Ready to merge** (same criteria as Step 3):
 - Notify: `✅ PR #<number> ready to merge! — <title> — <url>`
 - Self-cancel and stop.
 
-**Unresolved comments remain (UNRESOLVED > 0):**
-- Notify: `💬 PR #<number> has <count> unresolved threads after auto-fix. Review needed. <url>`
+**Unresolved feedback remains:**
+- Notify: `💬 PR #<number> has unresolved feedback after auto-fix (<threads> threads, <bodies> review bodies, <comments> issue comments). Review needed. <url>`
 - Stop. Next cycle will re-check.
 
 **Changes requested, awaiting re-review (reviewDecision is CHANGES_REQUESTED):**


### PR DESCRIPTION
## Summary

- Adds `/dlc:babysit` — a loop-driven skill for autonomous PR monitoring via `/loop 10m /dlc:babysit`
- CI auto-fix: reads failed logs, attempts targeted fixes (lint, type, test), retries flaky runs
- Auto-rebase with conflict resolution — reads conflict markers and resolves, only escalates genuinely ambiguous clashes
- Invokes `dlc:pr-check` for review comment handling, then re-requests review via `gh pr edit --add-reviewer`
- Only notifies on errors and completion — routine actions (rebase, lint fix, retry) are silent
- State tracking in `.dev/dlc/` for notification deduplication across cycles
- Self-cancels when PR is ready to merge (user merges on their own terms)
- Designed for Remote Control — no Telegram/channel dependency

## Test plan

- [ ] Run `/dlc:babysit` manually on an open PR — verify PR detection and CI check
- [ ] Run `/loop 10m /dlc:babysit` — verify recurring execution and self-cancellation
- [ ] Test with failing CI — verify auto-fix attempt and fallback notification
- [ ] Test with PR behind base — verify rebase + conflict resolution
- [ ] Test with unresolved review threads — verify pr-check invocation and re-review request
- [ ] Verify notification dedup: same state across cycles should not re-print

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs for a new /dlc:babysit skill that monitors PRs, tracks CI status, attempts targeted automated fixes for failing checks, manages rebases when behind base branch, coordinates reviewer re-requests, and suppresses duplicate notifications.
  * Updated the plugin reference to include the new /dlc:babysit trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->