### PR TITLE
fix(dlc): babysit also checks gh run list for in-progress runs

### DIFF
--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -86,11 +86,12 @@ If checkout fails, stop. Do not proceed with git operations on the wrong branch.
 
 ## Step 1: Check CI Status
 
-Query the named checks **and** the raw workflow runs on the HEAD commit — the two views can disagree. An Action workflow can be `in_progress` or `queued` before (or without ever) registering a named check status, so relying on `gh pr checks` alone will prematurely classify CI as "settled" while bot reviewers are still writing comments. Treat either source reporting activity as a pending state.
+Query the named checks **and** the raw workflow runs on the PR's current HEAD commit — the two views can disagree. An Action workflow can be `in_progress` or `queued` before (or without ever) registering a named check status, so relying on `gh pr checks` alone will prematurely classify CI as "settled" while bot reviewers are still writing comments. Derive a single `PR_HEAD_SHA` from GitHub via `gh pr view --json headRefOid` so both checks evaluate the same commit even if the local checkout falls behind; `--limit 100` keeps reruns and multi-workflow PRs from falling outside the default 20-run window. Treat either source reporting activity as a pending state.
 
 ```bash
+PR_HEAD_SHA=$(gh pr view $PR_NUMBER --json headRefOid --jq '.headRefOid')
 gh pr checks $PR_NUMBER --json name,state,bucket
-IN_PROGRESS_RUNS=$(gh run list --commit $(git rev-parse HEAD) --json status --jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length')
+IN_PROGRESS_RUNS=$(gh run list --commit "$PR_HEAD_SHA" --limit 100 --json status --jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length')
 ```
 
 Categorize each named check by its `bucket` field:
@@ -102,7 +103,7 @@ Categorize each named check by its `bucket` field:
 **If any checks are still running OR `IN_PROGRESS_RUNS > 0`:**
 Stop without printing anything. This is the normal waiting state — no point acting on incomplete results. `IN_PROGRESS_RUNS > 0` catches bot-review workflows (Copilot, CodeRabbit, Codex) that execute via GitHub Actions but may not surface a named check.
 
-**If ALL checks passed or neutral (no pending/fail/cancel) AND `IN_PROGRESS_RUNS == 0`, or NO checks and no runs exist:** Set `CI_STATUS=passing`. Continue to Step 2.
+**If ALL checks passed or neutral (no pending/fail/cancel) AND `IN_PROGRESS_RUNS == 0`, or NO checks and no runs in progress:** Set `CI_STATUS=passing`. Continue to Step 2.
 
 **If any checks failed:** Set `CI_STATUS=failing` and record the failing check names. Continue to Step 1b (attempt auto-fix).
 
@@ -274,14 +275,15 @@ If pr-check did NOT push commits, skip the re-request — there's nothing new to
 After pr-check completes, re-fetch the PR state (pr-check may have pushed commits that changed things). Query both the named checks and the raw workflow runs, same as Step 1 — especially critical here because `pr-check` may have just pushed a commit that triggered new bot-review workflows that take minutes to finish:
 
 ```bash
+PR_HEAD_SHA=$(gh pr view $PR_NUMBER --json headRefOid --jq '.headRefOid')
 gh pr checks $PR_NUMBER --json name,state,bucket
-IN_PROGRESS_RUNS=$(gh run list --commit $(git rev-parse HEAD) --json status --jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length')
+IN_PROGRESS_RUNS=$(gh run list --commit "$PR_HEAD_SHA" --limit 100 --json status --jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length')
 gh pr view $PR_NUMBER --json reviewDecision,mergeable
 ```
 
 Categorize the fresh check results by `bucket` field (same logic as Step 1 — `fail`/`cancel` = failed, `pass` = passed, `skipping` = neutral, `pending` = running):
 - **If any checks are still running** (`bucket` is `pending`) **OR `IN_PROGRESS_RUNS > 0`**: Stop silently — CI is incomplete on the new HEAD. Do NOT take any terminal action (notification + self-cancel) in this state. Next cycle will re-evaluate.
-- **If ALL checks passed or neutral (no pending/fail/cancel) AND `IN_PROGRESS_RUNS == 0`, or NO checks and no runs exist:** Set `CI_STATUS=passing`.
+- **If ALL checks passed or neutral (no pending/fail/cancel) AND `IN_PROGRESS_RUNS == 0`, or NO checks and no runs in progress:** Set `CI_STATUS=passing`.
 - **If any checks failed** (`bucket` is `fail` or `cancel`): Set `CI_STATUS=failing` and record the fresh failing check names (replacing any stale values from Step 1).
 
 Evaluate the following conditions **in order**. The first matching condition wins:

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -86,20 +86,23 @@ If checkout fails, stop. Do not proceed with git operations on the wrong branch.
 
 ## Step 1: Check CI Status
 
