### PR TITLE
feat(ci-review): add cross-run comment dedup

### DIFF
--- a/plugins/ci-review/README.md
+++ b/plugins/ci-review/README.md
@@ -46,7 +46,7 @@ jobs:
           prompt: |
             /ci-review ${{ github.event.pull_request.number }} ${{ contains(fromJSON('["opened","reopened","ready_for_review"]'), github.event.action) && '--lean' || '--single' }}
           claude_args: |
-            --allowedTools "Read,Grep,Glob,Agent,Bash(gh auth status:*),Bash(gh pr:*),Bash(gh repo view:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews:*),Bash(git branch:*),Bash(git rev-parse:*),Bash(git blame:*),Bash(jq:*),Bash(echo:*),Bash(cat:*)"
+            --allowedTools "Read,Grep,Glob,Agent,Bash(gh auth status:*),Bash(gh pr:*),Bash(gh repo view:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments:*),Bash(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments:*),Bash(sh *fetch-pr-comments.sh:*),Bash(git branch:*),Bash(git rev-parse:*),Bash(git blame:*),Bash(jq:*),Bash(echo:*),Bash(cat:*)"
 ```
 
 This gives you the best cost/coverage tradeoff: full multi-agent review once on open (~6 agents), then cheap single-agent reviews on each push (~1 agent + confidence scoring).
@@ -182,7 +182,8 @@ claude plugin install ci-review@rube-cc-skills
 │  3. Gather Context (parallel)                           │
 │     ├── gh pr diff (full diff, warns if >10K lines)     │
 │     ├── gh pr view --json (metadata)                    │
-│     └── Discover CLAUDE.md files                        │
+│     ├── Discover CLAUDE.md files                        │
+│     └── Fetch existing PR comments (cross-run dedup)    │
 │                                                         │
 │  3.5. Checkout PR branch — agents need file access      │
 │                                                         │
@@ -197,7 +198,8 @@ claude plugin install ci-review@rube-cc-skills
 │     ├── Score 0-100 (is this factually correct?)        │
 │     ├── Confidence filter: drop findings < 65           │
 │     ├── Severity filter: drop below --min-severity      │
-│     └── Deduplicate: exact match + near match (±5 lines)│
+│     ├── Deduplicate: exact match + near match (±5 lines)│
+│     └── Existing comment dedup: skip already-flagged    │
 │                                                         │
 │  6. Build Review Payload                                │
 │     ├── Inline comments (file:line in diff)             │

--- a/plugins/ci-review/README.md
+++ b/plugins/ci-review/README.md
@@ -46,7 +46,7 @@ jobs:
           prompt: |
             /ci-review ${{ github.event.pull_request.number }} ${{ contains(fromJSON('["opened","reopened","ready_for_review"]'), github.event.action) && '--lean' || '--single' }}
           claude_args: |
-            --allowedTools "Read,Grep,Glob,Agent,Bash(gh auth status:*),Bash(gh pr:*),Bash(gh repo view:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments:*),Bash(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments:*),Bash(sh *fetch-pr-comments.sh:*),Bash(git branch:*),Bash(git rev-parse:*),Bash(git blame:*),Bash(jq:*),Bash(echo:*),Bash(cat:*)"
+            --allowedTools "Read,Grep,Glob,Agent,Bash(gh auth status:*),Bash(gh pr:*),Bash(gh repo view:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments:*),Bash(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments:*),Bash(sh *scripts/fetch-pr-comments.sh:*),Bash(git branch:*),Bash(git rev-parse:*),Bash(git blame:*),Bash(jq:*),Bash(echo:*),Bash(cat:*)"
 ```
 
 This gives you the best cost/coverage tradeoff: full multi-agent review once on open (~6 agents), then cheap single-agent reviews on each push (~1 agent + confidence scoring).

