### PR TITLE
feat(dlc): extend --unattended to Fixable items

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -977,4 +977,4 @@ The first pass of `--unattended` only split the classifier for Discussion items.
 
 **Good pattern:** audit every call site before merging the first mode-split. If `AskUserQuestion` fires anywhere under `UNATTENDED=true`, the feature is incomplete.
 
-> Source: follow-up to #212 (#213); review thread `plugins/dlc/skills/pr-check/SKILL.md:35` (copilot-pull-request-reviewer); files: `plugins/dlc/skills/pr-check/references/fixable-workflow.md`
+> Source: follow-up to #212 (#213); surfaced by copilot-pull-request-reviewer on PR #213; files: `plugins/dlc/skills/pr-check/references/fixable-workflow.md`

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -966,3 +966,15 @@ babysit fires PushNotification + CronDelete + state file cleanup
 ```
 
 > Source: PR implementing issue #212; spec `.dev/pm/specs/2026-04-17-dlc-autonomy-and-halt-on-defer.md`; files: `plugins/dlc/skills/pr-check/**`, `plugins/dlc/skills/babysit/SKILL.md`
+
+### The mode-split invariant: `AskUserQuestion` must be gated by `UNATTENDED` wherever it appears
+
+The first pass of `--unattended` only split the classifier for Discussion items. Fixable items still called `AskUserQuestion` on Medium/Low confidence — which meant unattended `/loop` runs re-introduced the exact empty-answer failure mode the feature was designed to kill. A reviewer caught it in post-merge review; the Pending-Human halt surfaced the gap rather than hiding it (meta-validation).
+
+**Rule:** Every `AskUserQuestion` call site in pr-check must check `UNATTENDED` before firing. Attended mode keeps the menu; unattended mode reclassifies as **Pending-Human**. An empty-answer safeguard belongs next to every call site, not just one — attended empty answers must reclassify as Pending-Human, never silently default to a user-facing acknowledgement reply.
+
+**Bad pattern:** split the classifier in one workflow (`discussion-workflow.md`) and leave another (`fixable-workflow.md`) unchanged. The invariant leaks.
+
+**Good pattern:** audit every call site before merging the first mode-split. If `AskUserQuestion` fires anywhere under `UNATTENDED=true`, the feature is incomplete.
+
+> Source: follow-up to #212 (#213); review thread `plugins/dlc/skills/pr-check/SKILL.md:35` (copilot-pull-request-reviewer); files: `plugins/dlc/skills/pr-check/references/fixable-workflow.md`

--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -181,7 +181,7 @@ If no **Fixable** items exist from Step 2, skip this step.
 
 Otherwise, read [`references/fixable-workflow.md`](references/fixable-workflow.md) now and follow its three-phase workflow: context read → critical evaluation → confidence-gated implementation.
 
-The reference covers the four evaluation criteria (technical correctness, project alignment, regression risk, scope), anti-sycophancy rules, implementation guardrails, the attended/unattended split for Medium/Low-confidence items (unattended classifies as **Pending-Human** rather than calling `AskUserQuestion`), the attended empty-answer safeguard, and the Blocked-on-error reclassification rule. Items that implement successfully reclassify as **Fixed** and enter the Step 4 reply queue; Medium/Low-confidence items in unattended mode reclassify as **Pending-Human** and enter the Step 6 summary line; items whose implementation fails reclassify as **Blocked** and are handled by Step 5.
+The reference covers the four evaluation criteria (technical correctness, project alignment, regression risk, scope), anti-sycophancy rules, implementation guardrails, the attended/unattended split for Medium/Low-confidence items (unattended classifies as **Pending-Human** rather than calling `AskUserQuestion`), the attended empty-answer safeguard, and the Blocked-on-error reclassification rule. Items that implement successfully reclassify as **Fixed** and enter the Step 4 reply queue; Medium/Low-confidence items in unattended mode — and attended items where the empty-answer safeguard fires twice — reclassify as **Pending-Human** and enter the Step 6 summary line; items whose implementation fails reclassify as **Blocked** and are handled by Step 5.
 
 ## Step 3.5: Handle Discussion Items
 

--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -30,7 +30,7 @@ Do **not** preload these references — each Step pointer below names its file a
 The skill accepts two arguments, in any order:
 
 - `<PR_NUMBER>` — numeric PR reference. Optional; when omitted, auto-detect from the current branch.
-- `--unattended` — optional flag. When present, set `UNATTENDED=true` and carry it through downstream steps. Gates the autonomy ladder in Step 3.5, suppresses `AskUserQuestion` in Steps 3.5 and 5a, activates Pending-Human classification, and emits the Step 6 `Pending-Human:` summary line. When absent (default), behavior is identical to attended mode.
+- `--unattended` — optional flag. When present, set `UNATTENDED=true` and carry it through downstream steps. Gates the autonomy ladder in Step 3.5, suppresses `AskUserQuestion` in Steps 3, 3.5, and 5a, activates Pending-Human classification, and emits the Step 6 `Pending-Human:` summary line. When absent (default), behavior is identical to attended mode.
 
 Parse `--unattended` out of the argument string before invoking the script; only the PR number (if any) goes to `pr-comments.sh`.
 

--- a/plugins/dlc/skills/pr-check/SKILL.md
+++ b/plugins/dlc/skills/pr-check/SKILL.md
@@ -181,7 +181,7 @@ If no **Fixable** items exist from Step 2, skip this step.
 
 Otherwise, read [`references/fixable-workflow.md`](references/fixable-workflow.md) now and follow its three-phase workflow: context read → critical evaluation → confidence-gated implementation.
 
-The reference covers the four evaluation criteria (technical correctness, project alignment, regression risk, scope), anti-sycophancy rules, implementation guardrails, and the Blocked-on-error reclassification rule. Items that implement successfully reclassify as **Fixed** and enter the Step 4 reply queue; items whose implementation fails reclassify as **Blocked** and are handled by Step 5.
+The reference covers the four evaluation criteria (technical correctness, project alignment, regression risk, scope), anti-sycophancy rules, implementation guardrails, the attended/unattended split for Medium/Low-confidence items (unattended classifies as **Pending-Human** rather than calling `AskUserQuestion`), the attended empty-answer safeguard, and the Blocked-on-error reclassification rule. Items that implement successfully reclassify as **Fixed** and enter the Step 4 reply queue; Medium/Low-confidence items in unattended mode reclassify as **Pending-Human** and enter the Step 6 summary line; items whose implementation fails reclassify as **Blocked** and are handled by Step 5.
 
 ## Step 3.5: Handle Discussion Items
 

--- a/plugins/dlc/skills/pr-check/references/fixable-workflow.md
+++ b/plugins/dlc/skills/pr-check/references/fixable-workflow.md
@@ -39,14 +39,25 @@ Assign a confidence level:
 
 ## 3. Confidence-Gated Implementation
 
-- **High confidence** → Implement directly using `Edit` or `Write`, then stage: `git add <file>`
-- **Medium or Low confidence** → Use `AskUserQuestion` to present:
+**High confidence** (all four criteria pass) → Implement directly using `Edit` or `Write`, then stage: `git add <file>`. Mode-agnostic — works identically in attended and unattended runs.
+
+**Medium or Low confidence** — genuinely ambiguous items where reasonable engineers would disagree — split by mode:
+
+- **Attended runs** (`UNATTENDED` unset or false): Use `AskUserQuestion` to present:
   - The quoted reviewer comment
   - Your assessment (which criteria passed/failed and why)
   - Options: "Implement as suggested" / "Skip this comment" / "Implement with modification"
-  - If "Implement with modification" is chosen, ask for guidance before proceeding
+  - If "Implement with modification" is chosen, ask for guidance before proceeding.
 
-> **Bias toward implementation**: Default to **High confidence** and implement fixes directly when a change is technically correct and straightforward (rename, add a check, fix a typo, adjust formatting, add missing validation) — code is cheap; generating a fix costs less than deliberating about whether to. Do not inflate uncertainty to avoid work or defer small fixes as "out of scope." The confidence gate exists for genuinely ambiguous suggestions where reasonable engineers would disagree — not as an escape hatch for effort avoidance.
+- **Unattended runs** (`UNATTENDED=true`): Skip `AskUserQuestion` entirely. Classify the item as **Pending-Human**. Post no outgoing reply. Do NOT default to "Skip this comment" — that path produces an `Acknowledged — deferred (out of scope for this PR)` reply, which is an implicit decision the user never made. Pending-Human items enter the Step 6 `Pending-Human:` summary line and halt the caller. Babysit fires `PushNotification` and self-cancels the cron; an attended `/dlc:pr-check` rerun surfaces the same items through the menu for explicit user triage.
+
+> Why the split: `AskUserQuestion` has no user surface in an unattended `/loop`. Calling it there produces empty answers, which historically fell through to implicit "skip" — an `Acknowledged` reply the user never authorized. Pending-Human is the honest halt signal: the bot stops, the user gets a push, and the decision happens in attended mode.
+
+### Empty-answer safeguard (attended mode)
+
+If `AskUserQuestion` returns an empty answer (no user selection captured), do **not** assume a default. Re-ask the question once. If the second attempt is also empty, reclassify the item as **Pending-Human** and skip it. Never silently route to "Skip this comment" — that path posts an `Acknowledged — deferred` reply, and acknowledgements are reserved for explicit user clicks.
+
+> **Bias toward implementation**: Default to **High confidence** and implement fixes directly when a change is technically correct and straightforward (rename, add a check, fix a typo, adjust formatting, add missing validation) — code is cheap; generating a fix costs less than deliberating about whether to. Do not inflate uncertainty to avoid work or defer small fixes as "out of scope." The confidence gate exists for genuinely ambiguous suggestions where reasonable engineers would disagree — not as an escape hatch for effort avoidance. In unattended runs, this bias matters double: every item that gets the High-confidence treatment lands as a real fix instead of a Pending-Human halt.
 
 **Guardrails:**
 - Only modify files that are part of the PR's diff
@@ -64,6 +75,8 @@ Each Fixable item lands in one of these final states:
 | Implementation succeeds | **Fixed** | SKILL.md Step 4 reply queue with `Fixed:` prefix |
 | User chose "Skip this comment" | **Skipped (user decision)** | SKILL.md Step 5 follow-up flow — acknowledged in [`followup-and-summary.md`](followup-and-summary.md) Step 5b with `Acknowledged — deferred (out of scope for this PR)` |
 | User chose "Implement with modification" | Proceeds as Fixed once the modified implementation lands | Same as Fixed |
+| Unattended mode, Medium/Low confidence (no `AskUserQuestion`) | **Pending-Human** | No reply, no Step 5 follow-up, no thread resolve. Counted in Step 4b coverage and emitted in the Step 6 `Pending-Human:` summary line for babysit to parse. |
+| Attended mode, `AskUserQuestion` empty after one re-ask | **Pending-Human** | Same as above — honest halt rather than silent `Acknowledged — deferred`. |
 | Implementation fails (tool error, conflict) | **Blocked** with reason `implementation failed: {error}` | SKILL.md Step 5 follow-up flow (issue creation + acknowledgement) |
 
 Coverage verification (Step 4b) counts each of these final states toward the reviewer's total — no Fixable item is ever silently dropped.

--- a/plugins/dlc/skills/pr-check/references/fixable-workflow.md
+++ b/plugins/dlc/skills/pr-check/references/fixable-workflow.md
@@ -75,7 +75,7 @@ Each Fixable item lands in one of these final states:
 | Implementation succeeds | **Fixed** | SKILL.md Step 4 reply queue with `Fixed:` prefix |
 | User chose "Skip this comment" | **Skipped (user decision)** | SKILL.md Step 5 follow-up flow — acknowledged in [`followup-and-summary.md`](followup-and-summary.md) Step 5b with `Acknowledged — deferred (out of scope for this PR)` |
 | User chose "Implement with modification" | Proceeds as Fixed once the modified implementation lands | Same as Fixed |
-| Unattended mode, Medium/Low confidence (no `AskUserQuestion`) | **Pending-Human** | No reply, no Step 5 follow-up, no thread resolve. Counted in Step 4b coverage and emitted in the Step 6 `Pending-Human:` summary line for babysit to parse. |
+| Unattended mode, Medium/Low confidence (no `AskUserQuestion`) | **Pending-Human** | No reply, no Step 5a issue creation, no Step 5b decision-aware reply, no thread resolve. Counted in Step 4b coverage, may appear in the Step 5c summary row when mixed with other follow-up categories, and emitted in the Step 6 `Pending-Human:` summary line for babysit to parse. |
 | Attended mode, `AskUserQuestion` empty after one re-ask | **Pending-Human** | Same as above — honest halt rather than silent `Acknowledged — deferred`. |
 | Implementation fails (tool error, conflict) | **Blocked** with reason `implementation failed: {error}` | SKILL.md Step 5 follow-up flow (issue creation + acknowledgement) |
 


### PR DESCRIPTION
## Summary
- Follow-up to PR #213 — closes the last `AskUserQuestion` call site that wasn't gated on `UNATTENDED`
- Mirror the Discussion mode-split in `fixable-workflow.md` so Medium/Low-confidence Fixable items in unattended `/loop` runs reclassify as **Pending-Human** instead of calling `AskUserQuestion`
- Add an attended-mode empty-answer safeguard (re-ask once, then Pending-Human) so attended empty answers never silently default to "Skip this comment" → `Acknowledged — deferred`
- Record the invariant in `docs/learnings.md`: `AskUserQuestion` must be gated by `UNATTENDED` at **every** call site; leaving one unchanged re-opens the empty-answer failure mode the feature was designed to kill

## Context
Discovered during `/dlc:babysit` on PR #213 — the prior cycle surfaced this exact gap as a Pending-Human item (copilot review at `plugins/dlc/skills/pr-check/SKILL.md:35`). The halt behaved correctly, which is the meta-validation: the feature caught its own missing case instead of hiding it.

## Scope
- `plugins/dlc/skills/pr-check/references/fixable-workflow.md` — section 3 mode-split + empty-answer safeguard + two Pending-Human rows in the Outcome table
- `plugins/dlc/skills/pr-check/SKILL.md` — Step 3 pointer now names the mode-split and the Pending-Human outcome path
- `docs/learnings.md` — new h3 entry on the mode-split invariant

No changes to `babysit` — downstream handling already routes Pending-Human correctly regardless of which workflow produced it. No changes to Step 4b coverage or Step 6 summary — Pending-Human is already first-class there.

## Test plan
- [ ] `bun scripts/validate-plugins.mjs` (already green locally)
- [ ] Manual unattended smoke: `/loop 10m /dlc:babysit <PR>` on a PR with at least one Medium/Low-confidence Fixable comment — confirm it reclassifies as Pending-Human, fires `PushNotification`, self-cancels, and posts no `Acknowledged — deferred` replies
- [ ] Manual attended smoke: `/dlc:pr-check <PR>` on the same PR — confirm `AskUserQuestion` still fires for the same items, and that an empty answer re-asks once before Pending-Human takeover
- [ ] `rg -n "AskUserQuestion" plugins/dlc/skills/pr-check/` — every match should be inside an attended-mode gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for unattended mode behavior, clarifying how items are classified and routed
  * Added safeguards documentation for handling empty responses in user interactions
  * Updated workflow rules documentation to reflect confidence-based behavior across different execution modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->