+Query the named checks **and** the raw workflow runs on the HEAD commit — the two views can disagree. An Action workflow can be `in_progress` or `queued` before (or without ever) registering a named check status, so relying on `gh pr checks` alone will prematurely classify CI as "settled" while bot reviewers are still writing comments. Treat either source reporting activity as a pending state.
+
 ```bash
 gh pr checks $PR_NUMBER --json name,state,bucket
+IN_PROGRESS_RUNS=$(gh run list --commit $(git rev-parse HEAD) --json status --jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length')
 ```
 
-Categorize each check by its `bucket` field:
+Categorize each named check by its `bucket` field:
 - **Running**: `bucket` is `pending`
 - **Failed**: `bucket` is `fail` or `cancel` — cancelled checks are not passing per GitHub required-check semantics
 - **Passed**: `bucket` is `pass`
 - **Neutral**: `bucket` is `skipping` — treat as non-blocking (not a failure)
 
-**If any checks are still running:**
-Stop without printing anything. This is the normal waiting state — no point acting on incomplete results.
+**If any checks are still running OR `IN_PROGRESS_RUNS > 0`:**
+Stop without printing anything. This is the normal waiting state — no point acting on incomplete results. `IN_PROGRESS_RUNS > 0` catches bot-review workflows (Copilot, CodeRabbit, Codex) that execute via GitHub Actions but may not surface a named check.
 
-**If ALL checks passed or neutral (no pending/fail/cancel), or NO checks exist:** Set `CI_STATUS=passing`. Continue to Step 2.
+**If ALL checks passed or neutral (no pending/fail/cancel) AND `IN_PROGRESS_RUNS == 0`, or NO checks and no runs exist:** Set `CI_STATUS=passing`. Continue to Step 2.
 
 **If any checks failed:** Set `CI_STATUS=failing` and record the failing check names. Continue to Step 1b (attempt auto-fix).
 
@@ -268,16 +271,17 @@ If pr-check did NOT push commits, skip the re-request — there's nothing new to
 
 ## Step 4: Assess and Notify
 
-After pr-check completes, re-fetch the PR state (pr-check may have pushed commits that changed things):
+After pr-check completes, re-fetch the PR state (pr-check may have pushed commits that changed things). Query both the named checks and the raw workflow runs, same as Step 1 — especially critical here because `pr-check` may have just pushed a commit that triggered new bot-review workflows that take minutes to finish:
 
 ```bash
 gh pr checks $PR_NUMBER --json name,state,bucket
+IN_PROGRESS_RUNS=$(gh run list --commit $(git rev-parse HEAD) --json status --jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length')
 gh pr view $PR_NUMBER --json reviewDecision,mergeable
 ```
 
 Categorize the fresh check results by `bucket` field (same logic as Step 1 — `fail`/`cancel` = failed, `pass` = passed, `skipping` = neutral, `pending` = running):
-- **If any checks are still running** (`bucket` is `pending`): Stop silently — CI is incomplete on the new HEAD. Next cycle will re-evaluate.
-- **If ALL checks passed or neutral (no pending/fail/cancel), or NO checks exist:** Set `CI_STATUS=passing`.
+- **If any checks are still running** (`bucket` is `pending`) **OR `IN_PROGRESS_RUNS > 0`**: Stop silently — CI is incomplete on the new HEAD. Do NOT take any terminal action (notification + self-cancel) in this state. Next cycle will re-evaluate.
+- **If ALL checks passed or neutral (no pending/fail/cancel) AND `IN_PROGRESS_RUNS == 0`, or NO checks and no runs exist:** Set `CI_STATUS=passing`.
 - **If any checks failed** (`bucket` is `fail` or `cancel`): Set `CI_STATUS=failing` and record the fresh failing check names (replacing any stale values from Step 1).
 
 Evaluate the following conditions **in order**. The first matching condition wins:

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -86,12 +86,12 @@ If checkout fails, stop. Do not proceed with git operations on the wrong branch.
 
 ## Step 1: Check CI Status
 
