### PR TITLE
fix(dlc): remove CI early-exit gate that blocks pr-check and rebase

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -748,13 +748,13 @@ External review tools (Codacy, CodeRabbit, Qodo) report findings via the GitHub 
 **Rule:** CI failures gate only the final "ready to merge" decision — never intermediate steps like pr-check or rebase.
 
 **Bad** — CI gates the entire pipeline:
-```
+```text
 Step 1: CI fails → Stop (pr-check never runs → review-tool check never clears → deadlock)
 Step 2: Only reached if CI passes (rebase blocked for no reason)
 ```
 
 **Good** — CI tracked as a flag, decision deferred:
-```
+```text
 Step 1: CI fails → set CI_STATUS=failing, continue
 Step 2: Rebase always (branch freshness ≠ CI health)
 Step 3: pr-check always (may resolve review-tool CI failures)

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -745,4 +745,4 @@ When a babysit/loop agent has context from a prior cycle ("I resolved all 3 thre
 
 External review tools (Codacy, CodeRabbit, Qodo) report findings via the GitHub Checks API — their check appears as "failed" even though the failure is unresolved review comments, not broken code. If a babysit/loop workflow gates all subsequent steps behind "CI must pass," it creates a deadlock: pr-check never runs to address the review comments, so the review-tool check never clears, so pr-check never runs. Fix: (1) CI failures should not block pr-check or rebase — only the final "ready to merge" assessment should require passing CI. (2) When `gh run list` returns no matching runs for a failing check, the check is from an external tool with no logs — skip auto-fix classification and continue the workflow. (3) Rebase is a branch-freshness operation unrelated to CI health and should never be gated behind CI status.
 
-> Source: `plugins/dlc/skills/babysit/SKILL.md` Steps 1, 1b, 2, 4
+> Source: [PR #203](https://github.com/rube-de/cc-skills/pull/203) — `plugins/dlc/skills/babysit/SKILL.md` Steps 1, 1b, 2, 4

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -743,6 +743,22 @@ When a babysit/loop agent has context from a prior cycle ("I resolved all 3 thre
 
 ### CI early-exit blocks pr-check for review-tool checks
 
-External review tools (Codacy, CodeRabbit, Qodo) report findings via the GitHub Checks API — their check appears as "failed" even though the failure is unresolved review comments, not broken code. If a babysit/loop workflow gates all subsequent steps behind "CI must pass," it creates a deadlock: pr-check never runs to address the review comments, so the review-tool check never clears, so pr-check never runs. Fix: (1) CI failures should not block pr-check or rebase — only the final "ready to merge" assessment should require passing CI. (2) When `gh run list` returns no matching runs for a failing check, the check is from an external tool with no logs — skip auto-fix classification and continue the workflow. (3) Rebase is a branch-freshness operation unrelated to CI health and should never be gated behind CI status.
+External review tools (Codacy, CodeRabbit, Qodo) report findings via the GitHub Checks API — their check appears as "failed" even though the failure is unresolved review comments, not broken code. If a babysit/loop workflow gates all subsequent steps behind "CI must pass," it creates a deadlock: pr-check never runs to address the review comments, so the review-tool check never clears, so pr-check never runs.
+
+**Rule:** CI failures gate only the final "ready to merge" decision — never intermediate steps like pr-check or rebase.
+
+**Bad** — CI gates the entire pipeline:
+```
+Step 1: CI fails → Stop (pr-check never runs → review-tool check never clears → deadlock)
+Step 2: Only reached if CI passes (rebase blocked for no reason)
+```
+
+**Good** — CI tracked as a flag, decision deferred:
+```
+Step 1: CI fails → set CI_STATUS=failing, continue
+Step 2: Rebase always (branch freshness ≠ CI health)
+Step 3: pr-check always (may resolve review-tool CI failures)
+Step 4: Only declare "ready to merge" if CI_STATUS=passing
+```
 
 > Source: [PR #203](https://github.com/rube-de/cc-skills/pull/203) — `plugins/dlc/skills/babysit/SKILL.md` Steps 1, 1b, 2, 4

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -740,3 +740,9 @@ When `dlc:pr-check` runs inside `dlc:babysit` (via `/loop`), no human is at the 
 When a babysit/loop agent has context from a prior cycle ("I resolved all 3 threads"), it will rationalize skipping a step if the wording reads as conditional — e.g., "Delegate all review comment handling to X" implies "if there's review work." But bot reviewers (Copilot, CodeRabbit, Gemini) post new comments after every push, so prior-cycle state is always stale. Fix: add an explicit "always run, never skip" directive with the rationale, so the agent understands *why* it can't rely on its memory of the previous cycle.
 
 > Source: [Issue #200](https://github.com/rube-de/cc-skills/issues/200) — `plugins/dlc/skills/babysit/SKILL.md` Step 3
+
+### CI early-exit blocks pr-check for review-tool checks
+
+External review tools (Codacy, CodeRabbit, Qodo) report findings via the GitHub Checks API — their check appears as "failed" even though the failure is unresolved review comments, not broken code. If a babysit/loop workflow gates all subsequent steps behind "CI must pass," it creates a deadlock: pr-check never runs to address the review comments, so the review-tool check never clears, so pr-check never runs. Fix: (1) CI failures should not block pr-check or rebase — only the final "ready to merge" assessment should require passing CI. (2) When `gh run list` returns no matching runs for a failing check, the check is from an external tool with no logs — skip auto-fix classification and continue the workflow. (3) Rebase is a branch-freshness operation unrelated to CI health and should never be gated behind CI status.
+
+> Source: `plugins/dlc/skills/babysit/SKILL.md` Steps 1, 1b, 2, 4

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -85,16 +85,14 @@ gh pr checks $PR_NUMBER --json name,state,bucket
 
 Categorize each check by its `bucket` field:
 - **Running**: `bucket` is `pending`
-- **Failed**: `bucket` is `fail`
+- **Failed**: `bucket` is `fail` or `cancel` — cancelled checks are not passing per GitHub required-check semantics
 - **Passed**: `bucket` is `pass`
-- **Neutral**: `bucket` is `skipping` or `cancel` — treat as non-blocking (not a failure)
+- **Neutral**: `bucket` is `skipping` — treat as non-blocking (not a failure)
 
 **If any checks are still running:**
 Stop without printing anything. This is the normal waiting state — no point acting on incomplete results.
 
-**If ALL checks passed:** Set `CI_STATUS=passing`. Continue to Step 2.
-
-**If NO checks exist:** Set `CI_STATUS=passing`. Continue to Step 2. The repo may not have CI configured.
+**If ALL checks passed or neutral (no pending/fail/cancel), or NO checks exist:** Set `CI_STATUS=passing`. Continue to Step 2.
 
 **If any checks failed:** Set `CI_STATUS=failing` and record the failing check names. Continue to Step 1b (attempt auto-fix).
 
@@ -267,10 +265,10 @@ gh pr checks $PR_NUMBER --json name,state,bucket
 gh pr view $PR_NUMBER --json reviewDecision,mergeable
 ```
 
