### PR TITLE
feat(council): add documentation drift verification to codebase-context

### DIFF
--- a/plugins/council/agents/claude-codebase-context.md
+++ b/plugins/council/agents/claude-codebase-context.md
@@ -141,6 +141,32 @@ git blame -L <changed-range> <file>
 - **Stale docs/ content**: Changes that invalidate existing documentation — guides referencing removed features, architecture diagrams that no longer match, setup instructions with outdated steps (if `docs/` exists)
 - **Missing migration guides**: Breaking changes (removed/renamed APIs, changed config formats, dropped support) without a migration guide or upgrade notes (if `docs/` exists)
 
+#### Documentation Accuracy Verification
+
+Don't just check if documentation exists — verify it matches the code:
+
+```
+1. For each new config key or field in the diff:
+   a. Grep README.md and docs/ for references to the field name
+   b. If documented: read the documentation claim, then read the code to verify the claim is true
+   c. If the code doesn't implement the documented behavior, flag as "documentation describes unimplemented behavior"
+2. For each field referenced in docstrings/JSDoc:
+   a. Read the type definition the docstring describes
+   b. Verify every @param, @returns, and referenced field actually exists in the type
+   c. Flag phantom fields (referenced in docs but absent from types)
+3. For config examples in README or docs:
+   a. Trace the config value through the code — does the code handle the example value correctly?
+   b. Common trap: tilde paths (~/.local/...) documented but code uses Path() without expanduser()
+   c. Common trap: config key documented but code accesses a differently-named key
+4. For changelog/release notes entries in the diff:
+   a. Compare each bullet to the actual code changes in the same PR
+   b. Flag entries that describe the opposite of what the code does
+   c. Flag entries that describe features the code doesn't implement
+5. For ADRs (Architecture Decision Records):
+   a. Verify the ADR's stated constraints don't conflict with existing repo policies
+   b. Verify the ADR's listed mitigations are actually implemented in the code
+```
+
 #### docs/ Directory Audit
 
 ```

--- a/plugins/council/agents/claude-codebase-context.md
+++ b/plugins/council/agents/claude-codebase-context.md
@@ -143,17 +143,17 @@ git blame -L <changed-range> <file>
 
 #### Documentation Accuracy Verification
 
-Don't just check if documentation exists — verify it matches the code:
+Use the following checks to validate that documentation matches implementation:
 
-```
+```text
 1. For each new config key or field in the diff:
-   a. Grep README.md and docs/ for references to the field name
+   a. Grep **/README.md and docs/ for references to the field name
    b. If documented: read the documentation claim, then read the code to verify the claim is true
    c. If the code doesn't implement the documented behavior, flag as "documentation describes unimplemented behavior"
-2. For each field referenced in docstrings/JSDoc:
-   a. Read the type definition the docstring describes
-   b. Verify every @param, @returns, and referenced field actually exists in the type
-   c. Flag phantom fields (referenced in docs but absent from types)
+2. For each field referenced in docstrings (JSDoc, Python docstrings, etc.):
+   a. Read the type definition or code signature the docstring describes
+   b. Verify every documented parameter, return value, and referenced field actually exists in the code
+   c. Flag phantom fields (referenced in docs but absent from code)
 3. For config examples in README or docs:
    a. Trace the config value through the code — does the code handle the example value correctly?
    b. Common trap: tilde paths (~/.local/...) documented but code uses Path() without expanduser()


### PR DESCRIPTION
## Summary

- Adds a `Documentation Accuracy Verification` subsection to `claude-codebase-context.md` under the Documentation section
- 5 numbered verification procedures that use Grep/Read to verify documentation **matches the code** — not just that docs exist
- Covers: config key drift, phantom JSDoc fields, config example tracing, changelog accuracy, and ADR constraint verification

Closes #153

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [x] Subsection positioned before `docs/ Directory Audit` as specified
- [x] Format matches existing code-block + lettered-sub-step style (cf. CLAUDE.md Compliance section)
- [ ] Verify council review correctly flags documentation drift in a PR with known stale docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation accuracy verification workflow to validate configuration keys, examples, docstrings, and changelog entries against actual code implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->