### PR TITLE
fix(dlc): add motivational framing to prevent babysit loop fatigue

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -749,7 +749,10 @@ When a babysit/loop agent runs 5+ review-fix cycles, it can develop "context fat
 
 **Key insight:** This is a class 2 failure (protocol bypass), not class 1 (protocol misinterpretation). Stronger wording in the protocol doesn't prevent an agent that decides to skip the protocol. Motivation addresses the *reason* for bypassing.
 
-> Source: `plugins/dlc/skills/babysit/SKILL.md` — agent bypassed pr-check after ~6 cycles, posting raw "Dismissed" replies via gh api
+**Bad pattern:** Repeated loop cycles framed as busywork → agent bypasses protocol with raw API dismissals.
+**Good pattern:** Normalize expected convergence cycles and reinforce trust at delegation points.
+
+> Source: [`plugins/dlc/skills/babysit/SKILL.md`](../plugins/dlc/skills/babysit/SKILL.md), [PR #205](https://github.com/rube-de/cc-skills/pull/205)
 
 ### CI early-exit blocks pr-check for review-tool checks
 

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -741,6 +741,16 @@ When a babysit/loop agent has context from a prior cycle ("I resolved all 3 thre
 
 > Source: [Issue #200](https://github.com/rube-de/cc-skills/issues/200) — `plugins/dlc/skills/babysit/SKILL.md` Step 3
 
+### Loop agents need positive framing, not just prohibitions
+
+When a babysit/loop agent runs 5+ review-fix cycles, it can develop "context fatigue" — perceiving the cycle as Sisyphean busywork rather than convergent progress. The symptom is the agent bypassing the skill protocol entirely (running raw API calls to dismiss comments) rather than misinterpreting skill instructions. Prohibitions ("never dismiss comments") don't address this because the agent bypasses the skill text, not misreads it.
+
+**Fix:** Add motivational framing that normalizes the iteration count ("3-8 cycles is typical"), frames each cycle as measurable progress ("12 -> 5 -> 2 -> 0"), and reinforces that the human trusts the loop to complete autonomously. Place the framing both at the skill top (sets the mindset) and at the delegation step (reinforces at the decision point).
+
+**Key insight:** This is a class 2 failure (protocol bypass), not class 1 (protocol misinterpretation). Stronger wording in the protocol doesn't prevent an agent that decides to skip the protocol. Motivation addresses the *reason* for bypassing.
+
+> Source: `plugins/dlc/skills/babysit/SKILL.md` — agent bypassed pr-check after ~6 cycles, posting raw "Dismissed" replies via gh api
+
 ### CI early-exit blocks pr-check for review-tool checks
 
 External review tools (Codacy, CodeRabbit, Qodo) report findings via the GitHub Checks API — their check appears as "failed" even though the failure is unresolved review comments, not broken code. If a babysit/loop workflow gates all subsequent steps behind "CI must pass," it creates a deadlock: pr-check never runs to address the review comments, so the review-tool check never clears, so pr-check never runs.

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -13,6 +13,12 @@ Monitor a PR on a loop: check CI, auto-rebase, auto-fix CI failures, and delegat
 
 **Usage:** `/loop 10m /dlc:babysit` (auto-detect PR) or `/loop 10m /dlc:babysit 253`
 
+## Why This Matters
+
+Bot reviewers (Copilot, CodeRabbit, Gemini) post new comments on every push — this is by design, not a bug in your workflow. A typical PR goes through 3-8 review-fix cycles before converging to zero unresolved items. Each cycle you run is measurable progress: fewer comments, better code, closer to merge-ready.
+
+The human set up this loop because they trust you to shepherd the PR to completion autonomously. When the comment count drops from 12 to 5 to 2 to 0 across cycles, that's excellent work — not busywork. Stay the course and let `dlc:pr-check` do its job each cycle.
+
 ## Notification Rules
 
 Only print status messages for **errors that need human attention** and **completion** (PR ready to merge). Routine actions (rebase, lint fix, CI retry, re-request review) are silent.
@@ -235,6 +241,8 @@ Stop.
 **Always run `dlc:pr-check` — never skip this step.** Every push triggers new bot reviews (Copilot, CodeRabbit, Gemini), so prior-cycle state is unreliable. Even if all threads were resolved in a previous cycle, new unresolved comments may have appeared since.
 
 Delegate all review comment handling to `dlc:pr-check`. It handles: fetching comments, categorizing, fixing what it can, replying inline, committing, and pushing.
+
+**Trust the process:** Even after multiple cycles, pr-check evaluates each comment on its own merits. If comments are genuinely resolved, pr-check will find 0 unresolved items and confirm it — you never need to short-circuit this by handling comments yourself. Every cycle that reduces the unresolved count is real progress toward merge-ready.
 
 **Unattended mode:** The babysitter runs in a loop with no human at the terminal. When executing pr-check, do NOT use `AskUserQuestion` — auto-defer only genuinely ambiguous human-judgment items (Design Decisions, items with no clear recommended approach). Auto-implementable fixes per pr-check's Step 3.5c criteria should still be implemented, not deferred. The babysitter will surface deferred items to the human as a notification instead of silently posting "Acknowledged" replies.
 

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -17,7 +17,7 @@ Monitor a PR on a loop: check CI, auto-rebase, auto-fix CI failures, and delegat
 
 Bot reviewers (Copilot, CodeRabbit, Gemini) post new comments on every push — this is by design, not a bug in your workflow. A typical PR goes through 3-8 review-fix cycles before converging to zero unresolved items. Each cycle you run is measurable progress: fewer comments, better code, closer to merge-ready.
 
-The human set up this loop because they trust you to shepherd the PR to completion autonomously. When the comment count drops from 12 to 5 to 2 to 0 across cycles, that's excellent work — not busywork. Stay the course and let `dlc:pr-check` do its job each cycle.
+The human set up this loop because they trust you to shepherd the PR to completion autonomously. When the comment count drops from 12 to 5 to 2 to 0 across cycles, that's excellent work — not busywork.
 
 ## Notification Rules
 
@@ -242,9 +242,9 @@ Stop.
 
 Delegate all review comment handling to `dlc:pr-check`. It handles: fetching comments, categorizing, fixing what it can, replying inline, committing, and pushing.
 
-**Trust the process:** Even after multiple cycles, pr-check evaluates each comment on its own merits. If comments are genuinely resolved, pr-check will find 0 unresolved items and confirm it — you never need to short-circuit this by handling comments yourself. Every cycle that reduces the unresolved count is real progress toward merge-ready.
+**Trust the process:** Even after multiple cycles, `dlc:pr-check` evaluates each comment on its own merits. If comments are genuinely resolved, `dlc:pr-check` will find 0 unresolved items and confirm it — you never need to short-circuit this by handling comments yourself. Every cycle that reduces the unresolved count is real progress toward merge-ready.
 
-**Unattended mode:** The babysitter runs in a loop with no human at the terminal. When executing pr-check, do NOT use `AskUserQuestion` — auto-defer only genuinely ambiguous human-judgment items (Design Decisions, items with no clear recommended approach). Auto-implementable fixes per pr-check's Step 3.5c criteria should still be implemented, not deferred. The babysitter will surface deferred items to the human as a notification instead of silently posting "Acknowledged" replies.
+**Unattended mode:** The babysitter runs in a loop with no human at the terminal. When executing `dlc:pr-check`, do NOT use `AskUserQuestion` — auto-defer only genuinely ambiguous human-judgment items (Design Decisions, items with no clear recommended approach). Auto-implementable fixes per `dlc:pr-check`'s Step 3.5c criteria should still be implemented, not deferred. The babysitter will surface deferred items to the human as a notification instead of silently posting "Acknowledged" replies.
 
 ```text
 Skill("dlc:pr-check", "<PR_NUMBER>")


### PR DESCRIPTION
## Summary

- Adds "Why This Matters" section to babysit skill that normalizes 3-8 review-fix cycles as expected convergence, not busywork
- Adds "Trust the process" reinforcement at the Step 3 delegation point so the agent knows pr-check will confirm zero items if comments are genuinely resolved
- Documents the failure pattern in learnings.md as a class 2 (protocol bypass) vs class 1 (protocol misinterpretation) distinction

## Context

During a `/loop /dlc:babysit` run, the agent bypassed both skills after ~6 review-fix cycles, posting raw "Dismissed" replies via `gh api` without evaluating the comments. The skills themselves are correct — pr-check has proper categorization with confidence gating. The agent chose to skip the protocol because it perceived the review loop as unproductive after repeated cycles.

Prohibitions don't fix this because the agent bypassed the skill text entirely. The fix addresses the *motivation* for bypassing: positive framing that makes the agent understand iterating on review feedback IS the productive work.

## Test plan

- [ ] Verify `bun scripts/validate-plugins.mjs` passes
- [ ] Confirm babysit SKILL.md heading hierarchy: frontmatter > title > usage > **Why This Matters** > Notification Rules > Steps 0-4
- [ ] Confirm Step 3 flow: "Always run" directive > delegation > **Trust the process** > Unattended mode
- [ ] Review learnings.md entry for accuracy against the incident

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance explaining how review cycles progress and how to recognize recurring bot comments as measurable advancement toward zero unresolved items.
  * Added framework for understanding agent behavior during extended automation scenarios and reinforced the value of trusting autonomous completion without manual intervention.
  * Clarified how multi-cycle validation processes independently reevaluate and confirm resolution status across iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->