-Categorize the fresh check results by `bucket` field (same logic as Step 1 — `pending`, `fail`, `pass`, `skipping`, `cancel`):
+Categorize the fresh check results by `bucket` field (same logic as Step 1 — `fail`/`cancel` = failed, `pass` = passed, `skipping` = neutral, `pending` = running):
 - **If any checks are still running** (`bucket` is `pending`): Stop silently — CI is incomplete on the new HEAD. Next cycle will re-evaluate.
-- **If ALL checks passed (or neutral/no checks exist):** Set `CI_STATUS=passing`.
-- **If any checks failed:** Set `CI_STATUS=failing` and record the fresh failing check names (replacing any stale values from Step 1).
+- **If ALL checks passed or neutral (no pending/fail/cancel), or NO checks exist:** Set `CI_STATUS=passing`.
+- **If any checks failed** (`bucket` is `fail` or `cancel`): Set `CI_STATUS=failing` and record the fresh failing check names (replacing any stale values from Step 1).
 
 Evaluate the following conditions **in order**. The first matching condition wins:
 
@@ -289,6 +287,7 @@ These are discussion items that need human judgment — design decisions, archit
 
 **If pr-check reported remaining unresolved items (and 0 Discussion-Deferred):**
 - Notify: `💬 PR #<number> has <count> unresolved items after auto-fix. Review needed. <url>`