--- a/plugins/ci-review/scripts/fetch-pr-comments.sh
+++ b/plugins/ci-review/scripts/fetch-pr-comments.sh
@@ -21,7 +21,7 @@ die_json() {
 
 command -v gh >/dev/null 2>&1  || die_json "gh CLI not found — install from https://cli.github.com" "GH_NOT_FOUND"
 command -v jq >/dev/null 2>&1  || die_json "jq not found — install from https://jqlang.github.io/jq" "JQ_NOT_FOUND"
-gh auth status >/dev/null 2>&1 || die_json "gh not authenticated — run: gh auth login" "GH_AUTH"
+gh auth status >/dev/null || die_json "gh not authenticated — run: gh auth login" "GH_AUTH"
 
 # --- arg parsing -----------------------------------------------------------
 
@@ -41,7 +41,7 @@ if [ -n "$OWNER_REPO" ]; then
   OWNER=$(printf '%s\n' "$OWNER_REPO" | cut -d/ -f1)
   REPO=$(printf '%s\n' "$OWNER_REPO" | cut -d/ -f2)
 else
-  _repo_json=$(gh repo view --json owner,name 2>/dev/null) || die_json "Could not detect repository — pass OWNER/REPO as argument" "REPO_DETECT"
+  _repo_json=$(gh repo view --json owner,name) || die_json "Could not detect repository — pass OWNER/REPO as argument" "REPO_DETECT"
   OWNER=$(printf '%s\n' "$_repo_json" | jq -r '.owner.login')
   REPO=$(printf '%s\n' "$_repo_json" | jq -r '.name')
 fi
@@ -53,7 +53,7 @@ fi
 # --- PR number detection ---------------------------------------------------
 
 if [ -z "$PR_NUMBER" ]; then
-  PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null) || die_json "No PR found for current branch — push and open a PR first" "PR_DETECT"
+  PR_NUMBER=$(gh pr view --json number -q .number) || die_json "No PR found for current branch — push and open a PR first" "PR_DETECT"
 fi
 
 if [ -z "$PR_NUMBER" ] || ! printf '%s\n' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
