### PR TITLE
fix(dlc): prevent babysit from skipping pr-check on resolved threads

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -692,3 +692,9 @@ Also update: teammate pairs list, marketplace.json description, and mode count i
 When `dlc:pr-check` runs inside `dlc:babysit` (via `/loop`), no human is at the terminal to answer `AskUserQuestion`. Discussion items auto-defer and get an "Acknowledged — will be addressed by the author" reply on the PR, but the human is never notified. The fix has two parts: (1) babysit must surface Discussion-Deferred items as a dedicated notification (`needs_decision` state key), and (2) pr-check's auto-implementation gate should be wider — if you'd confidently mark one option "(Recommended)", you already know the answer, so just implement it. `AskUserQuestion` is for genuine ambiguity, not a rubber stamp.
 
 > Source: [`plugins/dlc/skills/babysit/SKILL.md`](../plugins/dlc/skills/babysit/SKILL.md), [`plugins/dlc/skills/pr-check/SKILL.md`](../plugins/dlc/skills/pr-check/SKILL.md)
+
+### Conditional-sounding steps get skipped by loop agents
+
+When a babysit/loop agent has context from a prior cycle ("I resolved all 3 threads"), it will rationalize skipping a step if the wording reads as conditional — e.g., "Delegate all review comment handling to X" implies "if there's review work." But bot reviewers (Copilot, CodeRabbit, Gemini) post new comments after every push, so prior-cycle state is always stale. Fix: add an explicit "always run, never skip" directive with the rationale, so the agent understands *why* it can't rely on its memory of the previous cycle.
+
+> Source: [Issue #200](https://github.com/rube-de/cc-skills/issues/200) — `plugins/dlc/skills/babysit/SKILL.md` Step 3

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -226,6 +226,8 @@ Stop.
 
 ## Step 3: Run PR Review Check
 
+**Always run `dlc:pr-check` — never skip this step.** Every push triggers new bot reviews (Copilot, CodeRabbit, Gemini), so prior-cycle state is unreliable. Even if all threads were resolved in a previous cycle, new unresolved comments may have appeared since.
+
 Delegate all review comment handling to `dlc:pr-check`. It handles: fetching comments, categorizing, fixing what it can, replying inline, committing, and pushing.
 
 **Unattended mode:** The babysitter runs in a loop with no human at the terminal. When executing pr-check, do NOT use `AskUserQuestion` — auto-defer only genuinely ambiguous human-judgment items (Design Decisions, items with no clear recommended approach). Auto-implementable fixes per pr-check's Step 3.5c criteria should still be implemented, not deferred. The babysitter will surface deferred items to the human as a notification instead of silently posting "Acknowledged" replies.


### PR DESCRIPTION
## Summary

- Add explicit "always run, never skip" directive to babysit Step 3 with rationale explaining that every push triggers new bot reviews (Copilot, CodeRabbit, Gemini), making prior-cycle state unreliable
- Document the generalizable pattern in `docs/learnings.md`: conditional-sounding steps get skipped by loop agents

Closes #200

## Test plan

- [ ] Run `/loop 10m /dlc:babysit` on a PR with bot reviewers enabled
- [ ] Verify pr-check runs every cycle even after all threads are resolved
- [ ] Push a fix commit and confirm new bot comments are caught in the next cycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guidance on writing instructions to prevent loop agents from unintentionally skipping conditional steps
  * Updated skill documentation to ensure PR review checks always execute and are never skipped, guaranteeing consistent handling of review feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->