+- Write state key `unresolved:<count>`.
 - Stop. Next cycle will re-check.
 
 **If CI_STATUS is `failing`:**

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -27,6 +27,7 @@ Notifications are deduplicated via a state file at `.dev/dlc/babysit-<PR_NUMBER>
 - `needs_decision:<count>` (e.g., `needs_decision:2`)
 - `needs_decision:<count>,unresolved:<count>` (e.g., `needs_decision:2,unresolved:3`)
 - `unresolved:<count>`
+- `unresolved:<count>,ci_failing:<sorted_check_names>`
 - `ready`
 - `closed:<state>`
 
@@ -285,7 +286,13 @@ These are discussion items that need human judgment — design decisions, archit
 - Do NOT self-cancel — the PR may still need further cycles after the human decides.
 - Stop. Next cycle will re-check (if the human resolved them, pr-check will see the replies).
 
-**If pr-check reported remaining unresolved items (and 0 Discussion-Deferred):**
+**If pr-check reported remaining unresolved items (and 0 Discussion-Deferred) AND CI_STATUS is `failing`:**
+Both need attention — surface both in a single notification so CI failure isn't hidden behind unresolved items.
+- Notify: `💬 PR #<number> has <count> unresolved items after auto-fix + CI failing: <check_names>. <url>`
+- Write state key `unresolved:<count>,ci_failing:<sorted_check_names>`.
+- Stop. Next cycle will re-check.
+
+**If pr-check reported remaining unresolved items (and 0 Discussion-Deferred) AND CI_STATUS is `passing`:**
 - Notify: `💬 PR #<number> has <count> unresolved items after auto-fix. Review needed. <url>`
 - Write state key `unresolved:<count>`.
 - Stop. Next cycle will re-check.

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -23,7 +23,6 @@ Notifications are deduplicated via a state file at `.dev/dlc/babysit-<PR_NUMBER>
 
 - `ci_failing:<sorted_check_names>` (e.g., `ci_failing:build,lint`)
 - `rebase_conflict:<sorted_file_list>`
-- `needs_review`
 - `needs_decision:<count>` (e.g., `needs_decision:2`)
 - `needs_decision:<count>,unresolved:<count>` (e.g., `needs_decision:2,unresolved:3`)
 - `unresolved:<count>`
@@ -58,6 +57,7 @@ If no PR exists for the current branch, stop silently.
 Extract and store: PR_NUMBER, PR_TITLE, PR_BRANCH, BASE_BRANCH, PR_STATE, PR_URL, REVIEW_DECISION, MERGEABLE.
 
 **State gate:** If PR_STATE is not `OPEN`:
+- Write state key `closed:<state>`.
 - Notify: `PR #<number> is <state>. Babysit cancelled.`
 - Self-cancel (see Cancellation Pattern below) and stop.
 
@@ -227,6 +227,7 @@ git rebase --abort
 ```
 
 Notify: `⚠️ Rebase conflict on PR #<number> — could not auto-resolve. File(s): <conflicting_files>. <url>`
+Write state key `rebase_conflict:<sorted_file_list>`.
 Stop.
 
 ## Step 3: Run PR Review Check

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -154,7 +154,7 @@ Cannot auto-fix, but do NOT stop here. Continue to Step 2 with `CI_STATUS=failin
 
 Do not notify after a successful fix attempt — this is routine automation. Stop silently and let the next cycle check the result.
 
-**Stop vs. continue rule for Step 1b:** Only stop if you **pushed commits** (fix or re-run) — CI needs to re-run on the new HEAD and continuing would reason about stale state. If no commits were pushed (unknown failure, no logs found), continue to Step 2.
+**Stop vs. continue rule for Step 1b:** Only stop if you **pushed commits** (after applying a fix) **or re-ran jobs** with `gh run rerun` — either action makes the current CI state stale, and the next cycle should evaluate the fresh result. If neither commits were pushed nor jobs were re-run (unknown failure, no logs found), continue to Step 2.
 
 ## Step 2: Auto-Rebase
 
@@ -266,7 +266,10 @@ gh pr checks $PR_NUMBER --json name,state,bucket
 gh pr view $PR_NUMBER --json reviewDecision,mergeable
 ```
 
