### PR TITLE
feat(dlc): autonomy ladder + halt-on-defer with PushNotification

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -937,3 +937,32 @@ Reply categories: Silent (no post) | Fixed | Dismissed | Answered
 ```
 
 > Source: branch fix/pr-check-silent-on-non-actionable, file: `plugins/dlc/skills/pr-check/SKILL.md`
+
+### `"Acknowledged — will be addressed by the author"` is a dishonest placeholder in unattended mode
+
+`dlc:pr-check` running under `/dlc:babysit` on a `/loop` posted `Acknowledged — will be addressed by the author` replies whenever a Discussion item fell through its conservative auto-implement rules. The bot isn't the author and no human saw the comment, so the reply is a lie — the thread was neither handled nor queued. Two pathologies followed: low-risk items that could have been auto-fixed (rename, typo, null check) got silently deferred, and genuine human-judgment items got buried behind the same polite reply + a terse `Notify:` line that was easy to miss on mobile.
+
+**Root pattern:** The reply text `Acknowledged — will be addressed by the author` was reachable both from an explicit user click ("Defer to author" in `AskUserQuestion`) AND as a silent fallback when `AskUserQuestion` returned empty in a non-interactive loop. The same string served two opposite semantics — an authored decision and a stand-in for "nobody decided" — so the timeline couldn't distinguish them.
+
+**Rule:** The placeholder reply fires if and only if the user explicitly selected the corresponding option in `AskUserQuestion`. Never on empty answers, never as a fallback, never in unattended mode, never on any automated path.
+
+**Fix:**
+1. Introduce an explicit `--unattended` mode in pr-check with a bright-line **Autonomy Ladder** (ten low-risk patterns: rename, typo, comment edit, null check, logging, tighten condition, add validation, extract constant, formatting, reviewer-flagged dead code) that auto-implements without `AskUserQuestion`.
+2. Add a **Pending-Human** classification for items that require human judgment. Pending-Human emits silence — no reply, no Discussion-Deferred assignment. Items are returned via a `Pending-Human: <n> — ...` line in pr-check's Step 6 summary.
+3. In babysit, fire `PushNotification` (a real tool call — not a `Notify:` print line that doesn't ping the device) on Pending-Human, then self-cancel the cron. The halt is the communication.
+4. Add an empty-answer safeguard inside attended mode: if `AskUserQuestion` returns empty, re-ask once; if still empty, reclassify as Pending-Human instead of defaulting to Defer.
+
+**Bad pattern (placeholder as fallback):**
+```text
+AskUserQuestion returns empty → default to "Defer to author" → post "Acknowledged — will be addressed by the author"
+(result: silent acknowledgment with no decision behind it)
+```
+
+**Good pattern (halt loudly; silence is a legitimate outcome):**
+```text
+AskUserQuestion returns empty → re-ask once → still empty → Pending-Human (no reply)
+pr-check Step 6 emits: "Pending-Human: 2 — naming of foo(); async shape"
+babysit fires PushNotification + CronDelete + state file cleanup
+```
+
+> Source: PR implementing issue #212; spec `.dev/pm/specs/2026-04-17-dlc-autonomy-and-halt-on-defer.md`; files: `plugins/dlc/skills/pr-check/**`, `plugins/dlc/skills/babysit/SKILL.md`

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -243,7 +243,7 @@ Delegate all review comment handling to `dlc:pr-check`. It handles: fetching com
 
 **Trust the process:** Even after multiple cycles, `dlc:pr-check` evaluates each comment on its own merits. If comments are genuinely resolved, `dlc:pr-check` will find 0 unresolved items and confirm it — you never need to short-circuit this by handling comments yourself. Every cycle that reduces the unresolved count is real progress toward merge-ready.
 
-**Unattended mode:** The babysitter runs in a loop with no human at the terminal, so invoke `dlc:pr-check` with the `--unattended` flag. That flag activates pr-check's **Autonomy Ladder** (ten low-risk patterns — rename, typo, null check, logging, etc. — always auto-implemented) and its **Pending-Human** classification for items that genuinely need human judgment (architectural trade-offs, product scope, ambiguous fixes). Pending-Human items surface back here through the `Pending-Human: <n> — ...` line in pr-check's Step 6 summary and produce a single `PushNotification` in Step 4. Under `--unattended`, pr-check posts **no** `Acknowledged — will be addressed by the author` replies — the halt is the communication.
+**Context — why unattended mode exists:** The babysitter runs in a loop with no human at the terminal. The invocation below therefore passes `--unattended` so pr-check activates its **Autonomy Ladder** (ten low-risk patterns — rename, typo, null check, logging, etc. — always auto-implemented) and its **Pending-Human** classification for items that genuinely need human judgment (architectural trade-offs, product scope, ambiguous fixes). Pending-Human items surface back here through the `Pending-Human: <n> — ...` line in pr-check's Step 6 summary and produce a single `PushNotification` in Step 4. Under `--unattended`, pr-check posts **no** `Acknowledged — will be addressed by the author` replies — the halt is the communication.
 
 ```text
 Skill("dlc:pr-check", "<PR_NUMBER> --unattended")
@@ -251,7 +251,7 @@ Skill("dlc:pr-check", "<PR_NUMBER> --unattended")
 
 After pr-check completes, parse its output summary to extract these values:
 - Total unresolved items remaining: items marked Fixed, Answered, Resolved, or Dismissed are **done**. Remaining = Total - (Fixed + Answered + Resolved + Dismissed).
-- **Pending-Human count and items**: parse the `Pending-Human: <n> — <item1_short>; <item2_short>; ...` line from the Step 6 summary. The `<n>` is the count; split the tail on `;` (trimming whitespace) to get the per-item short descriptions. If the line is absent, the count is 0. This line is emitted only under `--unattended`.
+- **Pending-Human count and items**: parse the `Pending-Human: <n> — <item1_short>; <item2_short>; ...` line from the Step 6 summary. The `<n>` is the count; split the tail on `;` (trimming whitespace) to get the per-item short descriptions. If the line is absent, the count is 0. This line is emitted only under `--unattended`. Worked example: `Pending-Human: 2 — rename foo to bar; clarify async semantics of handler()` → `count=2`, `items=["rename foo to bar", "clarify async semantics of handler()"]`.
 - Whether pr-check pushed any commits (look for "Pushed" in the summary or a non-empty git diff from before)
 
 If pr-check pushed commits, re-request review from all prior reviewers. Filter out bot accounts (logins ending in `[bot]`):

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -29,6 +29,7 @@ Notifications are deduplicated via a state file at `.dev/dlc/babysit-<PR_NUMBER>
 
 - `ci_failing:<sorted_check_names>` (e.g., `ci_failing:build,lint`)
 - `rebase_conflict:<sorted_file_list>`
+- `merge_conflict`
 - `pending_human:<count>` (count-only dedup, e.g., `pending_human:2`)
 - `unresolved:<count>`
 - `unresolved:<count>,ci_failing:<sorted_check_names>`
@@ -283,7 +284,7 @@ Evaluate the following conditions **in order**. The first matching condition win
 
 **If pr-check reported Pending-Human items (count > 0):**
 These items require human judgment — architectural trade-offs, product scope decisions, or ambiguous fixes with no clear winner. The babysitter cannot resolve them; halt the loop loudly.
-- Build the message body: concatenate the per-item shorts with `; ` separators, leading with the PR number and count. Target under 200 characters total; if longer, truncate trailing items and append `…` so the most important signal fits in a single mobile notification.
+- Build the message body: concatenate the per-item shorts with `;` separators, leading with the PR number and count. Target under 200 characters total; if longer, truncate trailing items and append `…` so the most important signal fits in a single mobile notification.
 - Fire `PushNotification` with message `PR #<number>: <count> items need your call — <item1_short>; <item2_short>`.
 - Write state key `pending_human:<count>` (count-only dedup per spec).
 - Self-cancel (see Cancellation Pattern below) and stop. The user will triage via `/dlc:pr-check <PR>` in attended mode, then relaunch `/loop 10m /dlc:babysit <PR>` when ready to resume.
@@ -309,6 +310,7 @@ Stop silently. Re-review was already requested in Step 3. Next cycle will re-che
 
 **If mergeable is CONFLICTING:**
 - Fire `PushNotification` with message `⚠️ PR #<number> has merge conflicts. <url>`.
+- Write state key `merge_conflict`.
 - Stop. Next cycle will attempt rebase in Step 2.
 
 **If pr-check reported 0 remaining unresolved items AND 0 Pending-Human AND CI_STATUS is `passing` AND reviewDecision is APPROVED (or empty) AND mergeable is MERGEABLE:**
@@ -326,4 +328,4 @@ To self-cancel the babysit loop:
 4. Delete the state file: `.dev/dlc/babysit-<PR_NUMBER>.state`
 5. If no matching task is found, this was a manual invocation — skip cancellation.
 
-**Terminal states that follow this pattern:** `ready`, `closed:<state>`, `pending_human:<count>`. Each emits exactly one `PushNotification`, writes its state key, then runs the cancellation above. Non-terminal branches (`ci_failing:*`, `rebase_conflict:*`, `unresolved:*`) notify and stop without cancelling — the next `/loop` cycle re-evaluates.
+**Terminal states that follow this pattern:** `ready`, `closed:<state>`, `pending_human:<count>`. Each emits exactly one `PushNotification`, writes its state key, then runs the cancellation above. Non-terminal branches (`ci_failing:*`, `rebase_conflict:*`, `merge_conflict`, `unresolved:*`) notify and stop without cancelling — the next `/loop` cycle re-evaluates.

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   PR babysitter: monitors CI status, auto-rebases when behind, auto-fixes CI
   where possible, delegates review comment handling to dlc:pr-check, and
   re-requests review after fixes. Designed for /loop usage with Remote Control.
-allowed-tools: [Bash, Read, Edit, Write, Grep, Glob, Skill, CronList, CronDelete]
+allowed-tools: [Bash, Read, Edit, Write, Grep, Glob, Skill, CronList, CronDelete, PushNotification]
 ---
 
 # DLC: PR Babysitter
@@ -21,7 +21,7 @@ The human set up this loop because they trust you to shepherd the PR to completi
 
 ## Notification Rules
 
-Only print status messages for **errors that need human attention** and **completion** (PR ready to merge). Routine actions (rebase, lint fix, CI retry, re-request review) are silent.
+Only fire `PushNotification` for **errors that need human attention** and **completion** (PR ready to merge). Routine actions (rebase, lint fix, CI retry, re-request review) are silent. `PushNotification` is always the sanctioned channel — never substitute with a `Notify:` print line or `echo`, because print output does not ping the user's device.
 
 ### Deduplication
 
@@ -29,8 +29,7 @@ Notifications are deduplicated via a state file at `.dev/dlc/babysit-<PR_NUMBER>
 
 - `ci_failing:<sorted_check_names>` (e.g., `ci_failing:build,lint`)
 - `rebase_conflict:<sorted_file_list>`
-- `needs_decision:<count>` (e.g., `needs_decision:2`)
-- `needs_decision:<count>,unresolved:<count>` (e.g., `needs_decision:2,unresolved:3`)
+- `pending_human:<count>` (count-only dedup, e.g., `pending_human:2`)
 - `unresolved:<count>`
 - `unresolved:<count>,ci_failing:<sorted_check_names>`
 - `ready`
@@ -64,7 +63,7 @@ Extract and store: PR_NUMBER, PR_TITLE, PR_BRANCH, BASE_BRANCH, PR_STATE, PR_URL
 
 **State gate:** If PR_STATE is not `OPEN`:
 - Write state key `closed:<state>`.
-- Notify: `PR #<number> is <state>. Babysit cancelled.`
+- Fire `PushNotification` with message `PR #<number> is <state>. Babysit cancelled.`
 - Self-cancel (see Cancellation Pattern below) and stop.
 
 ### Verify and checkout PR branch
@@ -232,7 +231,7 @@ Stop silently — CI needs to re-run.
 git rebase --abort
 ```
 
-Notify: `⚠️ Rebase conflict on PR #<number> — could not auto-resolve. File(s): <conflicting_files>. <url>`
+Fire `PushNotification` with message `⚠️ Rebase conflict on PR #<number> — could not auto-resolve. File(s): <conflicting_files>. <url>`.
 Write state key `rebase_conflict:<sorted_file_list>`.
 Stop.
 
@@ -244,15 +243,15 @@ Delegate all review comment handling to `dlc:pr-check`. It handles: fetching com
 
 **Trust the process:** Even after multiple cycles, `dlc:pr-check` evaluates each comment on its own merits. If comments are genuinely resolved, `dlc:pr-check` will find 0 unresolved items and confirm it — you never need to short-circuit this by handling comments yourself. Every cycle that reduces the unresolved count is real progress toward merge-ready.
 
-**Unattended mode:** The babysitter runs in a loop with no human at the terminal. When executing `dlc:pr-check`, do NOT use `AskUserQuestion` — auto-defer only genuinely ambiguous human-judgment items (Design Decisions, items with no clear recommended approach). Auto-implementable fixes per `dlc:pr-check`'s Step 3.5c criteria should still be implemented, not deferred. The babysitter will surface deferred items to the human as a notification instead of silently posting "Acknowledged" replies.
+**Unattended mode:** The babysitter runs in a loop with no human at the terminal, so invoke `dlc:pr-check` with the `--unattended` flag. That flag activates pr-check's **Autonomy Ladder** (ten low-risk patterns — rename, typo, null check, logging, etc. — always auto-implemented) and its **Pending-Human** classification for items that genuinely need human judgment (architectural trade-offs, product scope, ambiguous fixes). Pending-Human items surface back here through the `Pending-Human: <n> — ...` line in pr-check's Step 6 summary and produce a single `PushNotification` in Step 4. Under `--unattended`, pr-check posts **no** `Acknowledged — will be addressed by the author` replies — the halt is the communication.
 
 ```text
-Skill("dlc:pr-check", "<PR_NUMBER>")
+Skill("dlc:pr-check", "<PR_NUMBER> --unattended")
 ```
 
 After pr-check completes, parse its output summary to extract these values:
 - Total unresolved items remaining: items marked Fixed, Answered, Resolved, or Dismissed are **done**. Remaining = Total - (Fixed + Answered + Resolved + Dismissed).
-- **Discussion-Deferred count**: items where pr-check deferred to the author (these need human judgment). Extract the `{deferred}` value from the `Discussion: {n} ({deferred} deferred, {tracked} tracked)` line in the summary.
+- **Pending-Human count and items**: parse the `Pending-Human: <n> — <item1_short>; <item2_short>; ...` line from the Step 6 summary. The `<n>` is the count; split the tail on `;` (trimming whitespace) to get the per-item short descriptions. If the line is absent, the count is 0. This line is emitted only under `--unattended`.
 - Whether pr-check pushed any commits (look for "Pushed" in the summary or a non-empty git diff from before)
 
 If pr-check pushed commits, re-request review from all prior reviewers. Filter out bot accounts (logins ending in `[bot]`):
@@ -282,32 +281,26 @@ Categorize the fresh check results by `bucket` field (same logic as Step 1 — `
 
 Evaluate the following conditions **in order**. The first matching condition wins:
 
-**If pr-check reported Discussion-Deferred items (count > 0) AND remaining unresolved items:**
-Both need human attention — combine into a single notification so nothing is suppressed.
-- Notify: `🧑‍⚖️ PR #<number> has <deferred_count> discussion items needing your input + <unresolved_count> unresolved. <url>`
-- Write state key `needs_decision:<deferred_count>,unresolved:<unresolved_count>`.
-- Stop. Next cycle will re-check.
+**If pr-check reported Pending-Human items (count > 0):**
+These items require human judgment — architectural trade-offs, product scope decisions, or ambiguous fixes with no clear winner. The babysitter cannot resolve them; halt the loop loudly.
+- Build the message body: concatenate the per-item shorts with `; ` separators, leading with the PR number and count. Target under 200 characters total; if longer, truncate trailing items and append `…` so the most important signal fits in a single mobile notification.
+- Fire `PushNotification` with message `PR #<number>: <count> items need your call — <item1_short>; <item2_short>`.
+- Write state key `pending_human:<count>` (count-only dedup per spec).
+- Self-cancel (see Cancellation Pattern below) and stop. The user will triage via `/dlc:pr-check <PR>` in attended mode, then relaunch `/loop 10m /dlc:babysit <PR>` when ready to resume.
 
-**If pr-check reported Discussion-Deferred items (count > 0) AND 0 remaining unresolved:**
-These are discussion items that need human judgment — design decisions, architectural trade-offs, or ambiguous suggestions. The babysitter cannot resolve them.
-- Notify: `🧑‍⚖️ PR #<number> has <deferred_count> discussion items needing your input. <url>`
-- Write state key `needs_decision:<deferred_count>`.
-- Do NOT self-cancel — the PR may still need further cycles after the human decides.
-- Stop. Next cycle will re-check (if the human resolved them, pr-check will see the replies).
-
-**If pr-check reported remaining unresolved items (and 0 Discussion-Deferred) AND CI_STATUS is `failing`:**
+**If pr-check reported remaining unresolved items AND CI_STATUS is `failing`:**
 Both need attention — surface both in a single notification so CI failure isn't hidden behind unresolved items.
-- Notify: `💬 PR #<number> has <count> unresolved items after auto-fix + CI failing: <check_names>. <url>`
+- Fire `PushNotification` with message `💬 PR #<number> has <count> unresolved items after auto-fix + CI failing: <check_names>. <url>`.
 - Write state key `unresolved:<count>,ci_failing:<sorted_check_names>`.
 - Stop. Next cycle will re-check.
 
-**If pr-check reported remaining unresolved items (and 0 Discussion-Deferred) AND CI_STATUS is `passing`:**
-- Notify: `💬 PR #<number> has <count> unresolved items after auto-fix. Review needed. <url>`
+**If pr-check reported remaining unresolved items AND CI_STATUS is `passing`:**
+- Fire `PushNotification` with message `💬 PR #<number> has <count> unresolved items after auto-fix. Review needed. <url>`.
 - Write state key `unresolved:<count>`.
 - Stop. Next cycle will re-check.
 
 **If CI_STATUS is `failing`:**
-- Notify: `🔴 CI failing on PR #<number>: <title> — Failed: <check_names>. <url>/checks`
+- Fire `PushNotification` with message `🔴 CI failing on PR #<number>: <title> — Failed: <check_names>. <url>/checks`.
 - Write state key `ci_failing:<sorted_check_names>`.
 - Stop. Next cycle will re-check in Step 1.
 
@@ -315,12 +308,12 @@ Both need attention — surface both in a single notification so CI failure isn'
 Stop silently. Re-review was already requested in Step 3. Next cycle will re-check.
 
 **If mergeable is CONFLICTING:**
-- Notify: `⚠️ PR #<number> has merge conflicts. <url>`
+- Fire `PushNotification` with message `⚠️ PR #<number> has merge conflicts. <url>`.
 - Stop. Next cycle will attempt rebase in Step 2.
 
-**If pr-check reported 0 remaining unresolved items AND 0 Discussion-Deferred AND CI_STATUS is `passing` AND reviewDecision is APPROVED (or empty) AND mergeable is MERGEABLE:**
+**If pr-check reported 0 remaining unresolved items AND 0 Pending-Human AND CI_STATUS is `passing` AND reviewDecision is APPROVED (or empty) AND mergeable is MERGEABLE:**
 - Write state key `ready`.
-- Notify: `✅ PR #<number> ready to merge! — <title> — <url>`
+- Fire `PushNotification` with message `✅ PR #<number> ready to merge! — <title> — <url>`.
 - Self-cancel and stop.
 
 ## Cancellation Pattern
@@ -332,3 +325,5 @@ To self-cancel the babysit loop:
 3. Call `CronDelete` with that task's ID.
 4. Delete the state file: `.dev/dlc/babysit-<PR_NUMBER>.state`
 5. If no matching task is found, this was a manual invocation — skip cancellation.
+
+**Terminal states that follow this pattern:** `ready`, `closed:<state>`, `pending_human:<count>`. Each emits exactly one `PushNotification`, writes its state key, then runs the cancellation above. Non-terminal branches (`ci_failing:*`, `rebase_conflict:*`, `unresolved:*`) notify and stop without cancelling — the next `/loop` cycle re-evaluates.

--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -316,7 +316,7 @@ Do **not** retry more than once. A second failure indicates a structural issue t
 
 ## Step 5: Follow-Up Issue, Decision-Aware Replies, and PR Summary
 
-If no Discussion-Deferred, Discussion-Tracked, Blocked, or user-skipped Fixable items exist after Steps 3 and 3.5, skip this step and continue to Step 6.
+If no Discussion-Deferred, Discussion-Tracked, Blocked, user-skipped Fixable, or Pending-Human items exist after Steps 3 and 3.5, skip this step and continue to Step 6.
 
 Otherwise, read [`references/followup-and-summary.md`](references/followup-and-summary.md) now and follow its three sub-steps:
 
@@ -362,7 +362,7 @@ PR review compliance check complete.
   - Per-reviewer breakdown:
       @{reviewer1}: {top_level_threads} threads + {review_bodies} review bodies + {issue_comments} issue comments — Resolved={resolved_count}, Fixed={fixed_count}, Answered={answered_count}, Skipped={skipped_count}, Discussion={discussion_count} ({deferred_count} deferred, {tracked_count} tracked, {pending_human_count} pending-human), Blocked={blocked_count}, Dismissed={dismissed_count} — 0 missed
       @{reviewer2}: {top_level_threads} threads + {review_bodies} review bodies + {issue_comments} issue comments — Resolved={resolved_count}, Fixed={fixed_count}, Answered={answered_count}, Skipped={skipped_count}, Discussion={discussion_count} ({deferred_count} deferred, {tracked_count} tracked, {pending_human_count} pending-human), Blocked={blocked_count}, Dismissed={dismissed_count} — 0 missed
-  - Pending-Human: {n} — {item1_short}; {item2_short}; ...  [only when UNATTENDED=true AND n > 0; each short is the first 80 chars of the reviewer comment; babysit parses this exact line shape]
+  - Pending-Human: {n} — {item1_short}; {item2_short}; ...  [only when n > 0; each short is the first 80 chars of the reviewer comment; babysit parses this exact line shape]
   - Push: {Pushed {sha} to origin/{branch}}  [if push succeeded]
   - Push: Push failed: {reason}  [if push failed]
   - Follow-up issue: #{number} ({url})  [only if user approved creation]

--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   PR review compliance: fetch review comments from an open PR,
   categorize as resolved/unresolved/dismissed, critically evaluate
   fixable items, implement approved fixes, and reply inline.
+  Pass --unattended to halt on human-judgment items (emitted as
+  Pending-Human) instead of prompting via AskUserQuestion.
 allowed-tools: [Bash, Read, Grep, Glob, Write, Edit, AskUserQuestion]
 ---
 
@@ -22,6 +24,17 @@ This skill uses progressive disclosure. The orchestration skeleton (fetch, categ
 Do **not** preload these references — each Step pointer below names its file and its skip condition.
 
 ## Step 1: Fetch PR Data
+
+### Parse arguments
+
+The skill accepts two arguments, in any order:
+
+- `<PR_NUMBER>` — numeric PR reference. Optional; when omitted, auto-detect from the current branch.
+- `--unattended` — optional flag. When present, set `UNATTENDED=true` and carry it through downstream steps. Gates the autonomy ladder in Step 3.5, suppresses `AskUserQuestion` in Steps 3.5 and 5a, activates Pending-Human classification, and emits the Step 6 `Pending-Human:` summary line. When absent (default), behavior is identical to attended mode.
+
+Parse `--unattended` out of the argument string before invoking the script; only the PR number (if any) goes to `pr-comments.sh`.
+
+### Run pr-comments.sh
 
 Run the `pr-comments.sh` script from the plugin's `scripts/` directory (two levels up from this skill):
 
@@ -256,6 +269,7 @@ Verify that every top-level thread, every review body, **and** every issue comme
 | Discussion-Deferred | Yes | Yes | Yes |
 | Discussion-Answered | Yes | Yes | Yes |
 | Discussion-Tracked | Yes | Yes | Yes |
+| Pending-Human | Yes | Yes | Yes |
 | Blocked | Yes | Yes | Yes |
 
 For each reviewer from Step 1, assert **all three**:
@@ -343,11 +357,12 @@ Print summary:
 PR review compliance check complete.
   - PR: #{number} ({title})
   - Total comments: {n} ({thread_count} threads + {review_body_count} review bodies + {issue_comment_count} issue comments)
-  - Resolved: {n}, Fixed by DLC: {n}, Answered by DLC: {n}, Skipped (user decision): {n}, Discussion: {n} ({deferred} deferred, {tracked} tracked), Blocked: {n}, Dismissed: {n}
+  - Resolved: {n}, Fixed by DLC: {n}, Answered by DLC: {n}, Skipped (user decision): {n}, Discussion: {n} ({deferred} deferred, {tracked} tracked, {pending_human} pending-human), Blocked: {n}, Dismissed: {n}
   - Coverage: {verified_items}/{total_items} items verified ({thread_count} threads + {body_count} review bodies + {issue_comment_count} issue comments) (Step 4b passed)
   - Per-reviewer breakdown:
-      @{reviewer1}: {top_level_threads} threads + {review_bodies} review bodies + {issue_comments} issue comments — Resolved={resolved_count}, Fixed={fixed_count}, Answered={answered_count}, Skipped={skipped_count}, Discussion={discussion_count} ({deferred_count} deferred, {tracked_count} tracked), Blocked={blocked_count}, Dismissed={dismissed_count} — 0 missed
-      @{reviewer2}: {top_level_threads} threads + {review_bodies} review bodies + {issue_comments} issue comments — Resolved={resolved_count}, Fixed={fixed_count}, Answered={answered_count}, Skipped={skipped_count}, Discussion={discussion_count} ({deferred_count} deferred, {tracked_count} tracked), Blocked={blocked_count}, Dismissed={dismissed_count} — 0 missed
+      @{reviewer1}: {top_level_threads} threads + {review_bodies} review bodies + {issue_comments} issue comments — Resolved={resolved_count}, Fixed={fixed_count}, Answered={answered_count}, Skipped={skipped_count}, Discussion={discussion_count} ({deferred_count} deferred, {tracked_count} tracked, {pending_human_count} pending-human), Blocked={blocked_count}, Dismissed={dismissed_count} — 0 missed
+      @{reviewer2}: {top_level_threads} threads + {review_bodies} review bodies + {issue_comments} issue comments — Resolved={resolved_count}, Fixed={fixed_count}, Answered={answered_count}, Skipped={skipped_count}, Discussion={discussion_count} ({deferred_count} deferred, {tracked_count} tracked, {pending_human_count} pending-human), Blocked={blocked_count}, Dismissed={dismissed_count} — 0 missed
+  - Pending-Human: {n} — {item1_short}; {item2_short}; ...  [only when UNATTENDED=true AND n > 0; each short is the first 80 chars of the reviewer comment; babysit parses this exact line shape]
   - Push: {Pushed {sha} to origin/{branch}}  [if push succeeded]
   - Push: Push failed: {reason}  [if push failed]
   - Follow-up issue: #{number} ({url})  [only if user approved creation]

--- a/plugins/dlc/skills/pr-check/references/discussion-workflow.md
+++ b/plugins/dlc/skills/pr-check/references/discussion-workflow.md
@@ -38,11 +38,41 @@ Assess the effort and nature of each discussion item:
 Treat an Implementable Fix as auto-implementable when any of these hold:
 - All four criteria from `fixable-workflow.md` section 2 pass and there is a single clear approach
 - There are multiple approaches but one is clearly better (you would mark it "(Recommended)") — implement the recommended one
-- The confidence is medium, but the recommended action is obvious and low-risk (rename, add check, fix typo, adjust formatting, add missing validation), so it is safe to upgrade for execution purposes
+- The item matches an **Autonomy Ladder** pattern (see below) — always auto-implement in unattended runs; recommend auto-implementation in attended runs
 
 Apply this test: if you would present this to the user and confidently mark one option "(Recommended)", you already know the answer — just do it. `AskUserQuestion` exists for genuine ambiguity where reasonable engineers would disagree, not as a rubber stamp for decisions you've already made.
 
-Implementable Fix items that are not auto-implementable — for example, when there are multiple substantially different approaches with no clear winner, the change is behavior-changing or risky, or the trade-offs are non-obvious — route to `AskUserQuestion` in attended runs, or classify as **Discussion-Deferred** in unattended runs.
+### Autonomy Ladder
+
+The following low-risk patterns auto-implement when the change is **local** — under ~20 lines and confined to a single file:
+
+- Rename a variable, function, or type
+- Fix a typo
+- Edit a comment or docstring
+- Add a null check or guard
+- Add logging
+- Tighten a condition (narrow a range, add a precondition)
+- Add missing validation
+- Extract a constant or magic number
+- Adjust formatting, indentation, or whitespace
+- Remove reviewer-flagged dead code
+
+In unattended runs (`UNATTENDED=true`), matching any pattern is a **bright-line auto-implement rule** — skip `AskUserQuestion` entirely and implement now. In attended runs, the pattern still auto-implements unless the item also needs user judgment for another reason.
+
+If a ladder-pattern match would exceed the local-scope guard (touches multiple files or more than ~20 lines), fall through to standard Implementable-Fix handling — do not force it through the ladder.
+
+If the reviewer comment mixes a ladder pattern with an architectural concern (e.g., "rename this AND reconsider the overall design"), classify by the most complex ask. Do not auto-implement the rename in isolation when the reviewer's deeper concern is design.
+
+If implementation fails (file no longer exists, conflict, tool error), reclassify as **Blocked** with the reason `implementation failed: {error}` — same guardrail as section 4. Do NOT reclassify as Pending-Human; Blocked is the path for failed execution.
+
+### Attended / unattended mode split
+
+Implementable Fix items that are not auto-implementable — multiple substantially different approaches with no clear winner, behavior-changing or risky changes, or non-obvious trade-offs — split by mode:
+
+- **Attended runs** (`UNATTENDED` unset or false): route to `AskUserQuestion` in the menu below.
+- **Unattended runs** (`UNATTENDED=true`): classify as **Pending-Human**. Skip `AskUserQuestion`. Post no outgoing reply. Do NOT assign Discussion-Deferred — that path is attended-only and requires an explicit "Defer to author" click. Pending-Human items enter the Step 6 `Pending-Human:` summary line and halt the caller. Babysit fires `PushNotification` and self-cancels the cron; an attended `/dlc:pr-check` rerun surfaces the same items through the menu for explicit user triage.
+
+The same split applies to medium/low-confidence **Clarification Answer** items that don't meet the auto-reply criteria below, and to **Design Decision** / **Out-of-PR-Scope** items — these always require human judgment, so attended routes to the menu and unattended routes to Pending-Human.
 
 Skip `AskUserQuestion` and auto-reply **high-confidence Clarification Answer** items when the agent can draft a factual answer entirely from codebase evidence. A Clarification Answer is high-confidence when all four of these criteria pass:
 
@@ -70,7 +100,9 @@ When all four pass → auto-draft the reply without asking. Print: `Auto-replyin
 >
 > In these cases, fall through to `AskUserQuestion` instead (or reclassify per the defect-revealing rule above).
 
-**Genuinely ambiguous items only** — Medium/Low-confidence Implementable Fix that does not meet the auto-implement criteria above, medium/low-confidence Clarification Answer, true Design Decisions (architectural trade-offs where reasonable engineers would disagree), Out-of-PR-Scope, or Implementable Fix with multiple approaches (none clearly recommended) — use `AskUserQuestion`:
+**Attended mode, genuinely ambiguous items only** — This menu fires only when `UNATTENDED` is unset or false. For Medium/Low-confidence Implementable Fix that does not meet the auto-implement criteria above, medium/low-confidence Clarification Answer, true Design Decisions (architectural trade-offs where reasonable engineers would disagree), Out-of-PR-Scope, or Implementable Fix with multiple approaches (none clearly recommended), use `AskUserQuestion`:
+
+> **In unattended mode, skip this menu entirely and classify the item as Pending-Human per the mode split above.** Do not invoke `AskUserQuestion` on an unattended run — the tool has no user surface to render to, and empty returns silently produced `Acknowledged` replies under the old behavior.
 
 ```text
 Discussion item {n}/{total}: @{reviewer} at {location}
@@ -109,6 +141,10 @@ Include a brief rationale for why you recommend one approach over the others. Th
 
 The user can always override the recommendation by choosing any option.
 
+### Empty-answer safeguard (attended mode)
+
+If `AskUserQuestion` returns an empty answer (no user selection captured), do **not** assume a default. Re-ask the question once. If the second attempt is also empty, reclassify the item as **Pending-Human** and skip it. Never silently route to "Defer to author" — that path produces an `Acknowledged` reply, and `Acknowledged` is reserved for explicit user clicks only.
+
 ## 4. Execute Chosen Action
 
 **For "Implement now"**: Apply the same confidence-gated implementation as `fixable-workflow.md` section 3:
@@ -125,3 +161,4 @@ The user can always override the recommendation by choosing any option.
 
 > **Items reclassified as Fixed** follow the same `Fixed: {brief description}` reply format and routing used for Fixable items in SKILL.md Step 4.
 > **If an implementation fails** (tool error, file not found, conflict), reclassify as **Blocked** with the reason "implementation failed: {error}" — same guardrail as `fixable-workflow.md` section 3.
+> **Pending-Human** items (from unattended-mode classification in Section 3 or from the empty-answer safeguard) do NOT appear in the table above. They bypass Section 4 entirely: no user-chosen action, no reply text, no Step 5 follow-up, no thread resolve. They are emitted only in the Step 6 `Pending-Human:` summary line and counted in Step 4b coverage.

--- a/plugins/dlc/skills/pr-check/references/followup-and-summary.md
+++ b/plugins/dlc/skills/pr-check/references/followup-and-summary.md
@@ -15,7 +15,10 @@ If none of these exist, SKILL.md skips this reference entirely and jumps to the 
 >
 > **Note:** Discussion items resolved in Step 3.5 (implemented as Implementable Fix or answered as Clarification) are already handled in SKILL.md Step 4. Discussion items deferred to the author proceed directly to Step 5b below — they do not appear here.
 >
-> **Unattended-mode behavior:** In unattended runs (`UNATTENDED=true`), Branches 2 and 3 skip `AskUserQuestion` and auto-create the follow-up issue for Blocked or Skipped items. The resulting reply `Acknowledged — tracked in #ISSUE_NUMBER` is factual (the issue exists), so the hard rule that `Acknowledged — will be addressed by the author` fires only on explicit user selection is not violated. Discussion-Tracked items cannot arise in unattended runs (they require an explicit "Create follow-up issue" click in `discussion-workflow.md` Section 4), so Branch 1 is the only reachable path for tracked items under `UNATTENDED=true`.
+> **Unattended-mode behavior** (applies when `UNATTENDED=true`):
+> - Branches 2 and 3 skip `AskUserQuestion` and auto-create the follow-up issue for Blocked or Skipped items — no user prompt.
+> - The resulting reply `Acknowledged — tracked in #ISSUE_NUMBER` is factual (the issue exists), so the hard rule that `Acknowledged — will be addressed by the author` fires only on explicit user selection is not violated — those are two different reply templates.
+> - Discussion-Tracked items cannot arise (they require an explicit "Create follow-up issue" click in `discussion-workflow.md` Section 4), so Branch 1 is the only reachable tracked-items path in unattended runs.
 
 **Per-item decisions from the Discussion workflow are final:**
 - **Discussion-Tracked** items are automatically included in the follow-up issue — the user already approved per-item during `discussion-workflow.md` section 3. Do not re-ask.

--- a/plugins/dlc/skills/pr-check/references/followup-and-summary.md
+++ b/plugins/dlc/skills/pr-check/references/followup-and-summary.md
@@ -9,7 +9,7 @@ This reference covers the three post-reply steps that only fire when unresolved 
 
 If none of these exist, SKILL.md skips this reference entirely and jumps to the final commit/push/report step.
 
-## Step 5a: User-Gated Issue Creation
+## Step 5a: Follow-up Issue Creation
 
 > **Skip this sub-step entirely** if there are no issue-creation candidates — i.e. no **Discussion-Tracked**, **Blocked**, or **user-skipped Fixable** items remain. For example, when the only remaining items are Discussion-Deferred, proceed directly to Step 5b below (issue creation has no candidates to consider).
 >
@@ -142,7 +142,7 @@ gh pr comment $PR_NUMBER --body "> {first 100 chars of original body}...
 
 ## Step 5c: PR Summary Comment
 
-If there are no remaining Discussion-Deferred, Discussion-Tracked, Blocked, or user-skipped Fixable items, skip this step.
+If there are no remaining Discussion-Deferred, Discussion-Tracked, Blocked, user-skipped Fixable, or Pending-Human items, skip this step.
 
 > **Unattended-mode conditional suppression:** In unattended runs (`UNATTENDED=true`), if the ONLY remaining items are Pending-Human — no Fixed, Answered, Deferred, Tracked, Blocked, or Skipped items to report — do NOT post this summary comment. The halt signal comes from the `PushNotification` fired by babysit, not from a PR-level comment. When auto-handled items coexist with Pending-Human items (e.g., 3 fixed + 2 pending), post the summary as normal with the Pending-Human row included.
 

--- a/plugins/dlc/skills/pr-check/references/followup-and-summary.md
+++ b/plugins/dlc/skills/pr-check/references/followup-and-summary.md
@@ -14,6 +14,8 @@ If none of these exist, SKILL.md skips this reference entirely and jumps to the 
 > **Skip this sub-step entirely** if there are no issue-creation candidates — i.e. no **Discussion-Tracked**, **Blocked**, or **user-skipped Fixable** items remain. For example, when the only remaining items are Discussion-Deferred, proceed directly to Step 5b below (issue creation has no candidates to consider).
 >
 > **Note:** Discussion items resolved in Step 3.5 (implemented as Implementable Fix or answered as Clarification) are already handled in SKILL.md Step 4. Discussion items deferred to the author proceed directly to Step 5b below — they do not appear here.
+>
+> **Unattended-mode behavior:** In unattended runs (`UNATTENDED=true`), Branches 2 and 3 skip `AskUserQuestion` and auto-create the follow-up issue for Blocked or Skipped items. The resulting reply `Acknowledged — tracked in #ISSUE_NUMBER` is factual (the issue exists), so the hard rule that `Acknowledged — will be addressed by the author` fires only on explicit user selection is not violated. Discussion-Tracked items cannot arise in unattended runs (they require an explicit "Create follow-up issue" click in `discussion-workflow.md` Section 4), so Branch 1 is the only reachable path for tracked items under `UNATTENDED=true`.
 
 **Per-item decisions from the Discussion workflow are final:**
 - **Discussion-Tracked** items are automatically included in the follow-up issue — the user already approved per-item during `discussion-workflow.md` section 3. Do not re-ask.
@@ -78,6 +80,8 @@ If issue creation fails, save draft to `/tmp/dlc-draft-${TIMESTAMP}.md` and prin
 
 If there are no remaining Discussion-Deferred, Discussion-Tracked, Blocked, or user-skipped Fixable items, skip this step.
 
+> **Pending-Human items do NOT reach this step.** They were classified upstream in `discussion-workflow.md` and intentionally have no reply. Pending-Human is not equivalent to Discussion-Deferred: the former emits silence, the latter (attended-only) emits `Acknowledged — will be addressed by the author` when the user explicitly clicks "Defer to author" in the Section 3 menu. Never post `Acknowledged — will be addressed by the author` outside that explicit click.
+
 Post replies reflecting each item's outcome. The routing below covers inline threads, review bodies, and issue comments — not only inline threads. Items arrive here from different decision paths:
 
 For each **Discussion-Deferred** item (user chose "Defer to author" in the Discussion workflow), always reply:
@@ -137,6 +141,8 @@ gh pr comment $PR_NUMBER --body "> {first 100 chars of original body}...
 
 If there are no remaining Discussion-Deferred, Discussion-Tracked, Blocked, or user-skipped Fixable items, skip this step.
 
+> **Unattended-mode conditional suppression:** In unattended runs (`UNATTENDED=true`), if the ONLY remaining items are Pending-Human — no Fixed, Answered, Deferred, Tracked, Blocked, or Skipped items to report — do NOT post this summary comment. The halt signal comes from the `PushNotification` fired by babysit, not from a PR-level comment. When auto-handled items coexist with Pending-Human items (e.g., 3 fixed + 2 pending), post the summary as normal with the Pending-Human row included.
+
 Post a PR-level summary comment containing the overall status and decisions.
 
 Build the summary with these sections:
@@ -152,6 +158,7 @@ Build the summary with these sections:
 | Skipped (user decision) | {n} | {n} | {n} | {n} |
 | Discussion-Deferred | {n} | {n} | {n} | {n} |
 | Discussion-Tracked | {n} | {n} | {n} | {n} |
+| Pending-Human | {n} | {n} | {n} | {n} |
 | Blocked | {n} | {n} | {n} | {n} |
 | Dismissed | {n} | {n} | {n} | {n} |
 | **Total** | **{n}** | **{n}** | **{n}** | **{n}** |


### PR DESCRIPTION
## Summary

- **pr-check `--unattended` flag** activates a bright-line **Autonomy Ladder** (ten low-risk patterns — rename, typo, comment edit, null check, logging, tighten condition, add validation, extract constant, formatting, reviewer-flagged dead code) that always auto-implements, and introduces a **Pending-Human** classification for judgment items (no reply, no Discussion-Deferred assignment).
- **babysit** invokes pr-check with `--unattended`, parses the new `Pending-Human: <n> — ...` summary line, fires **`PushNotification`**, and self-cancels the cron. All nine prior `Notify:` directives migrated to `PushNotification` tool calls — print output doesn't ping mobile devices.
- **Acknowledged-gate hardening**: `"Acknowledged — will be addressed by the author"` now fires **if and only if** the user explicitly selected the corresponding option in `AskUserQuestion`. Added an empty-answer safeguard (re-ask once → Pending-Human) to close the `/loop` leak where silent AskUserQuestion failures produced placeholder replies.

Closes #212. Design source: `.dev/pm/specs/2026-04-17-dlc-autonomy-and-halt-on-defer.md`.

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [x] Acknowledged-gate audit: both firing sites (followup-and-summary.md:91, :105) reachable only via explicit AskUserQuestion clicks; no automated paths
- [x] Terminology sweep: `Pending-Human` prose + `pending_human` state-key used consistently across the three touched skills; zero `needs_decision:*` leftovers
- [ ] Manual smoke test (unattended): run \`/dlc:babysit <PR>\` on a live PR with mixed Discussion items — verify ladder auto-implements, residual items surface as Pending-Human, \`PushNotification\` fires, cron self-cancels, no \`Acknowledged — will be addressed by the author\` replies posted
- [ ] Manual smoke test (attended): run \`/dlc:pr-check <PR>\` — verify AskUserQuestion still works, user decisions post as real replies, no Pending-Human leakage
- [ ] Relaunch test: after Pending-Human halt, \`/loop 10m /dlc:babysit <PR>\` without resolving items — first cycle fires fresh PushNotification (state file deleted on self-cancel), subsequent cycles dedup on \`pending_human:<count>\`
- [ ] Regression: \`ready\`, \`closed:<state>\`, \`ci_failing:*\`, \`rebase_conflict:*\`, \`unresolved:*\` branches still work with PushNotification swap (no semantic change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an unattended mode that auto-applies low-risk fixes without prompting.
  * Introduced a Pending-Human classification for items that require human review; these produce silence (no reply) and are surfaced only in the final summary.
  * Send push notifications and self-cancel workflows when Pending-Human is detected; attended runs re-ask once before marking Pending-Human.

* **Documentation**
  * Updated workflow docs with the autonomy ladder, attended/unattended rules, and summary/reporting changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->