-Query the named checks **and** the raw workflow runs on the PR's current HEAD commit — the two views can disagree. An Action workflow can be `in_progress` or `queued` before (or without ever) registering a named check status, so relying on `gh pr checks` alone will prematurely classify CI as "settled" while bot reviewers are still writing comments. Derive a single `PR_HEAD_SHA` from GitHub via `gh pr view --json headRefOid` so both checks evaluate the same commit even if the local checkout falls behind; `--limit 100` keeps reruns and multi-workflow PRs from falling outside the default 20-run window. Treat either source reporting activity as a pending state.
+Query the named checks **and** the raw workflow runs for the PR — the two views can disagree. An Action workflow can be `in_progress`, `queued`, `waiting`, `requested`, or `pending` before (or without ever) registering a named check status, so relying on `gh pr checks` alone will prematurely classify CI as "settled" while bot reviewers are still writing comments. Derive `PR_HEAD_SHA` from GitHub via `gh pr view --json headRefOid` so the `gh run list` query is pinned to the PR's current HEAD commit even if the local checkout falls behind; `gh pr checks $PR_NUMBER` is still read from the PR as usual. The `status != "completed"` filter catches every non-terminal run state (queued, in_progress, waiting, requested, pending). `--limit 100` keeps reruns and multi-workflow PRs from falling outside the default 20-run window. Treat either source reporting activity as a pending state.
 
 ```bash
 PR_HEAD_SHA=$(gh pr view $PR_NUMBER --json headRefOid --jq '.headRefOid')
 gh pr checks $PR_NUMBER --json name,state,bucket
-IN_PROGRESS_RUNS=$(gh run list --commit "$PR_HEAD_SHA" --limit 100 --json status --jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length')
+IN_PROGRESS_RUNS=$(gh run list --commit "$PR_HEAD_SHA" --limit 100 --json status --jq '[.[] | select(.status != "completed")] | length')
 ```
 
 Categorize each named check by its `bucket` field:
@@ -277,7 +277,7 @@ After pr-check completes, re-fetch the PR state (pr-check may have pushed commit
 ```bash
 PR_HEAD_SHA=$(gh pr view $PR_NUMBER --json headRefOid --jq '.headRefOid')
 gh pr checks $PR_NUMBER --json name,state,bucket
-IN_PROGRESS_RUNS=$(gh run list --commit "$PR_HEAD_SHA" --limit 100 --json status --jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length')
+IN_PROGRESS_RUNS=$(gh run list --commit "$PR_HEAD_SHA" --limit 100 --json status --jq '[.[] | select(.status != "completed")] | length')
 gh pr view $PR_NUMBER --json reviewDecision,mergeable
 ```
 


### PR DESCRIPTION
## Summary

- **Bug**: `dlc:babysit` relied on `gh pr checks` alone to decide if CI was settled. That view doesn't surface workflow runs that are `in_progress` or `queued` without registering a named check — which is the common case for bot-review Actions (Copilot code review, CodeRabbit scans, etc.).
- **Symptom**: After a push, `gh pr checks` can report all named checks `pass` while a bot-review workflow is still executing. Babysit hits the "ready to merge" condition, notifies, and self-cancels the loop **before the bot finishes writing its review comments**. Any comments posted after self-cancel are silently missed.
- **Fix**: Add a second query — `gh run list --commit $HEAD_SHA --json status --jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length'` — and treat any non-zero count as equivalent to a pending check. `CI_STATUS=passing` is now only set when **both** sources agree nothing is running. Applied symmetrically in Step 1 and Step 4.

## Why this matters

Found the hard way during a babysit run on PR #210 — babysit self-cancelled while a Copilot code review was still in progress, and I (Claude) had actually flagged the in-progress run in my own caveats before cancelling. Spec took precedence over observable evidence. This fix closes that gap in the spec itself so future runs won't make the same mistake.

## Test plan

- [ ] Push a commit to any PR that triggers bot-review Actions. Run `/dlc:babysit <PR>` **immediately** after push. Verify babysit stops silently with no notification while runs are in_progress, instead of declaring ready.
- [ ] Wait for all runs to finish, re-invoke `/dlc:babysit`. Verify it now correctly classifies CI as passing (both sources agree nothing is running).
- [ ] Check that `gh run list` works on PRs with no Actions workflow at all — returns empty array, `length == 0`, so `IN_PROGRESS_RUNS=0` and CI_STATUS can still transition to passing (doesn't regress PRs without CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI status detection to recognize active workflow runs and derive the current PR commit.
  * Expanded “waiting” state when workflows are in progress or queued, preventing premature continuation.
  * Tightened “passing” criteria to require no in-progress workflows and non-blocking checks.
  * Terminal actions (notifications/cancel) are now withheld while workflows are still running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->