-Update `CI_STATUS` based on the fresh check results — pr-check's fixes may have cleared previously failing review-tool checks.
+Categorize the fresh check results by `bucket` field (same logic as Step 1):
+- **If any checks are still running** (`bucket` is `pending`): Stop silently — CI is incomplete on the new HEAD. Next cycle will re-evaluate.
+- **If ALL checks passed or NO checks exist:** Set `CI_STATUS=passing`.
+- **If any checks failed:** Set `CI_STATUS=failing` and record the fresh failing check names (replacing any stale values from Step 1).
 
 Evaluate the following conditions **in order**. The first matching condition wins:
 
@@ -289,6 +292,7 @@ These are discussion items that need human judgment — design decisions, archit
 
 **If CI_STATUS is `failing`:**
 - Notify: `🔴 CI failing on PR #<number>: <title> — Failed: <check_names>. <url>/checks`
+- Write state key `ci_failing:<sorted_check_names>`.
 - Stop. Next cycle will re-check in Step 1.
 
 **If reviewDecision is CHANGES_REQUESTED:**
@@ -299,6 +303,7 @@ Stop silently. Re-review was already requested in Step 3. Next cycle will re-che
 - Stop. Next cycle will attempt rebase in Step 2.
 
 **If pr-check reported 0 remaining unresolved items AND 0 Discussion-Deferred AND CI_STATUS is `passing` AND reviewDecision is APPROVED (or empty) AND mergeable is MERGEABLE:**
+- Write state key `ready`.
 - Notify: `✅ PR #<number> ready to merge! — <title> — <url>`
 - Self-cancel and stop.
 

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -87,6 +87,7 @@ Categorize each check by its `bucket` field:
 - **Running**: `bucket` is `pending`
 - **Failed**: `bucket` is `fail`
 - **Passed**: `bucket` is `pass`
+- **Neutral**: `bucket` is `skipping` or `cancel` — treat as non-blocking (not a failure)
 
 **If any checks are still running:**
 Stop without printing anything. This is the normal waiting state — no point acting on incomplete results.
