### PR TITLE
fix(dlc): surface design decisions in babysit loop instead of swallowing them

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -686,3 +686,9 @@ When adding a new mode to a skill that defines roles in SKILL.md, update every r
 Also update: teammate pairs list, marketplace.json description, and mode count in the skill's description frontmatter.
 
 > Source: [PR #195](https://github.com/rube-de/cc-skills/pull/195) — `plugins/cdt/skills/cdt/SKILL.md`, `.claude-plugin/marketplace.json`
+
+### Loop/babysit swallows Discussion-Deferred items
+
+When `dlc:pr-check` runs inside `dlc:babysit` (via `/loop`), no human is at the terminal to answer `AskUserQuestion`. Discussion items auto-defer and get an "Acknowledged — will be addressed by the author" reply on the PR, but the human is never notified. The fix has two parts: (1) babysit must surface Discussion-Deferred items as a dedicated notification (`needs_decision` state key), and (2) pr-check's auto-implementation gate should be wider — if you'd confidently mark one option "(Recommended)", you already know the answer, so just implement it. `AskUserQuestion` is for genuine ambiguity, not a rubber stamp.
+
+> Source: `plugins/dlc/skills/babysit/SKILL.md`, `plugins/dlc/skills/pr-check/SKILL.md`

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -691,4 +691,4 @@ Also update: teammate pairs list, marketplace.json description, and mode count i
 
 When `dlc:pr-check` runs inside `dlc:babysit` (via `/loop`), no human is at the terminal to answer `AskUserQuestion`. Discussion items auto-defer and get an "Acknowledged — will be addressed by the author" reply on the PR, but the human is never notified. The fix has two parts: (1) babysit must surface Discussion-Deferred items as a dedicated notification (`needs_decision` state key), and (2) pr-check's auto-implementation gate should be wider — if you'd confidently mark one option "(Recommended)", you already know the answer, so just implement it. `AskUserQuestion` is for genuine ambiguity, not a rubber stamp.
 
-> Source: `plugins/dlc/skills/babysit/SKILL.md`, `plugins/dlc/skills/pr-check/SKILL.md`
+> Source: [`plugins/dlc/skills/babysit/SKILL.md`](../plugins/dlc/skills/babysit/SKILL.md), [`plugins/dlc/skills/pr-check/SKILL.md`](../plugins/dlc/skills/pr-check/SKILL.md)

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -228,7 +228,7 @@ Stop.
 
 Delegate all review comment handling to `dlc:pr-check`. It handles: fetching comments, categorizing, fixing what it can, replying inline, committing, and pushing.
 
-**Unattended mode:** The babysitter runs in a loop with no human at the terminal. When executing pr-check, do NOT use `AskUserQuestion` for Discussion items — auto-defer all items that would normally require human input (Design Decisions, medium/low-confidence Implementable Fixes, etc.). The babysitter will surface these to the human as a notification instead of silently posting "Acknowledged" replies.
+**Unattended mode:** The babysitter runs in a loop with no human at the terminal. When executing pr-check, do NOT use `AskUserQuestion` — auto-defer only genuinely ambiguous human-judgment items (Design Decisions, items with no clear recommended approach). Auto-implementable fixes per pr-check's Step 3.5c criteria should still be implemented, not deferred. The babysitter will surface deferred items to the human as a notification instead of silently posting "Acknowledged" replies.
 
 ```text
 Skill("dlc:pr-check", "<PR_NUMBER>")
@@ -270,8 +270,8 @@ Both need human attention — combine into a single notification so nothing is s
 
 **If pr-check reported Discussion-Deferred items (count > 0) AND 0 remaining unresolved:**
 These are discussion items that need human judgment — design decisions, architectural trade-offs, or ambiguous suggestions. The babysitter cannot resolve them.
-- Notify: `🧑‍⚖️ PR #<number> has <count> discussion items needing your input. <url>`
-- Write state key `needs_decision:<count>`.
+- Notify: `🧑‍⚖️ PR #<number> has <deferred_count> discussion items needing your input. <url>`
+- Write state key `needs_decision:<deferred_count>`.
 - Do NOT self-cancel — the PR may still need further cycles after the human decides.
 - Stop. Next cycle will re-check (if the human resolved them, pr-check will see the replies).
 

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -25,6 +25,7 @@ Notifications are deduplicated via a state file at `.dev/dlc/babysit-<PR_NUMBER>
 - `ci_unfixable:<sorted_check_names>`
 - `rebase_conflict:<sorted_file_list>`
 - `needs_review`
+- `needs_decision:<count>` (e.g., `needs_decision:2`)
 - `unresolved:<count>`
 - `ready`
 - `closed:<state>`
@@ -226,12 +227,15 @@ Stop.
 
 Delegate all review comment handling to `dlc:pr-check`. It handles: fetching comments, categorizing, fixing what it can, replying inline, committing, and pushing.
 
+**Unattended mode:** The babysitter runs in a loop with no human at the terminal. When executing pr-check, do NOT use `AskUserQuestion` for Discussion items — auto-defer all items that would normally require human input (Design Decisions, medium/low-confidence Implementable Fixes, etc.). The babysitter will surface these to the human as a notification instead of silently posting "Acknowledged" replies.
+
 ```text
 Skill("dlc:pr-check", "<PR_NUMBER>")
 ```
 
 After pr-check completes, parse its output summary to extract these values:
 - Total unresolved items remaining: items marked Fixed, Answered, Resolved, or Dismissed are **done**. Remaining = Total - (Fixed + Answered + Resolved + Dismissed).
+- **Discussion-Deferred count**: items where pr-check deferred to the author (these need human judgment). Extract from the `Discussion: {n} ({deferred} deferred, {tracked} tracked)` line in the summary.
 - Whether pr-check pushed any commits (look for "Pushed" in the summary or a non-empty git diff from before)
 
 If pr-check pushed commits, re-request review from all prior reviewers. Filter out bot accounts (logins ending in `[bot]`):
@@ -257,7 +261,14 @@ gh pr view $PR_NUMBER --json reviewDecision,mergeable
 **If CI is not fully passing** (any check running or failed):
 Stop silently — next cycle will handle it in Step 1.
 
-**If pr-check reported 0 remaining unresolved items AND reviewDecision is APPROVED (or empty) AND mergeable is MERGEABLE:**
+**If pr-check reported Discussion-Deferred items (count > 0):**
+These are design decisions, architectural trade-offs, or ambiguous suggestions that need human judgment. The babysitter cannot resolve them — surface them so the human knows their input is needed.
+- Notify: `🧑‍⚖️ PR #<number> has <count> design decisions needing your input. <url>`
+- Write state key `needs_decision:<count>`.
+- Do NOT self-cancel — the PR may still need further cycles after the human decides.
+- Stop. Next cycle will re-check (if the human resolved them, pr-check will see the replies).
+
+**If pr-check reported 0 remaining unresolved items AND 0 Discussion-Deferred AND reviewDecision is APPROVED (or empty) AND mergeable is MERGEABLE:**
 - Notify: `✅ PR #<number> ready to merge! — <title> — <url>`
 - Self-cancel and stop.
 

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -235,7 +235,7 @@ Skill("dlc:pr-check", "<PR_NUMBER>")
 
 After pr-check completes, parse its output summary to extract these values:
 - Total unresolved items remaining: items marked Fixed, Answered, Resolved, or Dismissed are **done**. Remaining = Total - (Fixed + Answered + Resolved + Dismissed).
-- **Discussion-Deferred count**: items where pr-check deferred to the author (these need human judgment). Extract from the `Discussion: {n} ({deferred} deferred, {tracked} tracked)` line in the summary.
+- **Discussion-Deferred count**: items where pr-check deferred to the author (these need human judgment). Extract the `{deferred}` value from the `Discussion: {n} ({deferred} deferred, {tracked} tracked)` line in the summary.
 - Whether pr-check pushed any commits (look for "Pushed" in the summary or a non-empty git diff from before)
 
 If pr-check pushed commits, re-request review from all prior reviewers. Filter out bot accounts (logins ending in `[bot]`):
@@ -261,9 +261,15 @@ gh pr view $PR_NUMBER --json reviewDecision,mergeable
 **If CI is not fully passing** (any check running or failed):
 Stop silently — next cycle will handle it in Step 1.
 
-**If pr-check reported Discussion-Deferred items (count > 0):**
-These are design decisions, architectural trade-offs, or ambiguous suggestions that need human judgment. The babysitter cannot resolve them — surface them so the human knows their input is needed.
-- Notify: `🧑‍⚖️ PR #<number> has <count> design decisions needing your input. <url>`
+**If pr-check reported Discussion-Deferred items (count > 0) AND remaining unresolved items:**
+Both need human attention — combine into a single notification so nothing is suppressed.
+- Notify: `🧑‍⚖️ PR #<number> has <deferred_count> discussion items needing your input + <unresolved_count> unresolved. <url>`
+- Write state key `needs_decision:<deferred_count>,unresolved:<unresolved_count>`.
+- Stop. Next cycle will re-check.
+
+**If pr-check reported Discussion-Deferred items (count > 0) AND 0 remaining unresolved:**
+These are discussion items that need human judgment — design decisions, architectural trade-offs, or ambiguous suggestions. The babysitter cannot resolve them.
+- Notify: `🧑‍⚖️ PR #<number> has <count> discussion items needing your input. <url>`
 - Write state key `needs_decision:<count>`.
 - Do NOT self-cancel — the PR may still need further cycles after the human decides.
 - Stop. Next cycle will re-check (if the human resolved them, pr-check will see the replies).
@@ -272,7 +278,7 @@ These are design decisions, architectural trade-offs, or ambiguous suggestions t
 - Notify: `✅ PR #<number> ready to merge! — <title> — <url>`
 - Self-cancel and stop.
 
-**If pr-check reported remaining unresolved items:**
+**If pr-check reported remaining unresolved items (and 0 Discussion-Deferred):**
 - Notify: `💬 PR #<number> has <count> unresolved items after auto-fix. Review needed. <url>`
 - Stop. Next cycle will re-check.
 

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -80,13 +80,13 @@ If checkout fails, stop. Do not proceed with git operations on the wrong branch.
 ## Step 1: Check CI Status
 
 ```bash
-gh pr checks $PR_NUMBER --json name,state,conclusion
+gh pr checks $PR_NUMBER --json name,state,bucket
 ```
 
-Categorize each check:
-- **Running**: state is IN_PROGRESS, QUEUED, or PENDING, or conclusion is empty/null
-- **Failed**: conclusion is FAILURE, ERROR, TIMED_OUT, CANCELLED, ACTION_REQUIRED, STALE, or any other non-success value
-- **Passed**: conclusion is SUCCESS, SKIPPED, or NEUTRAL
+Categorize each check by its `bucket` field:
+- **Running**: `bucket` is `pending`
+- **Failed**: `bucket` is `fail`
+- **Passed**: `bucket` is `pass`
 
 **If any checks are still running:**
 Stop without printing anything. This is the normal waiting state.
@@ -254,7 +254,7 @@ If pr-check did NOT push commits, skip the re-request — there's nothing new to
 After pr-check completes, re-check the PR state:
 
 ```bash
-gh pr checks $PR_NUMBER --json name,state,conclusion
+gh pr checks $PR_NUMBER --json name,state,bucket
 gh pr view $PR_NUMBER --json reviewDecision,mergeable
 ```
 

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -26,6 +26,7 @@ Notifications are deduplicated via a state file at `.dev/dlc/babysit-<PR_NUMBER>
 - `rebase_conflict:<sorted_file_list>`
 - `needs_review`
 - `needs_decision:<count>` (e.g., `needs_decision:2`)
+- `needs_decision:<count>,unresolved:<count>` (e.g., `needs_decision:2,unresolved:3`)
 - `unresolved:<count>`
 - `ready`
 - `closed:<state>`

--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -232,7 +232,14 @@ Assess the effort and nature of each discussion item:
 
 ### 3.5c. Present to User, Auto-Implement, or Auto-Reply
 
-**High-confidence Implementable Fix** items (all four criteria from Step 3b (Critically Evaluate) pass, single clear implementation approach) follow the same auto-implementation path as Step 3c — implement directly, no `AskUserQuestion` needed. Print a brief note: `Auto-implementing Discussion item {n}/{total}: {brief description}`. Reclassify the item as **Fixed** — it enters the Step 4 reply queue with the `Fixed:` prefix, identical to user-chosen "Implement now" items.
+**High-confidence Implementable Fix** items follow the same auto-implementation path as Step 3c — implement directly, no `AskUserQuestion` needed. Print a brief note: `Auto-implementing Discussion item {n}/{total}: {brief description}`. Reclassify the item as **Fixed** — it enters the Step 4 reply queue with the `Fixed:` prefix, identical to user-chosen "Implement now" items.
+
+An Implementable Fix is high-confidence when any of these hold:
+- All four criteria from Step 3b pass and there is a single clear approach
+- There are multiple approaches but one is clearly better (you would mark it "(Recommended)") — implement the recommended one
+- The confidence is medium but the recommended action is obvious and low-risk (rename, add check, fix typo, adjust formatting, add missing validation)
+
+The test: if you would present this to the user and confidently mark one option "(Recommended)", you already know the answer — just do it. `AskUserQuestion` exists for genuine ambiguity where reasonable engineers would disagree, not as a rubber stamp for decisions you've already made.
 
 Skip `AskUserQuestion` and auto-reply **high-confidence Clarification Answer** items when the agent can draft a factual answer entirely from codebase evidence. A Clarification Answer is high-confidence when all four of these criteria pass:
 
@@ -260,7 +267,7 @@ When all four pass → auto-draft the reply without asking. Print: `Auto-replyin
 >
 > In these cases, fall through to `AskUserQuestion` instead (or reclassify per the defect-revealing rule above).
 
-**All other items** — Medium/Low-confidence Implementable Fix, Medium/Low-confidence Clarification Answer, Design Decision, Out-of-PR-Scope, or Implementable Fix with multiple approaches — use `AskUserQuestion`:
+**Genuinely ambiguous items only** — Low-confidence Implementable Fix, low-confidence Clarification Answer, true Design Decisions (architectural trade-offs where reasonable engineers would disagree), or Out-of-PR-Scope — use `AskUserQuestion`:
 
 ```text
 Discussion item {n}/{total}: @{reviewer} at {location}

--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -234,12 +234,14 @@ Assess the effort and nature of each discussion item:
 
 **High-confidence Implementable Fix** items follow the same auto-implementation path as Step 3c — implement directly, no `AskUserQuestion` needed. Print a brief note: `Auto-implementing Discussion item {n}/{total}: {brief description}`. Reclassify the item as **Fixed** — it enters the Step 4 reply queue with the `Fixed:` prefix, identical to user-chosen "Implement now" items.
 
-An Implementable Fix is high-confidence when any of these hold:
+Treat an Implementable Fix as high-confidence when any of these hold:
 - All four criteria from Step 3b pass and there is a single clear approach
 - There are multiple approaches but one is clearly better (you would mark it "(Recommended)") — implement the recommended one
 - The confidence is medium but the recommended action is obvious and low-risk (rename, add check, fix typo, adjust formatting, add missing validation)
 
-The test: if you would present this to the user and confidently mark one option "(Recommended)", you already know the answer — just do it. `AskUserQuestion` exists for genuine ambiguity where reasonable engineers would disagree, not as a rubber stamp for decisions you've already made.
+Apply this test: if you would present this to the user and confidently mark one option "(Recommended)", you already know the answer — just do it. `AskUserQuestion` exists for genuine ambiguity where reasonable engineers would disagree, not as a rubber stamp for decisions you've already made.
+
+Medium-confidence Implementable Fix items that do not satisfy the high-confidence tests above — for example, when there are multiple substantially different approaches with no clear winner, the change is behavior-changing or risky, or the trade-offs are non-obvious — route to `AskUserQuestion` in attended runs, or classify as **Discussion-Deferred** in unattended runs.
 
 Skip `AskUserQuestion` and auto-reply **high-confidence Clarification Answer** items when the agent can draft a factual answer entirely from codebase evidence. A Clarification Answer is high-confidence when all four of these criteria pass:
 
@@ -267,7 +269,7 @@ When all four pass → auto-draft the reply without asking. Print: `Auto-replyin
 >
 > In these cases, fall through to `AskUserQuestion` instead (or reclassify per the defect-revealing rule above).
 
-**Genuinely ambiguous items only** — Low-confidence Implementable Fix, low-confidence Clarification Answer, true Design Decisions (architectural trade-offs where reasonable engineers would disagree), or Out-of-PR-Scope — use `AskUserQuestion`:
+**Genuinely ambiguous items only** — Medium/Low-confidence Implementable Fix that does not meet the auto-implement criteria above, medium/low-confidence Clarification Answer, true Design Decisions (architectural trade-offs where reasonable engineers would disagree), Out-of-PR-Scope, or Implementable Fix with multiple approaches (none clearly recommended) — use `AskUserQuestion`:
 
 ```text
 Discussion item {n}/{total}: @{reviewer} at {location}

--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -232,16 +232,16 @@ Assess the effort and nature of each discussion item:
 
 ### 3.5c. Present to User, Auto-Implement, or Auto-Reply
 
-**High-confidence Implementable Fix** items follow the same auto-implementation path as Step 3c — implement directly, no `AskUserQuestion` needed. Print a brief note: `Auto-implementing Discussion item {n}/{total}: {brief description}`. Reclassify the item as **Fixed** — it enters the Step 4 reply queue with the `Fixed:` prefix, identical to user-chosen "Implement now" items.
+**Auto-implementable Implementable Fix** items follow the same auto-implementation path as Step 3c — implement directly, no `AskUserQuestion` needed. Print a brief note: `Auto-implementing Discussion item {n}/{total}: {brief description}`. Reclassify the item as **Fixed** — it enters the Step 4 reply queue with the `Fixed:` prefix, identical to user-chosen "Implement now" items.
 
-Treat an Implementable Fix as high-confidence when any of these hold:
+Treat an Implementable Fix as auto-implementable when any of these hold:
 - All four criteria from Step 3b pass and there is a single clear approach
 - There are multiple approaches but one is clearly better (you would mark it "(Recommended)") — implement the recommended one
-- The confidence is medium but the recommended action is obvious and low-risk (rename, add check, fix typo, adjust formatting, add missing validation)
+- The confidence is medium, but the recommended action is obvious and low-risk (rename, add check, fix typo, adjust formatting, add missing validation), so it is safe to upgrade for execution purposes
 
 Apply this test: if you would present this to the user and confidently mark one option "(Recommended)", you already know the answer — just do it. `AskUserQuestion` exists for genuine ambiguity where reasonable engineers would disagree, not as a rubber stamp for decisions you've already made.
 
-Medium-confidence Implementable Fix items that do not satisfy the high-confidence tests above — for example, when there are multiple substantially different approaches with no clear winner, the change is behavior-changing or risky, or the trade-offs are non-obvious — route to `AskUserQuestion` in attended runs, or classify as **Discussion-Deferred** in unattended runs.
+Implementable Fix items that are not auto-implementable — for example, when there are multiple substantially different approaches with no clear winner, the change is behavior-changing or risky, or the trade-offs are non-obvious — route to `AskUserQuestion` in attended runs, or classify as **Discussion-Deferred** in unattended runs.
 
 Skip `AskUserQuestion` and auto-reply **high-confidence Clarification Answer** items when the agent can draft a factual answer entirely from codebase evidence. A Clarification Answer is high-confidence when all four of these criteria pass:
 


### PR DESCRIPTION
## Summary

- **babysit**: adds `needs_decision:<count>` state key and notification path — Discussion-Deferred items are surfaced to the human instead of silently posting "Acknowledged" on the PR
- **babysit**: adds unattended mode context so pr-check auto-defers instead of blocking on `AskUserQuestion`
- **pr-check**: widens auto-implementation gate — if one option is clearly recommended, implement it instead of routing through `AskUserQuestion`. The litmus test: "if you'd mark it (Recommended), you already know the answer"
- **learnings**: documents the root cause pattern

## Test plan

- [ ] Run `/loop 5m /dlc:babysit` on a PR with a Design Decision review comment — verify the human gets a `needs_decision` notification
- [ ] Verify that medium-confidence Implementable Fix items with a clear recommendation auto-implement without `AskUserQuestion`
- [ ] `bun scripts/validate-plugins.mjs` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance describing an unattended failure mode and how Discussion-Deferred items are surfaced and tracked.

* **New Features**
  * Introduced unattended-mode behavior: auto-defer genuinely ambiguous discussion items, surface combined “needs your input + unresolved” notifications, and add deduplicated state keys to track decision/unresolved counts.
  * Broadened auto-implementation rules to allow clearly recommended or low-risk fixes to be applied without prompting.

* **Bug Fixes**
  * Ensured humans are notified when items are auto-deferred and updated merge readiness to require zero deferred and unresolved items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->