### PR TITLE
feat(pm): add brainstorm skill for pre-creation design exploration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -50,7 +50,7 @@
     },
     {
       "name": "project-manager",
-      "description": "GitHub issue lifecycle: create structured issues for LLM agent teams, triage and recommend next issues, audit and clean up stale backlogs, and deep-validate individual issues against the codebase",
+      "description": "GitHub issue lifecycle: brainstorm design approaches, create structured issues for LLM agent teams, triage and recommend next issues, audit and clean up stale backlogs, and deep-validate individual issues against the codebase",
       "version": "1.58.2",
       "source": "./plugins/project-manager",
       "category": "productivity",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 |--------|----------|----------------|
 | council | Code Review | `/council`, `/council:review-plan` |
 | cdt | Development | `/cdt` |
-| project-manager | Productivity | `/pm`, `/pm:next`, `/pm:update`, `/pm:review` |
+| project-manager | Productivity | `/pm`, `/pm:brainstorm`, `/pm:next`, `/pm:update`, `/pm:review` |
 | plugin-dev | Development | `/plugin-dev`, `/plugin-dev:create`, `/plugin-dev:develop` |
 | temporal | Development | `/temporal` |
 | doppler | DevOps | `/doppler` |

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -111,6 +111,48 @@ The fix is always the same: add the consumed value as an explicit column/field i
 
 > Source: [Issue #124](https://github.com/rube-de/cc-skills/issues/124), [PR #171](https://github.com/rube-de/cc-skills/pull/171) — Three independent reviewers across two review rounds flagged the same gap: Epic sub-issue sizing consumed "structural changes" but the decomposition table had no column for it.
 
+### Template section ordering controls which sections get filled
+
+When a SKILL.md contains a template with optional sections (e.g., "Alternatives Considered" and "Work Breakdown" that should be skipped for simple features), the model fills sections top-to-bottom as it encounters them. If the scaling instructions ("skip these for simple work") come *after* the template, the model has already filled everything before seeing the skip rule.
+
+**Bad** — scaling note after template:
+```markdown
+## Template
+# Spec: <Topic>
+## Problem
+## Chosen Approach
+### Alternatives Considered   ← model fills this
+## Work Breakdown             ← model fills this too
+
+**Scaling:** Simple features should skip Alternatives and Work Breakdown.
+```
+
+**Good** — tier classification before template, inline comments inside:
+```markdown
+**Determine the complexity tier first:**
+| Simple | Skip Alternatives, Work Breakdown |
+| Medium | Include all sections |
+
+## Template
+### Alternatives Considered
+<!-- MEDIUM and COMPLEX only — omit for SIMPLE -->
+```
+
+The model reads SKILL.md top-to-bottom. Put conditional instructions *before* the content they gate, and add inline `<!-- -->` comments as defense-in-depth reminders inside the template itself.
+
+> Source: Brainstorm skill eval — Eval 3 (deceptive-health-check) produced a 75-line spec for a simple feature because the model filled Alternatives Considered and Work Breakdown before encountering the scaling instructions.
+
+### Cross-project topics need explicit handling in exploration steps
+
+Skills with codebase exploration steps (e.g., "use Glob/Grep to find affected files") implicitly assume the brainstorm topic is about the current working directory. When users brainstorm about a different project (e.g., "add rate limiting to my Express API" while in a skills marketplace repo), the exploration step silently fails or produces irrelevant results.
+
+Add explicit cross-project handling:
+1. Detect the mismatch in the context-gathering step
+2. Use `WebSearch` or ask the user for relevant file paths
+3. Mark paths in the output as `[unverified — user-provided]` so downstream consumers know to check them
+
+> Source: Brainstorm skill eval — Eval 1 (simple-rate-limiting) asked about an Express API while running in cc-skills. The agent improvised successfully but was unguided, making the behavior fragile.
+
 ---
 
 ## Agent Teams

--- a/plugins/project-manager/README.md
+++ b/plugins/project-manager/README.md
@@ -1,7 +1,7 @@
 # project-manager
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Skills](https://img.shields.io/badge/Skills-4-blue.svg)]()
+[![Skills](https://img.shields.io/badge/Skills-5-blue.svg)]()
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
 [![Install](https://img.shields.io/badge/Install-Plugin%20%7C%20Skill-informational.svg)]()
 
@@ -53,8 +53,9 @@ Before drafting, the plugin explores the repo to ensure:
 | Skill | Command | Purpose | Triggers |
 |-------|---------|---------|----------|
 | **pm** | `/pm` | Create structured issues | `create issue`, `write ticket`, `plan work`, `/pm` |
-| **brainstorm** | `/pm:brainstorm` | Explore approaches before creating issues | `brainstorm`, `explore idea`, `think through`, `compare solutions` |
+| **brainstorm** | `/pm:brainstorm` | Explore approaches before creating issues | `brainstorm`, `explore idea`, `think through`, `design approach`, `what should we build`, `explore options`, `weigh approaches`, `compare solutions` |
 | **next** | `/pm:next` | Triage & recommend next issue | `what should I work on next`, `triage backlog` |
+| **review** | `/pm:review` | Deep-validate a single issue against codebase | `review issue`, `validate issue`, `is this still needed` |
 | **update** | `/pm:update` | Audit & clean up issues | `audit issues`, `clean up issues`, `backlog cleanup` |
 
 ## Usage

--- a/plugins/project-manager/README.md
+++ b/plugins/project-manager/README.md
@@ -1,11 +1,11 @@
 # project-manager
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Skills](https://img.shields.io/badge/Skills-3-blue.svg)]()
+[![Skills](https://img.shields.io/badge/Skills-4-blue.svg)]()
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
 [![Install](https://img.shields.io/badge/Install-Plugin%20%7C%20Skill-informational.svg)]()
 
-GitHub issue lifecycle for LLM agent teams: **create** structured issues, **triage** what to work on next, and **audit** stale/orphaned issues. Produces machine-parseable issues that AI coding agents can execute autonomously.
+GitHub issue lifecycle for LLM agent teams: **brainstorm** design approaches, **create** structured issues, **triage** what to work on next, and **audit** stale/orphaned issues. Produces machine-parseable issues that AI coding agents can execute autonomously.
 
 > [!NOTE]
 > **Agent-First Design**: Every template section is a contract that agents parse. Acceptance criteria use `VERIFY:` prefixes for testable assertions, and scope boundaries are always explicit to prevent over-engineering.
@@ -53,6 +53,7 @@ Before drafting, the plugin explores the repo to ensure:
 | Skill | Command | Purpose | Triggers |
 |-------|---------|---------|----------|
 | **pm** | `/pm` | Create structured issues | `create issue`, `write ticket`, `plan work`, `/pm` |
+| **brainstorm** | `/pm:brainstorm` | Explore approaches before creating issues | `brainstorm`, `explore idea`, `think through`, `compare solutions` |
 | **next** | `/pm:next` | Triage & recommend next issue | `what should I work on next`, `triage backlog` |
 | **update** | `/pm:update` | Audit & clean up issues | `audit issues`, `clean up issues`, `backlog cleanup` |
 
@@ -61,9 +62,43 @@ Before drafting, the plugin explores the repo to ensure:
 ```bash
 /pm                       # Create a new issue (interactive flow)
 /pm -quick fix the login  # Create issue with smart defaults
+/pm:brainstorm caching    # Explore approaches before creating issues
 /pm:next                  # Triage: recommend next issue to work on
 /pm:update                # Audit: find stale/orphaned issues
 ```
+
+## Brainstorm Workflow
+
+```
+┌─────────────────────────────────────────────────────┐
+│            /pm:brainstorm [topic]                    │
+├─────────────────────────────────────────────────────┤
+│                                                     │
+│  1. Context — silently gather project awareness     │
+│                                                     │
+│  2. Clarify — one question at a time, multiple      │
+│     choice preferred over open-ended                │
+│                                                     │
+│  3. Propose — 2-3 approaches with trade-offs        │
+│     and a recommendation (not neutral)              │
+│                                                     │
+│  4. Converge — flesh out chosen approach with       │
+│     codebase exploration for real file paths        │
+│                                                     │
+│  5. Write Spec — save to .dev/pm/specs/             │
+│     (tier-scaled: simple/medium/complex)            │
+│                                                     │
+│  6. Self-Review — check for placeholders,           │
+│     contradictions, scope creep                     │
+│                                                     │
+│  7. User Review — approve or request changes        │
+│                                                     │
+│  8. Transition — hand off to /pm or /cdt            │
+│                                                     │
+└─────────────────────────────────────────────────────┘
+```
+
+> **Proactive triggering**: `/pm` detects ambiguous requests (unclear scope, multiple approaches, exploration language) and suggests brainstorming before issue creation.
 
 ## Create Workflow
 
@@ -134,6 +169,11 @@ npx skills add rube-de/cc-skills --skill project-manager
 ## Usage Examples
 
 ```bash
+# Brainstorm (before issue creation)
+/pm:brainstorm                 # Explore approaches for ambiguous work
+/pm:brainstorm plugin discovery  # Start with a topic
+"I'm not sure how to approach this"  # Natural language trigger
+
 # Issue creation
 /pm                            # Interactive flow
 /pm -quick fix login redirect  # Quick mode with smart defaults
@@ -167,6 +207,7 @@ npx skills add rube-de/cc-skills --skill project-manager
 ## References
 
 - [pm/SKILL.md](skills/pm/SKILL.md) — Router + create workflow
+- [brainstorm/SKILL.md](skills/brainstorm/SKILL.md) — Pre-creation design exploration
 - [next/SKILL.md](skills/next/SKILL.md) — Triage & recommendation workflow
 - [update/SKILL.md](skills/update/SKILL.md) — Audit & cleanup workflow
 - [TEMPLATES.md](skills/pm/references/TEMPLATES.md) — All 8 issue templates

--- a/plugins/project-manager/README.md
+++ b/plugins/project-manager/README.md
@@ -1,7 +1,7 @@
 # project-manager
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Skills](https://img.shields.io/badge/Skills-5-blue.svg)]()
+[![Skills](https://img.shields.io/badge/Skills-5-blue.svg)](skills/)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
 [![Install](https://img.shields.io/badge/Install-Plugin%20%7C%20Skill-informational.svg)]()
 
@@ -55,7 +55,7 @@ Before drafting, the plugin explores the repo to ensure:
 | **pm** | `/pm` | Create structured issues | `create issue`, `write ticket`, `plan work`, `/pm` |
 | **brainstorm** | `/pm:brainstorm` | Explore approaches before creating issues | `brainstorm`, `explore idea`, `think through`, `design approach`, `what should we build`, `explore options`, `weigh approaches`, `compare solutions` |
 | **next** | `/pm:next` | Triage & recommend next issue | `what should I work on next`, `triage backlog` |
-| **review** | `/pm:review` | Deep-validate a single issue against codebase | `review issue`, `validate issue`, `is this still needed` |
+| **review** | `/pm:review ISSUE_NUMBER` | Deep-validate a single issue against codebase | `review issue`, `validate issue`, `is this still needed` |
 | **update** | `/pm:update` | Audit & clean up issues | `audit issues`, `clean up issues`, `backlog cleanup` |
 
 ## Usage
@@ -70,7 +70,7 @@ Before drafting, the plugin explores the repo to ensure:
 
 ## Brainstorm Workflow
 
-```
+```text
 ┌─────────────────────────────────────────────────────┐
 │            /pm:brainstorm [topic]                    │
 ├─────────────────────────────────────────────────────┤

--- a/plugins/project-manager/skills/brainstorm/SKILL.md
+++ b/plugins/project-manager/skills/brainstorm/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   issue creation (/pm) and implementation planning (/cdt). Use this whenever the
   user says brainstorm, explore idea, think through, design approach, what should
   we build, explore options, weigh approaches, compare solutions, or needs help
-  deciding between alternatives — even if they don't explicitly say "brainstorm."
+  deciding between alternatives — even if they don't explicitly say "brainstorm".
 user-invocable: true
 argument-hint: "[topic or problem description]"
 allowed-tools:
@@ -334,8 +334,9 @@ Present the final spec to the user. Show:
 
 Ask explicitly: **"Spec looks good — approve to proceed, or want changes?"**
 
-If the user requests changes, revise the spec (go back to Step 5) and re-present. Loop until
-approved. Once approved, update the spec's `**Status:**` from `Draft` to `Approved`.
+If the user requests changes, revise the spec (go back to Step 5), run Step 6 self-review again,
+and re-present. Loop until approved. Once approved, update the spec's `**Status:**` from `Draft`
+to `Approved`.
 
 ### Step 8: Transition
 

--- a/plugins/project-manager/skills/brainstorm/SKILL.md
+++ b/plugins/project-manager/skills/brainstorm/SKILL.md
@@ -4,10 +4,10 @@ description: >-
   You MUST use this skill before /pm when work is ambiguous, scope is unclear,
   or multiple approaches exist. Explores problem space, proposes 2-3 approaches
   with trade-offs, and produces an approved spec document that feeds into both
-  issue creation (/pm) and implementation planning (/cdt). Use this whenever the
-  user says brainstorm, explore idea, think through, design approach, what should
-  we build, explore options, weigh approaches, compare solutions, or needs help
-  deciding between alternatives — even if they don't explicitly say "brainstorm".
+  issue creation (/pm) and implementation planning (/cdt). Triggers: brainstorm,
+  explore idea, think through, design approach, what should we build, explore
+  options, weigh approaches, compare solutions, needs help deciding between
+  alternatives.
 user-invocable: true
 argument-hint: "[topic or problem description]"
 allowed-tools:
@@ -85,7 +85,7 @@ in Step 2.
 Before asking any questions, gather context silently:
 
 1. **Project awareness**: Read the project's README, CLAUDE.md, or similar docs to understand what this project does
-2. **Recent work**: Run `git log --oneline -20` to see recent direction
+2. **Recent work**: If the current directory is inside a Git work tree, run `git log --oneline -20` to see recent direction. If not, skip this step silently.
 3. **Relevant code**: If the user mentioned a specific area, use `Glob` and `Grep` to survey it
 4. **Existing issues**: Check if `gh` is available and authenticated, then run `gh issue list --limit 10 --state open` to check for related work. If `gh` is not available or not authenticated, skip this step silently — it's informational, not blocking.
 5. **Visual workflow overview**: If the `visual-explainer:generate-web-diagram` skill is available, invoke it to show the user an interactive workflow diagram — the 8 steps as a flowchart with the current step highlighted and the review loop (Step 7 → Step 5) shown as a feedback edge. This gives the user a visual map of the process they're about to go through. Skip this if visual-explainer is not installed.

--- a/plugins/project-manager/skills/brainstorm/SKILL.md
+++ b/plugins/project-manager/skills/brainstorm/SKILL.md
@@ -12,6 +12,7 @@ user-invocable: true
 argument-hint: "[topic or problem description]"
 allowed-tools:
   - Read
+  - Edit
   - Grep
   - Glob
   - Bash
@@ -77,31 +78,6 @@ in Step 2.
 
 ```text
 1. Context → 2. Clarify → 3. Propose → 4. Converge → 5. Write Spec → 6. Self-Review → 7. User Review → 8. Transition
-```
-
-```dot
-digraph brainstorm {
-  rankdir=TB;
-  node [shape=box];
-
-  context [label="1. Explore Context"];
-  clarify [label="2. Clarify Intent"];
-  propose [label="3. Propose Approaches"];
-  converge [label="4. Converge on Design"];
-  write [label="5. Write Spec"];
-  review [label="6. Self-Review"];
-  user_review [label="7. User Review", shape=diamond];
-  transition [label="8. Transition"];
-
-  context -> clarify;
-  clarify -> propose;
-  propose -> converge;
-  converge -> write;
-  write -> review;
-  review -> user_review;
-  user_review -> write [label="changes requested"];
-  user_review -> transition [label="approved"];
-}
 ```
 
 ### Step 1: Explore Context
@@ -227,8 +203,8 @@ relevant file paths or architecture details instead of exploring. Mark all paths
 `Skill` to invoke `visual-explainer:generate-web-diagram`. Show component boundaries, data flow, and
 the decomposition into work units. Present the diagram alongside the architecture overview section.
 
-Present each section and wait for the user to confirm before moving to the next. Do NOT present
-the entire design at once for medium or complex work.
+For medium and complex work, present each section and wait for the user to confirm before moving
+to the next. For simple features, present the full design at once.
 
 ### Step 5: Write Spec Document
 
@@ -285,6 +261,7 @@ was filled in mechanically without thinking about what the reader needs.
 - <Decision 2>: <chosen option> — <rationale>
 
 ### Trade-offs Accepted
+<!-- MEDIUM and COMPLEX only — omit for SIMPLE -->
 
 - <What we're giving up and why that's acceptable>
 

--- a/plugins/project-manager/skills/brainstorm/SKILL.md
+++ b/plugins/project-manager/skills/brainstorm/SKILL.md
@@ -1,22 +1,20 @@
 ---
 name: brainstorm
 description: >-
-  Explore problem space, requirements, and design approaches before creating
-  issues. Use before /pm when the work is ambiguous, the scope is unclear, or
-  multiple approaches exist. Walks through structured discovery, proposes 2-3
-  approaches with trade-offs, and produces an approved spec document that feeds
-  into both issue creation (/pm) and implementation planning (/cdt). Triggers:
-  brainstorm, explore idea, think through, design approach, what should we build,
-  explore options, /pm brainstorm.
+  You MUST use this skill before /pm when work is ambiguous, scope is unclear,
+  or multiple approaches exist. Explores problem space, proposes 2-3 approaches
+  with trade-offs, and produces an approved spec document that feeds into both
+  issue creation (/pm) and implementation planning (/cdt). Use this whenever the
+  user says brainstorm, explore idea, think through, design approach, what should
+  we build, explore options, weigh approaches, compare solutions, or needs help
+  deciding between alternatives — even if they don't explicitly say "brainstorm."
 user-invocable: true
 argument-hint: "[topic or problem description]"
 allowed-tools:
   - Read
   - Grep
   - Glob
-  - Bash(gh:*)
-  - Bash(mkdir:*)
-  - Bash(git:*)
+  - Bash
   - AskUserQuestion
   - WebSearch
   - WebFetch
@@ -67,6 +65,13 @@ No. Every brainstorming session produces a spec. The spec scales with complexity
 
 The cost of a 30-second review of a short spec is negligible. The cost of a poorly scoped issue
 that an agent executes in the wrong direction is significant.
+
+## Arguments
+
+If the user provides arguments (e.g., `/pm:brainstorm caching layer for API`), treat the entire
+argument string as the **initial topic**. Use it to focus Step 1 context gathering and to skip
+obvious clarifications in Step 2. If no arguments are provided, start with an open-ended discovery
+in Step 2.
 
 ## Workflow
 
@@ -197,6 +202,16 @@ With the chosen approach, flesh out the design. Present it in sections scaled to
 - Risks and mitigations
 - Open questions
 
+**Codebase exploration.** Before presenting the design, explore the codebase for the chosen approach:
+
+1. Use `Glob` and `Grep` to find files that will need modification
+2. Use `Read` to understand existing patterns, interfaces, and conventions in the affected areas
+3. Check for related work: existing TODOs, tests, similar implementations
+4. Record concrete file paths — these feed directly into the spec's "Files Affected" section
+
+Do NOT present the design without grounding it in the actual codebase. An ungrounded design produces
+an ungrounded spec, which produces vague issues, which agents execute poorly.
+
 **Visual architecture diagram.** For medium and complex work, generate an architecture diagram using
 `Skill` to invoke `visual-explainer:generate-web-diagram`. Show component boundaries, data flow, and
 the decomposition into work units. Present the diagram alongside the architecture overview section.
@@ -287,12 +302,7 @@ mkdir -p .dev/pm/specs
 - **Medium** (2-3 issues): Include all sections but keep each concise
 - **Complex** (epic): Full spec — all sections fleshed out, architecture diagram referenced
 
-Commit the spec to git:
-
-```bash
-git add .dev/pm/specs/YYYY-MM-DD-<topic-slug>.md
-git -c commit.gpgsign=false commit -m "docs(brainstorm): <topic-slug> spec"
-```
+Do NOT commit yet — the self-review and user review may require changes.
 
 ### Step 6: Self-Review
 
@@ -321,6 +331,13 @@ Ask explicitly: **"Spec looks good — approve to proceed, or want changes?"**
 
 If the user requests changes, revise the spec (go back to Step 5) and re-present. Loop until
 approved.
+
+Once approved, commit the spec to git:
+
+```bash
+git add .dev/pm/specs/YYYY-MM-DD-<topic-slug>.md
+git -c commit.gpgsign=false commit -m "docs(brainstorm): <topic-slug> spec"
+```
 
 ### Step 8: Transition
 
@@ -353,12 +370,15 @@ committed to git — they can come back to it in a future session.
 
 ## Principles
 
-- **Depth over breadth** — one good question beats five shallow ones
-- **Take positions** — recommend an approach, don't just list options
-- **YAGNI** — remove speculative features from every design. If they say "might need X later,"
-  acknowledge it and leave it out unless there's a concrete use case now
-- **Scale the process** — a simple feature gets a 10-line spec, not a 2-page design doc
-- **The spec is the contract** — once approved, downstream workflows follow the spec. No
-  re-litigating decisions that were already made
-- **Visuals earn their keep** — generate diagrams only when they clarify something text cannot.
-  A bullet list of 3 components does not need an architecture diagram
+- Ask one focused question rather than multiple shallow ones — depth produces better answers
+  because users give more thought to a single question than to a wall of five
+- Recommend a specific approach rather than listing neutral options — fence-sitting wastes the
+  user's decision energy and signals you don't have an opinion
+- Remove speculative features from every design. If the user says "might need X later,"
+  acknowledge it and leave it out unless there is a concrete use case now
+- Scale the spec to match the work — a simple feature gets a 10-line spec, not a 2-page design
+  doc. Oversized specs for small work signal cargo-culting, not rigor
+- Treat the approved spec as the contract for downstream workflows. Do not re-litigate decisions
+  that were already made during brainstorming
+- Generate diagrams only when they clarify something text cannot — a bullet list of 3 components
+  does not need an architecture diagram

--- a/plugins/project-manager/skills/brainstorm/SKILL.md
+++ b/plugins/project-manager/skills/brainstorm/SKILL.md
@@ -80,12 +80,6 @@ in Step 2.
 1. Context → 2. Clarify → 3. Propose → 4. Converge → 5. Write Spec → 6. Self-Review → 7. User Review → 8. Transition
 ```
 
-**Visual workflow overview.** After completing Step 1 (context gathering), if the
-`visual-explainer:generate-web-diagram` skill is available, invoke it to show the user an
-interactive workflow diagram — the 8 steps as a flowchart with the current step highlighted and
-the review loop (Step 7 → Step 5) shown as a feedback edge. This gives the user a visual map
-of the process they're about to go through. Skip this if visual-explainer is not installed.
-
 ### Step 1: Explore Context
 
 Before asking any questions, gather context silently:
@@ -94,6 +88,7 @@ Before asking any questions, gather context silently:
 2. **Recent work**: Run `git log --oneline -20` to see recent direction
 3. **Relevant code**: If the user mentioned a specific area, use `Glob` and `Grep` to survey it
 4. **Existing issues**: Check if `gh` is available and authenticated, then run `gh issue list --limit 10 --state open` to check for related work. If `gh` is not available or not authenticated, skip this step silently — it's informational, not blocking.
+5. **Visual workflow overview**: If the `visual-explainer:generate-web-diagram` skill is available, invoke it to show the user an interactive workflow diagram — the 8 steps as a flowchart with the current step highlighted and the review loop (Step 7 → Step 5) shown as a feedback edge. This gives the user a visual map of the process they're about to go through. Skip this if visual-explainer is not installed.
 
 **Cross-project topics.** If the user's topic is about a different project than the current working
 directory (e.g., they ask about their Express API while you're in a skills marketplace repo),
@@ -347,8 +342,9 @@ designed to feed into two downstream workflows:
 > Create structured GitHub issues from the spec. The work breakdown maps directly to issues.
 
 **Path B: Implementation planning (`/cdt:plan-task`)**
-> Skip issue creation and go straight to an implementation plan. CDT's architect teammate will
-> use the spec as input.
+> Skip issue creation and go straight to an implementation plan. Invoke with the spec path as
+> context (e.g., `/cdt:plan-task implement the spec at .dev/pm/specs/YYYY-MM-DD-topic.md`).
+> CDT's architect teammate will use the spec as input.
 
 **Path C: Both**
 > Create issues first (`/pm`), then plan implementation for the top-priority issue (`/cdt`).

--- a/plugins/project-manager/skills/brainstorm/SKILL.md
+++ b/plugins/project-manager/skills/brainstorm/SKILL.md
@@ -1,0 +1,364 @@
+---
+name: brainstorm
+description: >-
+  Explore problem space, requirements, and design approaches before creating
+  issues. Use before /pm when the work is ambiguous, the scope is unclear, or
+  multiple approaches exist. Walks through structured discovery, proposes 2-3
+  approaches with trade-offs, and produces an approved spec document that feeds
+  into both issue creation (/pm) and implementation planning (/cdt). Triggers:
+  brainstorm, explore idea, think through, design approach, what should we build,
+  explore options, /pm brainstorm.
+user-invocable: true
+argument-hint: "[topic or problem description]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(gh:*)
+  - Bash(mkdir:*)
+  - Bash(git:*)
+  - AskUserQuestion
+  - WebSearch
+  - WebFetch
+  - Write
+  - Skill
+metadata:
+  author: claude-pm
+  version: "1.0"
+---
+
+# Brainstorm: Pre-Creation Design Exploration
+
+Explore the problem space, clarify requirements, and converge on a design direction **before** creating
+issues. This skill produces a **spec document** — capturing intent, trade-offs, the chosen approach, and
+enough detail for both issue creation (`/pm`) and implementation planning (`/cdt`).
+
+## When to Use
+
+Use this skill when:
+- The work is ambiguous — user knows *what* they want but not *how*
+- Multiple valid approaches exist and trade-offs need discussion
+- Scope is unclear — could be one issue or an epic with sub-issues
+- The problem domain is unfamiliar and needs exploration first
+- A request is large enough that jumping straight to issue creation would produce a vague ticket
+
+Do NOT use for:
+- Clear, well-scoped bugs (go directly to `/pm`)
+- Simple chores or dependency updates
+- Work that already has a design document or spec
+
+## Hard Gate
+
+<HARD-GATE>
+Do NOT invoke `/pm`, `/cdt`, create any GitHub issue, or take any implementation action until:
+1. You have proposed approaches and the user has selected one
+2. You have presented a spec document and the user has approved it
+
+This applies to EVERY brainstorming session regardless of perceived simplicity. A spec can be
+short (5-10 lines for a simple feature), but it must exist and be approved.
+</HARD-GATE>
+
+### "This Is Too Simple To Need a Spec"
+
+No. Every brainstorming session produces a spec. The spec scales with complexity:
+- Simple feature: 5-10 lines covering approach, scope, and key decisions
+- Medium feature: half a page with trade-off analysis and component breakdown
+- Complex initiative: full spec with architecture, decomposition, and risk assessment
+
+The cost of a 30-second review of a short spec is negligible. The cost of a poorly scoped issue
+that an agent executes in the wrong direction is significant.
+
+## Workflow
+
+```text
+1. Context → 2. Clarify → 3. Propose → 4. Converge → 5. Write Spec → 6. Self-Review → 7. User Review → 8. Transition
+```
+
+```dot
+digraph brainstorm {
+  rankdir=TB;
+  node [shape=box];
+
+  context [label="1. Explore Context"];
+  clarify [label="2. Clarify Intent"];
+  propose [label="3. Propose Approaches"];
+  converge [label="4. Converge on Design"];
+  write [label="5. Write Spec"];
+  review [label="6. Self-Review"];
+  user_review [label="7. User Review", shape=diamond];
+  transition [label="8. Transition"];
+
+  context -> clarify;
+  clarify -> propose;
+  propose -> converge;
+  converge -> write;
+  write -> review;
+  review -> user_review;
+  user_review -> write [label="changes requested"];
+  user_review -> transition [label="approved"];
+}
+```
+
+### Step 1: Explore Context
+
+Before asking any questions, gather context silently:
+
+1. **Project awareness**: Read the project's README, CLAUDE.md, or similar docs to understand what this project does
+2. **Recent work**: Run `git log --oneline -20` to see recent direction
+3. **Relevant code**: If the user mentioned a specific area, use `Glob` and `Grep` to survey it
+4. **Existing issues**: Run `gh issue list --limit 10 --state open` to check for related work
+
+Do NOT dump this research back at the user. Use it to ask smarter questions in Step 2.
+
+### Step 2: Clarify Intent
+
+Ask clarifying questions to understand what the user actually wants. Follow these rules strictly:
+
+**One question per message.** Never ask more than one question at a time. Wait for the answer before
+asking the next question. This forces depth — users give better answers to focused questions than to
+a wall of 5 questions at once.
+
+**Prefer multiple choice over open-ended.** When possible, offer 2-4 concrete options rather than
+asking "what do you want?" Open-ended questions get vague answers; structured choices get decisions.
+
+**Use your context research.** Frame questions using what you learned in Step 1. Instead of "what part
+of the codebase?" ask "I see the auth module uses JWT tokens in `src/auth/` — is this about the token
+refresh flow or the login flow?"
+
+**Stop when you have enough.** You need to understand:
+- What problem is being solved (the "why")
+- Who it's for (users, developers, ops)
+- What success looks like (observable outcome)
+- What's explicitly out of scope
+
+Three to five questions is typical. Do not over-interrogate — if the user gives a rich initial
+description, you may only need one or two clarifications.
+
+### Step 3: Propose Approaches
+
+Present 2-3 distinct approaches. For each approach, include:
+
+1. **Name** — a short label (e.g., "Approach A: Event-driven pipeline")
+2. **How it works** — 2-3 sentences describing the approach
+3. **Trade-offs** — what you gain and what you give up
+4. **Complexity** — rough effort level (small / medium / large)
+5. **Risk** — what could go wrong or what's unknown
+
+End with a **recommendation** — state which approach you'd pick and why. Do not be neutral. Take a
+position. The user can override, but fence-sitting wastes everyone's time.
+
+**Apply YAGNI ruthlessly.** If an approach adds flexibility "in case we need it later," flag that as
+speculative complexity. Propose the simplest approach that solves the stated problem. If the user
+wants extensibility, they'll ask.
+
+**Visual comparison (optional).** If the approaches involve architectural differences (data flow,
+component structure, system boundaries), use `Skill` to invoke `visual-explainer:generate-web-diagram`
+to render a side-by-side comparison diagram. This is especially valuable for:
+- Pipeline/workflow designs with different topologies
+- Component architectures with different boundaries
+- Data flow alternatives (push vs. pull, sync vs. async)
+
+Do NOT generate visuals for trivial choices or when the text description is sufficient. Ask the user
+first: "Would a visual comparison of these approaches help?"
+
+Use `AskUserQuestion` to let the user pick:
+
+```text
+Question: "Which approach do you prefer?"
+Options:
+  - Approach A: [name] — [one-line summary]
+  - Approach B: [name] — [one-line summary]
+  - Approach C: [name] — [one-line summary]
+  - None of these — let me describe what I want
+```
+
+### Step 4: Converge on Design
+
+With the chosen approach, flesh out the design. Present it in sections scaled to complexity:
+
+**For simple features (1 issue):**
+- Approach summary (2-3 sentences)
+- Key decisions (bullet list)
+- Scope boundary (in/out)
+
+**For medium features (2-3 issues):**
+- Approach summary
+- Key decisions with rationale
+- Component breakdown (what pieces need to change)
+- Scope boundary
+- Open questions (if any remain)
+
+**For complex initiatives (epic-level):**
+- Approach summary
+- Architecture overview (components, data flow, interfaces)
+- Decomposition into work units (each becomes an issue)
+- Dependencies between units
+- Scope boundary
+- Risks and mitigations
+- Open questions
+
+**Visual architecture diagram.** For medium and complex work, generate an architecture diagram using
+`Skill` to invoke `visual-explainer:generate-web-diagram`. Show component boundaries, data flow, and
+the decomposition into work units. Present the diagram alongside the architecture overview section.
+
+Present each section and wait for the user to confirm before moving to the next. Do NOT present
+the entire design at once for medium or complex work.
+
+### Step 5: Write Spec Document
+
+Save the approved design to a file:
+
+```bash
+# Ensure the directory exists
+mkdir -p .dev/pm/specs
+```
+
+**File path:** `.dev/pm/specs/YYYY-MM-DD-<topic-slug>.md`
+
+**Spec format:**
+
+```markdown
+# Spec: <Topic>
+
+**Date:** YYYY-MM-DD
+**Status:** Approved
+
+## Problem
+
+<What problem are we solving and why — include the user/stakeholder perspective>
+
+## Chosen Approach
+
+**<Approach name>**
+
+<2-3 paragraph description of the approach, how it works, and why it was chosen over alternatives>
+
+### Alternatives Considered
+
+| Approach | Pros | Cons | Why not |
+|----------|------|------|---------|
+| <Alt 1> | <pros> | <cons> | <reason rejected> |
+| <Alt 2> | <pros> | <cons> | <reason rejected> |
+
+### Key Decisions
+
+- <Decision 1>: <chosen option> — <rationale>
+- <Decision 2>: <chosen option> — <rationale>
+
+### Trade-offs Accepted
+
+- <What we're giving up and why that's acceptable>
+
+## Scope
+
+**In scope:**
+- <item>
+
+**Out of scope:**
+- <item>
+
+## Technical Design
+
+<For simple: 2-3 sentences on the approach>
+<For medium: component breakdown with interfaces>
+<For complex: architecture overview, data flow, key interfaces>
+
+### Files Affected
+
+<List real file paths found during codebase exploration, or "New files" for greenfield>
+
+- `src/path/to/file.ts` — <what changes>
+
+## Work Breakdown
+
+<For simple: skip this section>
+<For medium/complex: numbered list of work units with dependencies>
+
+1. <Unit 1> — <what it does, rough size> [no dependencies]
+2. <Unit 2> — <what it does, rough size> [depends on: 1]
+
+## Open Questions
+
+<Any unresolved items — or "None" if fully resolved>
+```
+
+**Scaling the format:**
+- **Simple** (1 issue): Skip "Alternatives Considered" table, "Work Breakdown", and keep "Technical Design" to 2-3 sentences
+- **Medium** (2-3 issues): Include all sections but keep each concise
+- **Complex** (epic): Full spec — all sections fleshed out, architecture diagram referenced
+
+Commit the spec to git:
+
+```bash
+git add .dev/pm/specs/YYYY-MM-DD-<topic-slug>.md
+git -c commit.gpgsign=false commit -m "docs(brainstorm): <topic-slug> spec"
+```
+
+### Step 6: Self-Review
+
+Before presenting the spec to the user, review it yourself. Check for:
+
+- **Placeholders**: Any "TBD", "TODO", or vague hand-waving? Replace with specifics or mark as
+  `[NEEDS CLARIFICATION: question]`
+- **Contradictions**: Does the scope say X is out but the work breakdown includes it?
+- **Missing rationale**: Every key decision should have a "why" — if one doesn't, add it
+- **Scope creep**: Does the work breakdown include items the user didn't ask for? Remove them
+- **Feasibility gaps**: Does the approach assume something about the codebase that you haven't
+  verified? Use `Grep`/`Read` to confirm
+- **File path accuracy**: Do the files listed in "Files Affected" actually exist? Verify with `Glob`
+
+Fix any issues found inline before proceeding.
+
+### Step 7: User Review
+
+Present the final spec to the user. Show:
+- The topic and chosen approach (one-liner)
+- Key decisions summary
+- Scope summary
+- Work breakdown (if applicable)
+
+Ask explicitly: **"Spec looks good — approve to proceed, or want changes?"**
+
+If the user requests changes, revise the spec (go back to Step 5) and re-present. Loop until
+approved.
+
+### Step 8: Transition
+
+Once approved, present the next steps. The spec at `.dev/pm/specs/YYYY-MM-DD-<topic-slug>.md` is
+designed to feed into two downstream workflows:
+
+**Path A: Issue creation (`/pm`)**
+> Create structured GitHub issues from the spec. The work breakdown maps directly to issues.
+
+**Path B: Implementation planning (`/cdt:plan-task`)**
+> Skip issue creation and go straight to an implementation plan. CDT's architect teammate will
+> use the spec as input.
+
+**Path C: Both**
+> Create issues first (`/pm`), then plan implementation for the top-priority issue (`/cdt`).
+
+Use `AskUserQuestion` to let the user choose:
+
+```text
+Question: "Spec approved. What's next?"
+Options:
+  - Create issues (/pm) — turn the spec into GitHub issues
+  - Plan implementation (/cdt:plan-task) — go straight to implementation planning
+  - Both — create issues first, then plan the first one
+  - Done for now — I'll come back to this later
+```
+
+Do NOT automatically invoke any downstream skill. Let the user choose their path. The spec is
+committed to git — they can come back to it in a future session.
+
+## Principles
+
+- **Depth over breadth** — one good question beats five shallow ones
+- **Take positions** — recommend an approach, don't just list options
+- **YAGNI** — remove speculative features from every design. If they say "might need X later,"
+  acknowledge it and leave it out unless there's a concrete use case now
+- **Scale the process** — a simple feature gets a 10-line spec, not a 2-page design doc
+- **The spec is the contract** — once approved, downstream workflows follow the spec. No
+  re-litigating decisions that were already made
+- **Visuals earn their keep** — generate diagrams only when they clarify something text cannot.
+  A bullet list of 3 components does not need an architecture diagram

--- a/plugins/project-manager/skills/brainstorm/SKILL.md
+++ b/plugins/project-manager/skills/brainstorm/SKILL.md
@@ -332,13 +332,6 @@ Ask explicitly: **"Spec looks good — approve to proceed, or want changes?"**
 If the user requests changes, revise the spec (go back to Step 5) and re-present. Loop until
 approved.
 
-Once approved, commit the spec to git:
-
-```bash
-git add .dev/pm/specs/YYYY-MM-DD-<topic-slug>.md
-git -c commit.gpgsign=false commit -m "docs(brainstorm): <topic-slug> spec"
-```
-
 ### Step 8: Transition
 
 Once approved, present the next steps. The spec at `.dev/pm/specs/YYYY-MM-DD-<topic-slug>.md` is

--- a/plugins/project-manager/skills/brainstorm/SKILL.md
+++ b/plugins/project-manager/skills/brainstorm/SKILL.md
@@ -80,6 +80,12 @@ in Step 2.
 1. Context → 2. Clarify → 3. Propose → 4. Converge → 5. Write Spec → 6. Self-Review → 7. User Review → 8. Transition
 ```
 
+**Visual workflow overview.** After completing Step 1 (context gathering), if the
+`visual-explainer:generate-web-diagram` skill is available, invoke it to show the user an
+interactive workflow diagram — the 8 steps as a flowchart with the current step highlighted and
+the review loop (Step 7 → Step 5) shown as a feedback edge. This gives the user a visual map
+of the process they're about to go through. Skip this if visual-explainer is not installed.
+
 ### Step 1: Explore Context
 
 Before asking any questions, gather context silently:
@@ -139,9 +145,10 @@ position. The user can override, but fence-sitting wastes everyone's time.
 speculative complexity. Propose the simplest approach that solves the stated problem. If the user
 wants extensibility, they'll ask.
 
-**Visual comparison (optional).** If the approaches involve architectural differences (data flow,
-component structure, system boundaries), use `Skill` to invoke `visual-explainer:generate-web-diagram`
-to render a side-by-side comparison diagram. This is especially valuable for:
+**Visual comparison (optional, requires visual-explainer plugin).** If the approaches involve
+architectural differences (data flow, component structure, system boundaries) and the
+`visual-explainer:generate-web-diagram` skill is available, invoke it to render a side-by-side
+comparison diagram. This is especially valuable for:
 - Pipeline/workflow designs with different topologies
 - Component architectures with different boundaries
 - Data flow alternatives (push vs. pull, sync vs. async)
@@ -199,9 +206,10 @@ If the topic is about a different project (see Step 1 cross-project note), ask t
 relevant file paths or architecture details instead of exploring. Mark all paths in the spec as
 `[unverified — user-provided]` so downstream consumers know to check them.
 
-**Visual architecture diagram.** For medium and complex work, generate an architecture diagram using
-`Skill` to invoke `visual-explainer:generate-web-diagram`. Show component boundaries, data flow, and
-the decomposition into work units. Present the diagram alongside the architecture overview section.
+**Visual architecture diagram (requires visual-explainer plugin).** For medium and complex work, if
+`visual-explainer:generate-web-diagram` is available, generate an architecture diagram showing
+component boundaries, data flow, and the decomposition into work units. Present the diagram
+alongside the architecture overview section. Skip if visual-explainer is not installed.
 
 For medium and complex work, present each section and wait for the user to confirm before moving
 to the next. For simple features, present the full design at once.

--- a/plugins/project-manager/skills/brainstorm/SKILL.md
+++ b/plugins/project-manager/skills/brainstorm/SKILL.md
@@ -93,7 +93,7 @@ Before asking any questions, gather context silently:
 1. **Project awareness**: Read the project's README, CLAUDE.md, or similar docs to understand what this project does
 2. **Recent work**: Run `git log --oneline -20` to see recent direction
 3. **Relevant code**: If the user mentioned a specific area, use `Glob` and `Grep` to survey it
-4. **Existing issues**: Run `gh issue list --limit 10 --state open` to check for related work
+4. **Existing issues**: Check if `gh` is available and authenticated, then run `gh issue list --limit 10 --state open` to check for related work. If `gh` is not available or not authenticated, skip this step silently — it's informational, not blocking.
 
 **Cross-project topics.** If the user's topic is about a different project than the current working
 directory (e.g., they ask about their Express API while you're in a skills marketplace repo),
@@ -223,7 +223,9 @@ Save the approved design to a file:
 mkdir -p .dev/pm/specs
 ```
 
-**File path:** `.dev/pm/specs/YYYY-MM-DD-<topic-slug>.md`
+**File path:** `.dev/pm/specs/$(date +%Y-%m-%d)-<topic-slug>.md`
+
+Use the `date` command to resolve the date — do not hardcode or guess the current date.
 
 **Before writing, determine the complexity tier.** This controls which sections to include:
 
@@ -243,7 +245,7 @@ was filled in mechanically without thinking about what the reader needs.
 # Spec: <Topic>
 
 **Date:** YYYY-MM-DD
-**Status:** Approved
+**Status:** Draft
 
 ## Problem
 
@@ -317,7 +319,8 @@ Before presenting the spec to the user, review it yourself. Check for:
 - **Scope creep**: Does the work breakdown include items the user didn't ask for? Remove them
 - **Feasibility gaps**: Does the approach assume something about the codebase that you haven't
   verified? Use `Grep`/`Read` to confirm
-- **File path accuracy**: Do the files listed in "Files Affected" actually exist? Verify with `Glob`
+- **File path accuracy**: Do the files listed in "Files Affected" actually exist? Verify with `Glob`.
+  Skip this check for cross-project paths marked `[unverified — user-provided]`
 
 Fix any issues found inline before proceeding.
 
@@ -332,7 +335,7 @@ Present the final spec to the user. Show:
 Ask explicitly: **"Spec looks good — approve to proceed, or want changes?"**
 
 If the user requests changes, revise the spec (go back to Step 5) and re-present. Loop until
-approved.
+approved. Once approved, update the spec's `**Status:**` from `Draft` to `Approved`.
 
 ### Step 8: Transition
 

--- a/plugins/project-manager/skills/brainstorm/SKILL.md
+++ b/plugins/project-manager/skills/brainstorm/SKILL.md
@@ -113,6 +113,13 @@ Before asking any questions, gather context silently:
 3. **Relevant code**: If the user mentioned a specific area, use `Glob` and `Grep` to survey it
 4. **Existing issues**: Run `gh issue list --limit 10 --state open` to check for related work
 
+**Cross-project topics.** If the user's topic is about a different project than the current working
+directory (e.g., they ask about their Express API while you're in a skills marketplace repo),
+acknowledge this in Step 2. You can still brainstorm effectively — use `WebSearch` to research
+the domain, ask the user for relevant file paths or architecture details, and note in the spec's
+"Files Affected" section that paths are assumed and should be verified. Do not fabricate file
+paths you cannot confirm.
+
 Do NOT dump this research back at the user. Use it to ask smarter questions in Step 2.
 
 ### Step 2: Clarify Intent
@@ -212,6 +219,10 @@ With the chosen approach, flesh out the design. Present it in sections scaled to
 Do NOT present the design without grounding it in the actual codebase. An ungrounded design produces
 an ungrounded spec, which produces vague issues, which agents execute poorly.
 
+If the topic is about a different project (see Step 1 cross-project note), ask the user for
+relevant file paths or architecture details instead of exploring. Mark all paths in the spec as
+`[unverified — user-provided]` so downstream consumers know to check them.
+
 **Visual architecture diagram.** For medium and complex work, generate an architecture diagram using
 `Skill` to invoke `visual-explainer:generate-web-diagram`. Show component boundaries, data flow, and
 the decomposition into work units. Present the diagram alongside the architecture overview section.
@@ -230,7 +241,19 @@ mkdir -p .dev/pm/specs
 
 **File path:** `.dev/pm/specs/YYYY-MM-DD-<topic-slug>.md`
 
-**Spec format:**
+**Before writing, determine the complexity tier.** This controls which sections to include:
+
+| Tier | Criteria | Sections to include |
+|------|----------|-------------------|
+| **Simple** (1 issue) | Single component, no structural changes | Problem, Chosen Approach (no Alternatives table), Key Decisions, Scope, Technical Design (2-3 sentences), Files Affected, Open Questions |
+| **Medium** (2-3 issues) | Multiple components or interfaces | All sections, each concise |
+| **Complex** (epic) | 3+ work units, cross-cutting concerns | All sections fully fleshed out, architecture diagram referenced |
+
+Omit sections that don't apply to the tier. A simple spec with an Alternatives Considered table
+and Work Breakdown is over-engineered — it signals the tier was misclassified or the template
+was filled in mechanically without thinking about what the reader needs.
+
+**Spec template** (include only the sections appropriate for the tier):
 
 ```markdown
 # Spec: <Topic>
@@ -249,6 +272,7 @@ mkdir -p .dev/pm/specs
 <2-3 paragraph description of the approach, how it works, and why it was chosen over alternatives>
 
 ### Alternatives Considered
+<!-- MEDIUM and COMPLEX only — omit for SIMPLE -->
 
 | Approach | Pros | Cons | Why not |
 |----------|------|------|---------|
@@ -274,9 +298,9 @@ mkdir -p .dev/pm/specs
 
 ## Technical Design
 
-<For simple: 2-3 sentences on the approach>
-<For medium: component breakdown with interfaces>
-<For complex: architecture overview, data flow, key interfaces>
+<SIMPLE: 2-3 sentences on the approach>
+<MEDIUM: component breakdown with interfaces>
+<COMPLEX: architecture overview, data flow, key interfaces>
 
 ### Files Affected
 
@@ -285,9 +309,7 @@ mkdir -p .dev/pm/specs
 - `src/path/to/file.ts` — <what changes>
 
 ## Work Breakdown
-
-<For simple: skip this section>
-<For medium/complex: numbered list of work units with dependencies>
+<!-- MEDIUM and COMPLEX only — omit for SIMPLE -->
 
 1. <Unit 1> — <what it does, rough size> [no dependencies]
 2. <Unit 2> — <what it does, rough size> [depends on: 1]
@@ -296,11 +318,6 @@ mkdir -p .dev/pm/specs
 
 <Any unresolved items — or "None" if fully resolved>
 ```
-
-**Scaling the format:**
-- **Simple** (1 issue): Skip "Alternatives Considered" table, "Work Breakdown", and keep "Technical Design" to 2-3 sentences
-- **Medium** (2-3 issues): Include all sections but keep each concise
-- **Complex** (epic): Full spec — all sections fleshed out, architecture diagram referenced
 
 Do NOT commit yet — the self-review and user review may require changes.
 
@@ -359,7 +376,7 @@ Options:
 ```
 
 Do NOT automatically invoke any downstream skill. Let the user choose their path. The spec is
-committed to git — they can come back to it in a future session.
+saved to `.dev/pm/specs/` — they can come back to it in a future session.
 
 ## Principles
 

--- a/plugins/project-manager/skills/pm/SKILL.md
+++ b/plugins/project-manager/skills/pm/SKILL.md
@@ -80,7 +80,8 @@ Otherwise, continue with the Ambiguity Check below.
 Before starting the Create Issue Workflow, check for existing specs and assess readiness.
 
 **Check for existing specs.** Use `Glob` to find specs in `.dev/pm/specs/*.md`, then `Read` the
-most recent candidates to check topic relevance and status. If a spec exists that matches the
+most recent candidates to check topic relevance and status. If multiple specs match, prefer the
+most recent by date prefix in the filename. If a spec exists that matches the
 user's topic **and its status is `Approved`**, use it as primary context for the Create Issue
 Workflow — the brainstorming was already completed. Skip the ambiguity check and proceed directly.
 If the matching spec's status is `Draft` (or missing), do not bypass ambiguity handling — the

--- a/plugins/project-manager/skills/pm/SKILL.md
+++ b/plugins/project-manager/skills/pm/SKILL.md
@@ -79,16 +79,14 @@ Otherwise, continue with the Ambiguity Check below.
 
 Before starting the Create Issue Workflow, check for existing specs and assess readiness.
 
-**Check for existing specs.** Look for relevant specs in `.dev/pm/specs/`:
+**Check for existing specs.** Use `Glob` to find specs in `.dev/pm/specs/*.md`, then `Read` the
+most recent candidates to check topic relevance and status. If a spec exists that matches the
+user's topic **and its status is `Approved`**, use it as primary context for the Create Issue
+Workflow — the brainstorming was already completed. Skip the ambiguity check and proceed directly.
+If the matching spec's status is `Draft` (or missing), do not bypass ambiguity handling — the
+brainstorm hasn't been approved yet. Continue with the assessment below.
 
-```bash
-ls -t .dev/pm/specs/*.md 2>/dev/null | head -5
-```
-
-If a spec exists that matches the user's topic, use it as primary context for the Create Issue
-Workflow — the brainstorming was already done. Skip the ambiguity check and proceed directly.
-
-**Assess ambiguity.** If no matching spec exists, check for these ambiguity signals:
+**Assess ambiguity.** If no matching Approved spec exists, check for these ambiguity signals:
 
 | Signal | Examples |
 |--------|----------|
@@ -108,9 +106,9 @@ Options:
   - No, create the issue directly — I know what I want
 ```
 
-If the user chooses brainstorming, invoke `/pm:brainstorm` with the original request as arguments.
-If the user chooses to proceed directly, or if fewer than two signals are present, continue with
-the Create Issue Workflow below.
+If the user chooses brainstorming, invoke `/pm:brainstorm` with the original request as arguments;
+otherwise (user chose to proceed directly, or fewer than two signals present), continue with the
+Create Issue Workflow below.
 
 Do NOT block on this check — it is a recommendation, not a gate. Clear requests like "fix the
 login crash" or "add a health check label" should flow straight through without asking.

--- a/plugins/project-manager/skills/pm/SKILL.md
+++ b/plugins/project-manager/skills/pm/SKILL.md
@@ -28,7 +28,7 @@ metadata:
 
 # Project Manager
 
-GitHub issue lifecycle: **create**, **triage**, **audit**, and **review**.
+GitHub issue lifecycle: **brainstorm**, **create**, **triage**, **audit**, and **review**.
 
 ## Sub-Skills
 
@@ -68,14 +68,27 @@ Parse the first argument:
 | `-quick [desc]` | Create Issue Workflow (quick mode) below |
 | anything else / empty | Create Issue Workflow below |
 
-If routed to a sub-skill, invoke it with `Skill` and pass remaining arguments. Otherwise, continue with the Ambiguity Check below.
+If routed to a sub-skill, invoke it with `Skill` and pass remaining arguments. If the first
+argument is `-quick`, skip the Ambiguity Check and go directly to the Create Issue Workflow
+(quick mode is an explicit signal that the user wants fast issue creation, not brainstorming).
+Otherwise, continue with the Ambiguity Check below.
 
 ---
 
 ## Ambiguity Check
 
-Before starting the Create Issue Workflow, assess whether the request is ready for issue creation
-or would benefit from brainstorming first. Check for these ambiguity signals:
+Before starting the Create Issue Workflow, check for existing specs and assess readiness.
+
+**Check for existing specs.** Look for relevant specs in `.dev/pm/specs/`:
+
+```bash
+ls -t .dev/pm/specs/*.md 2>/dev/null | head -5
+```
+
+If a spec exists that matches the user's topic, use it as primary context for the Create Issue
+Workflow — the brainstorming was already done. Skip the ambiguity check and proceed directly.
+
+**Assess ambiguity.** If no matching spec exists, check for these ambiguity signals:
 
 | Signal | Examples |
 |--------|----------|

--- a/plugins/project-manager/skills/pm/SKILL.md
+++ b/plugins/project-manager/skills/pm/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: pm
 description: >-
-  Project manager for GitHub issues: create structured issues optimized for LLM
-  agent teams, triage and recommend what to work on next, audit and clean up
-  stale issues, or deep-validate a single issue against the codebase. Triggers:
-  create issue, plan work, new task, project manager, write ticket, draft issue,
-  plan feature, plan project, start project, create ticket, review issue, pm.
+  Project manager for GitHub issues: brainstorm design approaches, create
+  structured issues optimized for LLM agent teams, triage and recommend what to
+  work on next, audit and clean up stale issues, or deep-validate a single issue
+  against the codebase. Triggers: create issue, plan work, new task, project
+  manager, write ticket, draft issue, plan feature, plan project, start project,
+  create ticket, review issue, brainstorm, explore idea, think through, pm.
 user-invocable: true
-argument-hint: "[next | update | review ISSUE_NUMBER | -quick <description>]"
+argument-hint: "[brainstorm | next | update | review ISSUE_NUMBER | -quick <description>]"
 allowed-tools:
   - Task
   - Skill

--- a/plugins/project-manager/skills/pm/SKILL.md
+++ b/plugins/project-manager/skills/pm/SKILL.md
@@ -67,7 +67,39 @@ Parse the first argument:
 | `-quick [desc]` | Create Issue Workflow (quick mode) below |
 | anything else / empty | Create Issue Workflow below |
 
-If routed to a sub-skill, invoke it with `Skill` and pass remaining arguments. Otherwise, continue with the Create Issue Workflow below.
+If routed to a sub-skill, invoke it with `Skill` and pass remaining arguments. Otherwise, continue with the Ambiguity Check below.
+
+---
+
+## Ambiguity Check
+
+Before starting the Create Issue Workflow, assess whether the request is ready for issue creation
+or would benefit from brainstorming first. Check for these ambiguity signals:
+
+| Signal | Examples |
+|--------|----------|
+| Multiple valid approaches | "we need better caching", "rethink the auth flow" |
+| Unclear scope | "improve the plugin system", "make it faster" |
+| No obvious issue type | request doesn't map clearly to bug/feature/refactor/chore |
+| Architecture decision needed | "should we use X or Y", "how should we structure this" |
+| Exploration language | "I'm thinking about...", "what if we...", "I'm not sure how to..." |
+
+If **two or more** signals are present, suggest brainstorming before issue creation:
+
+```text
+Question: "This sounds like it could benefit from brainstorming before creating issues —
+there are multiple approaches and the scope isn't fully defined yet. Want to explore first?"
+Options:
+  - Yes, brainstorm first (/pm:brainstorm) — explore approaches and produce a spec
+  - No, create the issue directly — I know what I want
+```
+
+If the user chooses brainstorming, invoke `/pm:brainstorm` with the original request as arguments.
+If the user chooses to proceed directly, or if fewer than two signals are present, continue with
+the Create Issue Workflow below.
+
+Do NOT block on this check — it is a recommendation, not a gate. Clear requests like "fix the
+login crash" or "add a health check label" should flow straight through without asking.
 
 ---
 

--- a/plugins/project-manager/skills/pm/SKILL.md
+++ b/plugins/project-manager/skills/pm/SKILL.md
@@ -34,6 +34,7 @@ GitHub issue lifecycle: **create**, **triage**, **audit**, and **review**.
 | Skill | Command | Description |
 |-------|---------|-------------|
 | Create | `/pm` or `/pm -quick <desc>` | Create structured issues optimized for agent execution |
+| Brainstorm | `/pm:brainstorm` | Explore problem space and design approaches before creating issues |
 | Next | `/pm:next` | Triage open issues — recommend what to work on next |
 | Update | `/pm:update` | Audit open issues — find stale, orphaned, and drift |
 | Review | `/pm:review ISSUE_NUMBER` | Deep-validate a single issue against the codebase |
@@ -43,6 +44,8 @@ GitHub issue lifecycle: **create**, **triage**, **audit**, and **review**.
 ```text
 /pm                       → Create a new issue (interactive flow)
 /pm -quick fix the login  → Create issue with smart defaults
+/pm brainstorm caching    → Explore approaches before creating issues
+/pm:brainstorm            → Same (alternate syntax)
 /pm next                  → Triage: recommend next issue to work on
 /pm:next                  → Same (alternate syntax)
 /pm update                → Audit: find stale/orphaned issues
@@ -57,6 +60,7 @@ Parse the first argument:
 
 | Argument | Route to |
 |----------|----------|
+| `brainstorm` | `/pm:brainstorm` sub-skill |
 | `next` | `/pm:next` sub-skill |
 | `update` | `/pm:update` sub-skill |
 | `review` | `/pm:review` sub-skill |


### PR DESCRIPTION
## Summary

- Add `/pm:brainstorm` skill — an 8-step workflow for exploring problem space, proposing 2-3 approaches with trade-offs, and producing an approved spec document before issue creation
- Spec output at `.dev/pm/specs/` feeds into both `/pm` (issue creation) and `/cdt` (implementation planning)
- Add ambiguity check to `/pm` router — detects vague requests (unclear scope, multiple approaches, exploration language) and suggests brainstorming first
- Key patterns: single-question discipline, hard gate preventing premature issue creation, YAGNI enforcement, tiered spec scaling (simple/medium/complex)
- Visual diagram support via `visual-explainer` plugin for architecture comparisons
- Cross-project brainstorming handled explicitly (when topic differs from current working directory)

Inspired by the brainstorming skill from [obra/superpowers](https://github.com/obra/superpowers), adapted for the project-manager plugin's issue lifecycle.

## Changes

| File | Change |
|------|--------|
| `plugins/project-manager/skills/brainstorm/SKILL.md` | **New** — brainstorm skill (8-step workflow) |
| `plugins/project-manager/skills/pm/SKILL.md` | Ambiguity check + routing for brainstorm |
| `plugins/project-manager/README.md` | Brainstorm workflow diagram, skills table, usage examples |
| `docs/learnings.md` | Two new patterns from eval runs |
| `CLAUDE.md` | Added `/pm:brainstorm` trigger |

## Eval Results

Ran 3 test cases (with-skill vs baseline) using skill-creator evals:

| Test Case | With Skill | Baseline | Key Finding |
|-----------|-----------|----------|-------------|
| Rate limiting (clear) | Structured spec, 3 clarifying questions, alternatives table | Implementation guide, jumped to solution | Skill asks before acting |
| Plugin discovery (ambiguous) | Full spec, 5-unit work breakdown, dependencies | Also produced spec (near-parity) | Complex prompts naturally elicit structure |
| Health check (mismatched) | Reframed request into plugin health-check skill | Correctly refused ("no API") | **Star result** — skill explores intent, doesn't execute literally |

Pass rate: 96% (24/25 structural assertions). One soft fail: conciseness threshold too tight for a legitimately detailed simple spec.

## Test plan

- [ ] Invoke `/pm:brainstorm caching` — verify 8-step workflow executes
- [ ] Invoke `/pm` with a vague request like "rethink our auth" — verify ambiguity check suggests brainstorming
- [ ] Invoke `/pm` with a clear request like "fix the login crash" — verify it flows through without brainstorm suggestion
- [ ] Verify `bun scripts/validate-plugins.mjs` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-invocable "/pm:brainstorm" command for structured design exploration: interactive clarification, multiple approaches with trade-offs, codebase-grounded specs, and a hard gate preventing downstream issue/implementation actions until an Approved spec exists.
  * Project manager now non-blockingly recommends brainstorming for ambiguous or multi-faceted requests and supports alternate invocation syntax.

* **Documentation**
  * Expanded docs with a detailed Brainstorm workflow, examples, lifecycle ordering, template/templating learnings, and updated skill trigger wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->