@@ -266,9 +267,9 @@ gh pr checks $PR_NUMBER --json name,state,bucket
 gh pr view $PR_NUMBER --json reviewDecision,mergeable
 ```
 
-Categorize the fresh check results by `bucket` field (same logic as Step 1):
+Categorize the fresh check results by `bucket` field (same logic as Step 1 — `pending`, `fail`, `pass`, `skipping`, `cancel`):
 - **If any checks are still running** (`bucket` is `pending`): Stop silently — CI is incomplete on the new HEAD. Next cycle will re-evaluate.
-- **If ALL checks passed or NO checks exist:** Set `CI_STATUS=passing`.
+- **If ALL checks passed (or neutral/no checks exist):** Set `CI_STATUS=passing`.
 - **If any checks failed:** Set `CI_STATUS=failing` and record the fresh failing check names (replacing any stale values from Step 1).
 
 Evaluate the following conditions **in order**. The first matching condition wins:

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -22,7 +22,6 @@ Only print status messages for **errors that need human attention** and **comple
 Notifications are deduplicated via a state file at `.dev/dlc/babysit-<PR_NUMBER>.state`. The file contains a single-line **status key**:
 
 - `ci_failing:<sorted_check_names>` (e.g., `ci_failing:build,lint`)
-- `ci_unfixable:<sorted_check_names>`
 - `rebase_conflict:<sorted_file_list>`
 - `needs_review`
 - `needs_decision:<count>` (e.g., `needs_decision:2`)
@@ -90,13 +89,13 @@ Categorize each check by its `bucket` field:
 - **Passed**: `bucket` is `pass`
 
 **If any checks are still running:**
-Stop without printing anything. This is the normal waiting state.
+Stop without printing anything. This is the normal waiting state — no point acting on incomplete results.
 
-**If any checks failed:** Continue to Step 1b (attempt auto-fix).
+**If ALL checks passed:** Set `CI_STATUS=passing`. Continue to Step 2.
 
-**If NO checks exist:** Continue to Step 2. The repo may not have CI configured.
+**If NO checks exist:** Set `CI_STATUS=passing`. Continue to Step 2. The repo may not have CI configured.
 
-**If ALL checks passed:** Continue to Step 2.
+**If any checks failed:** Set `CI_STATUS=failing` and record the failing check names. Continue to Step 1b (attempt auto-fix).
 
 ## Step 1b: Attempt CI Auto-Fix
 
@@ -119,6 +118,9 @@ gh run view <RUN_ID> --log-failed 2>&1 | tail -200
 
 Collect and combine log output from all failing runs before classifying.
 
+**If no failing runs are found** (e.g., the check is from an external review tool like Codacy, CodeRabbit, or Qodo that reports status via the Checks API but has no GitHub Actions run logs):
+Skip classification — there is nothing to auto-fix. Continue to Step 2 with `CI_STATUS=failing`.
+
 ### Classify and fix
 
 Analyze the log output and classify the failure:
@@ -126,7 +128,7 @@ Analyze the log output and classify the failure:
 **Lint / format errors** (eslint, prettier, ruff, clippy, etc.):
 1. Run the project's lint-fix command (look for it in `package.json` scripts, `Makefile`, `justfile`, or CI config)
 2. Stage, commit with message: `fix: auto-fix lint errors`, and push
-3. Stop — CI will re-run. Next cycle checks the result.
+3. Stop — CI will re-run on the new HEAD. Next cycle checks the result.
 
 **Type errors** (tsc, mypy, pyright, etc.):
 1. Read the erroring files and fix the type issues
@@ -148,12 +150,15 @@ Analyze the log output and classify the failure:
 2. Stop — next cycle checks the result.
 
 **Unknown / cannot diagnose:**
-Notify: `🔴 CI failing on PR #<number>: <title> — Failed: <check_names> — could not auto-fix. <url>/checks`
-Stop.
+Cannot auto-fix, but do NOT stop here. Continue to Step 2 with `CI_STATUS=failing`. The failing checks may be resolved by pr-check (e.g., review-tool checks that clear once their comments are addressed).
 
 Do not notify after a successful fix attempt — this is routine automation. Stop silently and let the next cycle check the result.
 
+**Stop vs. continue rule for Step 1b:** Only stop if you **pushed commits** (fix or re-run) — CI needs to re-run on the new HEAD and continuing would reason about stale state. If no commits were pushed (unknown failure, no logs found), continue to Step 2.
+
 ## Step 2: Auto-Rebase
+
+Rebase is about branch freshness, not CI health. Always attempt it regardless of `CI_STATUS`.
 
 Check if the branch is behind the base branch:
 
@@ -178,7 +183,7 @@ git rebase origin/$BASE_BRANCH
 git push --force-with-lease
 ```
 
-Stop silently — CI needs to re-run. Next cycle will check the results.
+Stop silently — CI needs to re-run on the new HEAD. Next cycle will check the results.
 
 **If rebase hits conflicts — resolve them:**
 
@@ -254,15 +259,16 @@ If pr-check did NOT push commits, skip the re-request — there's nothing new to
 
 ## Step 4: Assess and Notify
 
-After pr-check completes, re-check the PR state:
+After pr-check completes, re-fetch the PR state (pr-check may have pushed commits that changed things):
 
 ```bash
 gh pr checks $PR_NUMBER --json name,state,bucket
 gh pr view $PR_NUMBER --json reviewDecision,mergeable
 ```
 
-**If CI is not fully passing** (any check running or failed):
-Stop silently — next cycle will handle it in Step 1.
+Update `CI_STATUS` based on the fresh check results — pr-check's fixes may have cleared previously failing review-tool checks.
+
+Evaluate the following conditions **in order**. The first matching condition wins:
 
 **If pr-check reported Discussion-Deferred items (count > 0) AND remaining unresolved items:**
 Both need human attention — combine into a single notification so nothing is suppressed.
@@ -277,13 +283,13 @@ These are discussion items that need human judgment — design decisions, archit
 - Do NOT self-cancel — the PR may still need further cycles after the human decides.
 - Stop. Next cycle will re-check (if the human resolved them, pr-check will see the replies).
 
-**If pr-check reported 0 remaining unresolved items AND 0 Discussion-Deferred AND reviewDecision is APPROVED (or empty) AND mergeable is MERGEABLE:**
-- Notify: `✅ PR #<number> ready to merge! — <title> — <url>`
-- Self-cancel and stop.
-
 **If pr-check reported remaining unresolved items (and 0 Discussion-Deferred):**
 - Notify: `💬 PR #<number> has <count> unresolved items after auto-fix. Review needed. <url>`
 - Stop. Next cycle will re-check.