@@ -95,12 +95,14 @@ jq -n \
   ($reviews | add // []) as $all_reviews |
 
   # Inline comments: filter empty bodies, extract dedup fields
+  # Truncate bodies to 2000 chars — enough for content-signal matching
+  # without bloating LLM context on comment-heavy PRs
   [ $all_inline[] |
     select(.body != null and (.body | gsub("\\s"; "") | length > 0)) |
     {
       path: .path,
       line: (.line // .original_line // null),
-      body: .body,
+      body: (.body | .[0:2000]),
       author: (.user.login // "ghost"),
       created_at: .created_at
     }
@@ -110,7 +112,7 @@ jq -n \
   [ $all_pr[] |
     select(.body != null and (.body | gsub("\\s"; "") | length > 0)) |
     {
-      body: .body,
+      body: (.body | .[0:2000]),
       author: (.user.login // "ghost"),
       created_at: .created_at
     }
@@ -120,7 +122,7 @@ jq -n \
   [ $all_reviews[] |
     select(.body != null and (.body | gsub("\\s"; "") | length > 0)) |
     {
-      body: .body,
+      body: (.body | .[0:2000]),
       author: (.user.login // "ghost"),
       state: .state,
       created_at: .submitted_at
@@ -137,4 +139,4 @@ jq -n \
       total_review_bodies: ($review_bodies | length)
     }
   }
-'
+' || die_json "Failed to transform fetched comment payloads" "TRANSFORM_FAILED"

--- a/plugins/ci-review/scripts/fetch-pr-comments.sh
+++ b/plugins/ci-review/scripts/fetch-pr-comments.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+# fetch-pr-comments.sh — Fetch existing PR comments for cross-run dedup
+# Usage: fetch-pr-comments.sh [PR_NUMBER] [OWNER/REPO]
+# Returns structured JSON with inline comments, PR comments, and review bodies.
+# Uses REST API with gh api --paginate for automatic pagination.
+
+# --- helpers ---------------------------------------------------------------
+
+die_json() {
+  _code="${2:-UNKNOWN}"
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --arg err "$1" --arg code "$_code" '{error: $err, code: $code}' >&2
+  else
+    _err_escaped=$(printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr '\n' ' ')
+    printf '{"error":"%s","code":"%s"}\n' "$_err_escaped" "$_code" >&2
+  fi
+  exit 1
+}
+
+# --- prerequisites ---------------------------------------------------------
+
+command -v gh >/dev/null 2>&1  || die_json "gh CLI not found — install from https://cli.github.com" "GH_NOT_FOUND"
+command -v jq >/dev/null 2>&1  || die_json "jq not found — install from https://jqlang.github.io/jq" "JQ_NOT_FOUND"
+gh auth status >/dev/null 2>&1 || die_json "gh not authenticated — run: gh auth login" "GH_AUTH"
+
+# --- arg parsing -----------------------------------------------------------
+
+PR_NUMBER=""
+OWNER_REPO=""
+
+for arg in "$@"; do
+  case "$arg" in
+    */*) OWNER_REPO="$arg" ;;
+    *)   PR_NUMBER="$arg"  ;;
+  esac
+done
+
+# --- repo detection --------------------------------------------------------
+
+if [ -n "$OWNER_REPO" ]; then
+  OWNER=$(printf '%s\n' "$OWNER_REPO" | cut -d/ -f1)
+  REPO=$(printf '%s\n' "$OWNER_REPO" | cut -d/ -f2)
+else
+  _repo_json=$(gh repo view --json owner,name 2>/dev/null) || die_json "Could not detect repository — pass OWNER/REPO as argument" "REPO_DETECT"
+  OWNER=$(printf '%s\n' "$_repo_json" | jq -r '.owner.login')
+  REPO=$(printf '%s\n' "$_repo_json" | jq -r '.name')
+fi
+
+if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
+  die_json "Could not parse owner/repo" "REPO_PARSE"
+fi
+
+# --- PR number detection ---------------------------------------------------
+
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null) || die_json "No PR found for current branch — push and open a PR first" "PR_DETECT"
+fi
+
+if [ -z "$PR_NUMBER" ] || ! printf '%s\n' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+  die_json "Invalid PR number: ${PR_NUMBER}" "PR_INVALID"
+fi
+
+# --- temp files & cleanup --------------------------------------------------
+
+_tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/fetch-pr-comments.XXXXXX") || die_json "Failed to create temporary directory" "TMPDIR_CREATE"
+trap 'rm -rf "$_tmpdir"' EXIT
+
+# --- fetch REST endpoints --------------------------------------------------
+
+# Inline review comments (file path + line number + body)
+gh api --paginate "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments" \
+  > "$_tmpdir/inline_raw.json" 2>"$_tmpdir/inline_err.txt" \
+  || die_json "Failed to fetch inline comments: $(cat "$_tmpdir/inline_err.txt")" "INLINE_FETCH"
+
+# General PR-level comments (body only, no file association)
+gh api --paginate "repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" \
+  > "$_tmpdir/pr_raw.json" 2>"$_tmpdir/pr_err.txt" \
+  || die_json "Failed to fetch PR comments: $(cat "$_tmpdir/pr_err.txt")" "PR_COMMENTS_FETCH"
+
+# Review bodies (summary text at top of each review)
+gh api --paginate "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/reviews" \
+  > "$_tmpdir/reviews_raw.json" 2>"$_tmpdir/reviews_err.txt" \
+  || die_json "Failed to fetch reviews: $(cat "$_tmpdir/reviews_err.txt")" "REVIEWS_FETCH"
+
+# --- jq transform ----------------------------------------------------------
+
+jq -n \
+  --slurpfile inline "$_tmpdir/inline_raw.json" \
+  --slurpfile pr "$_tmpdir/pr_raw.json" \
+  --slurpfile reviews "$_tmpdir/reviews_raw.json" \
+'
+  # Merge paginated arrays (--paginate outputs one array per page)
+  ($inline | add // []) as $all_inline |
+  ($pr | add // []) as $all_pr |
+  ($reviews | add // []) as $all_reviews |
+
+  # Inline comments: filter empty bodies, extract dedup fields
+  [ $all_inline[] |
+    select(.body != null and (.body | gsub("\\s"; "") | length > 0)) |
+    {
+      path: .path,
+      line: (.line // .original_line // null),
+      body: .body,
+      author: (.user.login // "ghost"),
+      created_at: .created_at
+    }
+  ] as $inline_comments |
+
+  # PR-level comments: filter empty bodies
+  [ $all_pr[] |
+    select(.body != null and (.body | gsub("\\s"; "") | length > 0)) |
+    {
+      body: .body,
+      author: (.user.login // "ghost"),
+      created_at: .created_at
+    }
+  ] as $pr_comments |
+
+  # Review bodies: filter empty bodies
+  [ $all_reviews[] |
+    select(.body != null and (.body | gsub("\\s"; "") | length > 0)) |
+    {
+      body: .body,
+      author: (.user.login // "ghost"),
+      state: .state,
+      created_at: .submitted_at
+    }
+  ] as $review_bodies |
+
+  {
+    inline_comments: $inline_comments,
+    pr_comments: $pr_comments,
+    review_bodies: $review_bodies,
+    summary: {
+      total_inline: ($inline_comments | length),
+      total_pr_comments: ($pr_comments | length),
+      total_review_bodies: ($review_bodies | length)
+    }
+  }
+'

--- a/plugins/ci-review/scripts/fetch-pr-comments.sh
+++ b/plugins/ci-review/scripts/fetch-pr-comments.sh
@@ -21,7 +21,7 @@ die_json() {
 
 command -v gh >/dev/null 2>&1  || die_json "gh CLI not found — install from https://cli.github.com" "GH_NOT_FOUND"
 command -v jq >/dev/null 2>&1  || die_json "jq not found — install from https://jqlang.github.io/jq" "JQ_NOT_FOUND"
-gh auth status >/dev/null || die_json "gh not authenticated — run: gh auth login" "GH_AUTH"
+gh auth status >/dev/null 2>&1 || die_json "gh not authenticated — run: gh auth login" "GH_AUTH"
 
 # --- arg parsing -----------------------------------------------------------
 
@@ -41,7 +41,7 @@ if [ -n "$OWNER_REPO" ]; then
   OWNER=$(printf '%s\n' "$OWNER_REPO" | cut -d/ -f1)
   REPO=$(printf '%s\n' "$OWNER_REPO" | cut -d/ -f2)
 else
-  _repo_json=$(gh repo view --json owner,name) || die_json "Could not detect repository — pass OWNER/REPO as argument" "REPO_DETECT"
+  _repo_json=$(gh repo view --json owner,name 2>/dev/null) || die_json "Could not detect repository — pass OWNER/REPO as argument" "REPO_DETECT"
   OWNER=$(printf '%s\n' "$_repo_json" | jq -r '.owner.login')
   REPO=$(printf '%s\n' "$_repo_json" | jq -r '.name')
 fi
@@ -53,7 +53,7 @@ fi
 # --- PR number detection ---------------------------------------------------
 
 if [ -z "$PR_NUMBER" ]; then
-  PR_NUMBER=$(gh pr view --json number -q .number) || die_json "No PR found for current branch — push and open a PR first" "PR_DETECT"
+  PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null) || die_json "No PR found for current branch — push and open a PR first" "PR_DETECT"
 fi
 
 if [ -z "$PR_NUMBER" ] || ! printf '%s\n' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -250,12 +250,17 @@ For each surviving finding that has a `file` and `line`:
    - At least one content signal matches
 
 For findings without a `file` (body-only findings):
-1. Search `EXISTING_COMMENTS.pr_comments` and `EXISTING_COMMENTS.review_bodies` for content signal matches only
+1. Search `EXISTING_COMMENTS.pr_comments` and `EXISTING_COMMENTS.review_bodies` for comments where:
+   - The comment body mentions a **file path** related to the finding's context (or the finding's description references the same area), AND
+   - A **key phrase** match exists (see below)
+   - Both conditions are required — body-only matching without a location anchor is too loose and would suppress unrelated architectural findings
 
-**Content signal matching** — any ONE of these suffices (case-insensitive):
-- **Severity tag**: the comment body contains the finding's severity (e.g., `[high]`, `**[high]**`, `high`)
+**Content signal matching** — to avoid false negatives from overly broad matches, require a **key phrase match** or **two or more** of the following signals (case-insensitive):
+- **Severity tag**: the comment body contains the finding's severity in a tag-like context (e.g., `[high]`, `**[high]**`)
 - **Type keyword**: the comment body contains the finding's type keyword (`bug`, `security`, `error-handling`, `quality`, `review`, `guidelines`, `test-coverage`, `comment-accuracy`, `type-design`)
-- **Key phrases**: extract 2–3 significant noun phrases from the finding description (the core issue — e.g., "SQL injection", "null check", "race condition", "missing validation") and check if any appear in the comment body
+- **Key phrases** (strongest signal): extract 2–3 significant noun phrases from the finding description (the core issue — e.g., "SQL injection", "null check", "race condition", "missing validation") and check if any appear in the comment body. A key phrase match alone is sufficient — it is specific enough to confirm the same issue.
+
+A single generic signal (severity tag alone or type keyword alone) is NOT sufficient — common words like `high`, `bug`, or `review` appear in many unrelated comments and would suppress distinct findings near the same location.
 
 **Matching policy:**
 - Match generously — better to skip a potential duplicate than to re-post noise

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -101,7 +101,7 @@ Print: "Reviewing PR #N: {title} ({url}) — profile: {single|lean|full|agent}"
 
 ### Step 3: Gather Context (Parallel)
 
-Launch these three operations in parallel via Bash:
+Launch these four operations in parallel via Bash:
 
 **3a. Fetch PR diff:**
 ```bash
@@ -116,11 +116,24 @@ gh pr view <PR#> --json title,body,headRefName,baseRefName,files,additions,delet
 **3c. Discover CLAUDE.md files:**
 Search for CLAUDE.md files in the repo root and in directories containing changed files. Use `Glob` to find `**/CLAUDE.md` and `Read` to load the root CLAUDE.md and any others relevant to the changed files. **Preserve scope:** prefix each file's contents with its path (e.g., `### /CLAUDE.md`, `### /packages/api/CLAUDE.md`) so agents know which rules apply to which directories.
 
+**3d. Fetch existing PR comments:**
+Run the `fetch-pr-comments.sh` script to retrieve all existing comments on this PR (inline review comments, PR-level comments, and review bodies from all authors):
+```bash
+sh ../../scripts/fetch-pr-comments.sh <PR#>
+```
+Store the JSON output as `EXISTING_COMMENTS`. If the script fails (non-zero exit, or stderr contains `{"error":...}`), log a warning and continue — cross-run dedup is best-effort. On failure, set `EXISTING_COMMENTS` to:
+```json
+{"inline_comments":[],"pr_comments":[],"review_bodies":[],"summary":{"total_inline":0,"total_pr_comments":0,"total_review_bodies":0}}
+```
+
+Print: "Fetched {total_inline} inline comments, {total_pr_comments} PR comments, {total_review_bodies} review bodies for cross-run dedup."
+
 Compile the context bundle:
 - `PR_DIFF`: the full diff text
 - `PR_META`: title, body, branch names, file list, stats
 - `CLAUDE_MD`: path-prefixed CLAUDE.md contents (or "No CLAUDE.md found")
 - `FOCUS`: the focus text (or empty)
+- `EXISTING_COMMENTS`: structured JSON of all existing PR comments (for cross-run dedup in Step 5)
 
 **Large diffs:** If the diff exceeds 10,000 lines, warn: "Large diff ({N} lines) — review quality may degrade for files not near the top of the diff." Do not truncate — let agents handle context naturally. They can always `Read` individual files for deeper investigation.
 
@@ -222,6 +235,34 @@ Wait for all scorers to complete. Collect their scores.
 2. **Near match**: same file and lines within 5 of each other, describing the same root cause → keep the higher-scored one, note the other agent in the `Found by:` tag (e.g., `Found by: bug-detector, security-reviewer`)
 3. **Semantic overlap**: different files or lines but describing the same conceptual issue (e.g., "missing null check on user input" flagged independently by bug-detector and security-reviewer at two call sites) → these are NOT duplicates — keep both, they're separate instances of the same pattern
 
+**Existing comment dedup:** After within-run dedup, check each surviving finding against `EXISTING_COMMENTS` to skip findings already covered by prior comments on this PR. This prevents duplicate postings across multiple ci-review runs, and avoids piling on when humans or other bots already flagged the same issue.
+
+For each surviving finding that has a `file` and `line`:
+1. Search `EXISTING_COMMENTS.inline_comments` for any comment where:
+   - `path` matches the finding's file, AND
+   - `line` is within ±5 of the finding's line, AND
+   - At least one **content signal** matches (see below)
+   - If all three conditions match → mark the finding as already-commented and exclude it
+2. If no inline match found, search `EXISTING_COMMENTS.pr_comments` and `EXISTING_COMMENTS.review_bodies`:
+   - The comment body contains the finding's file path, AND
+   - At least one content signal matches
+
+For findings without a `file` (body-only findings):
+1. Search `EXISTING_COMMENTS.pr_comments` and `EXISTING_COMMENTS.review_bodies` for content signal matches only
+
+**Content signal matching** — any ONE of these suffices (case-insensitive):
+- **Severity tag**: the comment body contains the finding's severity (e.g., `[high]`, `**[high]**`, `high`)
+- **Type keyword**: the comment body contains the finding's type keyword (`bug`, `security`, `error-handling`, `quality`, `review`, `guidelines`, `test-coverage`, `comment-accuracy`, `type-design`)
+- **Key phrases**: extract 2–3 significant noun phrases from the finding description (the core issue — e.g., "SQL injection", "null check", "race condition", "missing validation") and check if any appear in the comment body
+
+**Matching policy:**
+- Match generously — better to skip a potential duplicate than to re-post noise
+- All existing comments are checked regardless of author (human reviewers, bots, previous ci-review runs)
+- Resolution status is irrelevant — whether resolved or unresolved, the issue was already flagged
+- String matching is case-insensitive
+
+Track the count of findings excluded by this pass as `EXISTING_DEDUP_COUNT`.
+
 **If no findings survive filtering:** Build a no-findings review body using the template from REVIEW-POSTING.md section 3 ("No Findings"), then skip to Step 7 to post it.
 
 ### Step 6: Build Review Payload
@@ -314,6 +355,7 @@ Agents: N launched, N completed [, N failed]
 Raw findings: N collected
 After confidence scoring (≥65): N survived
 After severity filter (≥{min-severity}): N survived
+Already commented (skipped): N
 Posted: N inline comments + review body
 Review: <URL>
 ```

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -101,7 +101,7 @@ Print: "Reviewing PR #N: {title} ({url}) — profile: {single|lean|full|agent}"
 
 ### Step 3: Gather Context (Parallel)
 
-Launch these four operations in parallel via Bash:
+Launch these four operations in parallel:
 
 **3a. Fetch PR diff:**
 ```bash
@@ -121,7 +121,9 @@ Run the `fetch-pr-comments.sh` script to retrieve all existing comments on this 
 ```bash
 sh ../../scripts/fetch-pr-comments.sh <PR#>
 ```
-Store the JSON output as `EXISTING_COMMENTS`. If the script fails (non-zero exit, or stderr contains `{"error":...}`), log a warning and continue — cross-run dedup is best-effort. On failure, set `EXISTING_COMMENTS` to:
+Store the JSON output as `EXISTING_COMMENTS`. Comment bodies are truncated to 2000 characters by the script to limit context size on comment-heavy PRs — this is sufficient for content-signal matching since actionable content appears early in comments.
+
+If the script fails (non-zero exit, or stderr contains `{"error":...}`), log a warning and continue — cross-run dedup is best-effort. On failure, set `EXISTING_COMMENTS` to:
 ```json
 {"inline_comments":[],"pr_comments":[],"review_bodies":[],"summary":{"total_inline":0,"total_pr_comments":0,"total_review_bodies":0}}
 ```
@@ -238,9 +240,9 @@ Wait for all scorers to complete. Collect their scores.
 **Existing comment dedup:** After within-run dedup, check each surviving finding against `EXISTING_COMMENTS` to skip findings already covered by prior comments on this PR. This prevents duplicate postings across multiple ci-review runs, and avoids piling on when humans or other bots already flagged the same issue.
 
 For each surviving finding that has a `file` and `line`:
-1. Search `EXISTING_COMMENTS.inline_comments` for any comment where:
+1. Search `EXISTING_COMMENTS.inline_comments` for any comment where (skip comments with `line: null`):
    - `path` matches the finding's file, AND
-   - `line` is within ±5 of the finding's line, AND
+   - `line` is numeric and within ±5 of the finding's line, AND
    - At least one **content signal** matches (see below)
    - If all three conditions match → mark the finding as already-commented and exclude it
 2. If no inline match found, search `EXISTING_COMMENTS.pr_comments` and `EXISTING_COMMENTS.review_bodies`:


### PR DESCRIPTION
## Summary

- Adds `fetch-pr-comments.sh` script that fetches all existing PR comments (inline review comments, PR-level comments, review bodies) via REST API with automatic pagination
- Integrates comment fetching into Step 3 (parallel with diff/metadata/CLAUDE.md discovery) and adds an existing-comment dedup pass in Step 5
- Findings already flagged by previous ci-review runs, human reviewers, or other bots are skipped based on file+line proximity (±5 lines) and content signal matching (severity tags, type keywords, key phrases)
- Updates README workflow diagram and `claude_args` allowlist for GitHub Actions

## Test plan

- [x] Shell syntax check passes (`sh -n fetch-pr-comments.sh`)
- [x] Script tested on PR #204: fetched 193 inline, 3 PR, 21 review body comments with correct structure
- [x] Error handling verified: non-existent PR returns structured JSON error on stderr
- [x] Plugin validation passes (`bun scripts/validate-plugins.mjs`)
- [ ] Integration test: run `/ci-review` on a PR with existing comments and verify "Already commented (skipped)" count in summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI review now fetches existing PR comments and reviews (best-effort fallback) and skips findings already covered by prior discussion.
  * Added a CLI tool to emit structured PR discussion data for workflow deduplication.

* **Documentation**
  * Updated docs and example workflow to describe comment retrieval, cross-run deduplication, location-aware matching rules, and run summary reporting (e.g., "Already commented (skipped): N").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->