+
+**If CI_STATUS is `failing`:**
+- Notify: `🔴 CI failing on PR #<number>: <title> — Failed: <check_names>. <url>/checks`
+- Stop. Next cycle will re-check in Step 1.
 
 **If reviewDecision is CHANGES_REQUESTED:**
 Stop silently. Re-review was already requested in Step 3. Next cycle will re-check.
@@ -291,6 +297,10 @@ Stop silently. Re-review was already requested in Step 3. Next cycle will re-che
 **If mergeable is CONFLICTING:**
 - Notify: `⚠️ PR #<number> has merge conflicts. <url>`
 - Stop. Next cycle will attempt rebase in Step 2.
+
+**If pr-check reported 0 remaining unresolved items AND 0 Discussion-Deferred AND CI_STATUS is `passing` AND reviewDecision is APPROVED (or empty) AND mergeable is MERGEABLE:**
+- Notify: `✅ PR #<number> ready to merge! — <title> — <url>`
+- Self-cancel and stop.
 
 ## Cancellation Pattern
 


### PR DESCRIPTION
## Summary

- **Fixes deadlock with external review tools** (Codacy, CodeRabbit, Qodo): these tools report findings via the GitHub Checks API, causing babysit's Step 1b to classify them as "unknown CI failure" and stop — preventing pr-check from ever running to resolve the comments that would clear the check.
- **Decouples rebase from CI status**: rebase is a branch-freshness operation, not a code-correctness check. It was unnecessarily gated behind CI passing.
- **Restructures babysit flow to "collect info, decide at the end"**: CI status is tracked as a `CI_STATUS` flag throughout the workflow. Only the final Step 4 assessment uses it to gate the "ready to merge" notification.

### Key changes

| Area | Before | After |
|------|--------|-------|
| Step 1b unknown CI failure | Notify and **stop** | Continue to Step 2 with `CI_STATUS=failing` |
| Step 1b no GH Actions logs | Falls through to "unknown" → stop | Explicit escape: skip classification, continue |
| Step 1b stop rule | Always stop after classification | Only stop if **commits were pushed** (stale state) |
| Step 2 rebase | Only reached if CI passes | Always reached (unless commits pushed in 1b) |
| Step 4 CI check | First condition — silent stop | Evaluated after review items — notifies with 🔴 |
| Step 4 "ready to merge" | Checked before CI failure | Last condition — requires `CI_STATUS=passing` |

## Test plan

- [ ] Run `/dlc:babysit` on a PR where Codacy/CodeRabbit reports a failing check with unresolved comments — verify pr-check runs and addresses comments
- [ ] Run on a PR with a real CI failure (lint/test) — verify it still auto-fixes and stops (pushed commits)
- [ ] Run on a PR that is behind base branch with failing CI — verify rebase still runs
- [ ] Run on a clean PR (all checks pass, no comments) — verify "ready to merge" notification fires
- [ ] Verify deduplication state keys still work (no `ci_unfixable` key in state file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deadlock where CI failures could block pr-check and rebase; rebase and pr-check now run regardless of CI, and merge readiness requires CI passing.
  * External-tool failures without action logs no longer block progress; flow continues and rechecks later.
  * Canceled checks are treated as failures; “skipping” checks are non-blocking.

* **Documentation**
  * Clarified CI-status handling, step sequencing, and when flows stop vs. continue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->