### PR TITLE
feat(cdt): add wave-gate handoff guardrails (#217)

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -292,6 +292,34 @@ JSON
 
 > Source: [PR #218](https://github.com/rube-de/cc-skills/pull/218) — `Stop` hook shipped with `hookSpecificOutput.additionalContext` (valid for `UserPromptSubmit`/`PostToolUse`, not `Stop`). Caught only after a live `Stop` event hit the runtime validator. Spec had flagged the risk in "Open Questions" — verification was not performed before merge.
 
+### `decision: "block"` on high-frequency events needs a cooldown
+
+`Stop` and `SubagentStop` fire on every assistant turn that ends without further tool use. A hook that emits `decision: "block"` on these events forces the LLM to respond → which ends in another Stop → which re-fires the hook → indefinitely. Production hit 8+ consecutive blocks per Stop attempt before this was diagnosed.
+
+The hook output schema offers no non-blocking inject for `Stop`/`SubagentStop` (`hookSpecificOutput.additionalContext` works only for `PreToolUse`/`UserPromptSubmit`/`PostToolUse`/`PostToolBatch`). A hook that *must* surface a reminder on `Stop` has to combine `decision: "block"` with a cooldown — without one, every Stop is blocked.
+
+**Pattern** — co-locate a timestamp file with whatever state already triggers the hook, and short-circuit if the timestamp is recent:
+
+```sh
+WARNED_FILE=".dev/cdt/${BRANCH}/.cdt-wave-gate-warned"
+COOLDOWN_SECONDS=300
+
+if [ -f "$WARNED_FILE" ]; then
+  NOW=$(date +%s)
+  # macOS: stat -f %m, Linux: stat -c %Y
+  LAST=$(stat -f %m "$WARNED_FILE" 2>/dev/null || stat -c %Y "$WARNED_FILE" 2>/dev/null || echo 0)
+  DELTA=$((NOW - LAST))
+  [ "$DELTA" -ge 0 ] && [ "$DELTA" -lt "$COOLDOWN_SECONDS" ] && exit 0
+fi
+
+touch "$WARNED_FILE"
+# ... emit decision:block JSON ...
+```
+
+A 5-minute window reads as a *last-resort safety net* — long enough that legitimate Stops during active work don't accumulate fatigue, short enough that genuinely stuck workflows still surface the reminder within a useful timeframe. **Reframe the reason text to match the cooldown semantics**: *"fires at most once per 5min, the doc-layer rules already failed to catch this"* tells future readers the hook is a backstop, not a primary mechanism. Without that framing, the hook can be misread as the load-bearing rule and the workflow doc gets skipped.
+
+> Source: [PR #218](https://github.com/rube-de/cc-skills/pull/218) — initial `Stop` hook hit 8+ consecutive blocks per Stop attempt during a live `auto-task` run; commit `e3001ee` added the cooldown. The original spec anticipated *reminder fatigue* (lead learns to ignore the reminder) but not the *doom-loop* variant (reminder physically prevents progress).
+
 ---
 
 ## Plugin Structure

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -260,6 +260,38 @@ Security-critical hooks should **block when uncertain** (fail-closed) rather tha
 
 > Note: `enforce-lead-delegation.sh` is now dormant (Issue #59) — its fail-closed patterns remain as reference for future hooks. See "PreToolUse hooks cannot enforce role boundaries" above.
 
+### Hook output schemas are per-event — `jq` parsing is not a validation step
+
+The Claude Code hook contract defines a separate `hookSpecificOutput` sub-schema **per event type**. Only `PreToolUse`, `UserPromptSubmit`, `PostToolUse`, and `PostToolBatch` have a `hookSpecificOutput` variant. `Stop`, `SubagentStop`, `SessionStart`, `SessionEnd`, `PreCompact`, and `Notification` accept only the top-level fields (`decision`, `reason`, `systemMessage`, `continue`, `suppressOutput`, `stopReason`). A hook that emits `hookSpecificOutput.additionalContext` on a `Stop` event will fail runtime validation with `"(root): Invalid input"` even though the JSON is well-formed.
+
+`jq .` checks JSON syntax, not schema conformance — a hook that passes manual smoke tests can still fail in production. There is no offline validator; the only reliable test is to trigger the real event in a live Claude Code session.
+
+**Bad** — assumed `additionalContext` works for all events (it doesn't for `Stop`):
+```sh
+cat <<'JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "Stop",
+    "additionalContext": "REMINDER: ..."
+  }
+}
+JSON
+```
+
+**Good** — `Stop` hooks use top-level `decision` + `reason`, matching `block-cdt-without-teams.sh`:
+```sh
+cat <<'JSON'
+{
+  "decision": "block",
+  "reason": "REMINDER: ..."
+}
+JSON
+```
+
+**Rule of thumb**: When wiring a new hook event type, copy the output shape from an *existing working hook on the same event*, not from a different event. The available output mechanisms also vary by event — JSON `decision`/`reason`, stderr + `exit 2`, and side-effect-only scripts are all valid in this plugin (`block-cdt-without-teams.sh`, `check-agent-teams.sh`, `track-team-state.sh` respectively). Pick the one used by an existing hook on the same event before inventing.
+
+> Source: [PR #218](https://github.com/rube-de/cc-skills/pull/218) — `Stop` hook shipped with `hookSpecificOutput.additionalContext` (valid for `UserPromptSubmit`/`PostToolUse`, not `Stop`). Caught only after a live `Stop` event hit the runtime validator. Spec had flagged the risk in "Open Questions" — verification was not performed before merge.
+
 ---
 
 ## Plugin Structure

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -306,8 +306,10 @@ COOLDOWN_SECONDS=300
 
 if [ -f "$WARNED_FILE" ]; then
   NOW=$(date +%s)
-  # macOS: stat -f %m, Linux: stat -c %Y
-  LAST=$(stat -f %m "$WARNED_FILE" 2>/dev/null || stat -c %Y "$WARNED_FILE" 2>/dev/null || echo 0)
+  # GNU stat first (-c %Y), then BSD stat (-f %m). On Linux, `stat -f` means
+  # --file-system, which would emit filesystem-status text and break the
+  # arithmetic below — so the GNU form must be tried first.
+  LAST=$(stat -c %Y "$WARNED_FILE" 2>/dev/null || stat -f %m "$WARNED_FILE" 2>/dev/null || echo 0)
   DELTA=$((NOW - LAST))
   [ "$DELTA" -ge 0 ] && [ "$DELTA" -lt "$COOLDOWN_SECONDS" ] && exit 0
 fi

--- a/plugins/cdt/hooks/hooks.json
+++ b/plugins/cdt/hooks/hooks.json
@@ -56,6 +56,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/check-wave-gate-handoff.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/cdt/scripts/check-wave-gate-handoff.sh
+++ b/plugins/cdt/scripts/check-wave-gate-handoff.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 # Stop hook: when the lead is about to go idle during an active CDT team,
-# emit a system reminder requiring TaskList verification before idling.
-# Pattern follows block-cdt-without-teams.sh — filesystem marker + reminder.
+# block the Stop and emit a system reminder requiring TaskList verification
+# before idling.
+#
+# Output schema: top-level `decision: "block"` + `reason` — the documented
+# Stop-hook contract. `hookSpecificOutput` has no Stop variant.
+# Pattern matches block-cdt-without-teams.sh.
+#
 # Active-team marker is maintained by track-team-state.sh.
 
 BRANCH=$(git branch --show-current 2>/dev/null | tr '/' '-')
@@ -14,10 +19,8 @@ cat >/dev/null  # drain stdin (hook contract requires consuming JSON event paylo
 
 cat <<'JSON'
 {
-  "hookSpecificOutput": {
-    "hookEventName": "Stop",
-    "additionalContext": "WAVE-GATE CHECK (REQUIRED before continuing): Active CDT team detected. Run TaskList now. If ANY task is `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe — send the kickoff message to the appropriate teammate and assign ownership before going idle. A pending+unblocked+unowned task during an active team is NEVER 'standing by' time."
-  }
+  "decision": "block",
+  "reason": "WAVE-GATE CHECK: Active CDT team detected. Run TaskList now. If ANY task is `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe — send the kickoff message to the appropriate teammate and assign ownership before idling. If NO such task exists, all handoffs are accounted for; reply briefly with what you verified and stop again."
 }
 JSON
 

--- a/plugins/cdt/scripts/check-wave-gate-handoff.sh
+++ b/plugins/cdt/scripts/check-wave-gate-handoff.sh
@@ -1,26 +1,47 @@
 #!/bin/sh
 # Stop hook: when the lead is about to go idle during an active CDT team,
-# block the Stop and emit a system reminder requiring TaskList verification
-# before idling.
+# remind the lead to verify TaskList for unowned wave-gate handoffs.
 #
-# Output schema: top-level `decision: "block"` + `reason` — the documented
-# Stop-hook contract. `hookSpecificOutput` has no Stop variant.
-# Pattern matches block-cdt-without-teams.sh.
+# Pattern follows block-cdt-without-teams.sh — filesystem marker + reminder
+# via decision:block + reason. Active-team marker is maintained by
+# track-team-state.sh.
 #
-# Active-team marker is maintained by track-team-state.sh.
+# Cooldown: at most one fire per 5 minutes (300s) per branch. The Stop event
+# fires on every assistant turn that ends without further tool use, so
+# without a cooldown a single active team session would re-block every Stop
+# attempt indefinitely. The 5-minute window scopes this hook to a
+# last-resort safety net — if the normal workflow rules (Step 6b in
+# dev-workflow.md + the Lead Verification Rule in SKILL.md) fail to catch a
+# wave-gate handoff, the next Stop after the cooldown surfaces a reminder.
 
 BRANCH=$(git branch --show-current 2>/dev/null | tr '/' '-')
 [ -z "$BRANCH" ] && exit 0
 
-STATE_FILE=".dev/cdt/${BRANCH}/.cdt-team-active"
+BRANCH_DIR=".dev/cdt/${BRANCH}"
+STATE_FILE="${BRANCH_DIR}/.cdt-team-active"
 [ ! -f "$STATE_FILE" ] && exit 0
 
 cat >/dev/null  # drain stdin (hook contract requires consuming JSON event payload)
 
+WARNED_FILE="${BRANCH_DIR}/.cdt-wave-gate-warned"
+COOLDOWN_SECONDS=300
+
+if [ -f "$WARNED_FILE" ]; then
+  NOW=$(date +%s)
+  # macOS: stat -f %m, Linux: stat -c %Y. Fall back to 0 (force fire) if neither works.
+  LAST=$(stat -f %m "$WARNED_FILE" 2>/dev/null || stat -c %Y "$WARNED_FILE" 2>/dev/null || echo 0)
+  DELTA=$((NOW - LAST))
+  if [ "$DELTA" -ge 0 ] && [ "$DELTA" -lt "$COOLDOWN_SECONDS" ]; then
+    exit 0
+  fi
+fi
+
+touch "$WARNED_FILE"
+
 cat <<'JSON'
 {
   "decision": "block",
-  "reason": "WAVE-GATE CHECK: Active CDT team detected. Run TaskList now. If ANY task is `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe — send the kickoff message to the appropriate teammate and assign ownership before idling. If NO such task exists, all handoffs are accounted for; reply briefly with what you verified and stop again."
+  "reason": "WAVE-GATE SAFETY NET (fires at most once per 5min during an active CDT team — if you are seeing this, the Step 6b rules and the Lead Verification Rule in SKILL.md did not catch a handoff in time): Run TaskList. If ANY task is `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe — send the kickoff message and assign ownership. If NO such task exists, all handoffs are accounted for; reply briefly with what you verified and stop again."
 }
 JSON
 

--- a/plugins/cdt/scripts/check-wave-gate-handoff.sh
+++ b/plugins/cdt/scripts/check-wave-gate-handoff.sh
@@ -1,18 +1,33 @@
 #!/bin/sh
-# Stop hook: when the lead is about to go idle during an active CDT team,
+# Stop hook: when the lead is about to go idle during an active CDT dev-team,
 # remind the lead to verify TaskList for unowned wave-gate handoffs.
 #
-# Pattern follows block-cdt-without-teams.sh — filesystem marker + reminder
-# via decision:block + reason. Active-team marker is maintained by
-# track-team-state.sh.
+# Last-resort safety net. The normal workflow rules (Step 6b in dev-workflow.md
+# + the Lead Verification Rule in SKILL.md) should catch every wave-gate
+# handoff before idle. If a handoff slips through, this hook fires at most
+# once per cooldown window per branch.
 #
-# Cooldown: at most one fire per 5 minutes (300s) per branch. The Stop event
-# fires on every assistant turn that ends without further tool use, so
-# without a cooldown a single active team session would re-block every Stop
-# attempt indefinitely. The 5-minute window scopes this hook to a
-# last-resort safety net — if the normal workflow rules (Step 6b in
-# dev-workflow.md + the Lead Verification Rule in SKILL.md) fail to catch a
-# wave-gate handoff, the next Stop after the cooldown surfaces a reminder.
+# Scope: dev-team only. plan-team and bugfix-team have different topologies
+# without the same wave-gate handoff shape, so the marker contents (team name
+# written by track-team-state.sh) gate this guardrail.
+#
+# stop_hook_active: when a Stop hook caused the model to keep going, Claude
+# Code re-fires Stop with stop_hook_active=true. Re-blocking in that state
+# would prevent any turn from ever completing — exit silently and let the
+# model's response close out naturally.
+
+# Drain stdin first (hook contract requires consuming the JSON payload). Skip
+# when stdin is a TTY so interactive smoke tests don't hang on `cat`.
+PAYLOAD=""
+if [ ! -t 0 ]; then
+  PAYLOAD=$(cat)
+fi
+
+if [ -n "$PAYLOAD" ] && command -v jq >/dev/null 2>&1; then
+  if printf '%s' "$PAYLOAD" | jq -e '.stop_hook_active == true' >/dev/null 2>&1; then
+    exit 0
+  fi
+fi
 
 BRANCH=$(git branch --show-current 2>/dev/null | tr '/' '-')
 [ -z "$BRANCH" ] && exit 0
@@ -21,15 +36,18 @@ BRANCH_DIR=".dev/cdt/${BRANCH}"
 STATE_FILE="${BRANCH_DIR}/.cdt-team-active"
 [ ! -f "$STATE_FILE" ] && exit 0
 
-cat >/dev/null  # drain stdin (hook contract requires consuming JSON event payload)
+TEAM_NAME=$(cat "$STATE_FILE" 2>/dev/null)
+[ "$TEAM_NAME" != "dev-team" ] && exit 0
 
 WARNED_FILE="${BRANCH_DIR}/.cdt-wave-gate-warned"
 COOLDOWN_SECONDS=300
 
 if [ -f "$WARNED_FILE" ]; then
   NOW=$(date +%s)
-  # macOS: stat -f %m, Linux: stat -c %Y. Fall back to 0 (force fire) if neither works.
-  LAST=$(stat -f %m "$WARNED_FILE" 2>/dev/null || stat -c %Y "$WARNED_FILE" 2>/dev/null || echo 0)
+  # GNU stat first (-c %Y), then BSD stat (-f %m). On Linux, `stat -f` means
+  # --file-system, which would emit filesystem-status text and break the
+  # arithmetic below — so the GNU form must be tried first.
+  LAST=$(stat -c %Y "$WARNED_FILE" 2>/dev/null || stat -f %m "$WARNED_FILE" 2>/dev/null || echo 0)
   DELTA=$((NOW - LAST))
   if [ "$DELTA" -ge 0 ] && [ "$DELTA" -lt "$COOLDOWN_SECONDS" ]; then
     exit 0
@@ -41,7 +59,7 @@ touch "$WARNED_FILE"
 cat <<'JSON'
 {
   "decision": "block",
-  "reason": "WAVE-GATE SAFETY NET (fires at most once per 5min during an active CDT team — if you are seeing this, the Step 6b rules and the Lead Verification Rule in SKILL.md did not catch a handoff in time): Run TaskList. If ANY task is `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe — send the kickoff message and assign ownership. If NO such task exists, all handoffs are accounted for; reply briefly with what you verified and stop again."
+  "reason": "WAVE-GATE SAFETY NET (fires at most once per 5min during an active CDT dev-team — if you are seeing this, the Step 6b rules and the Lead Verification Rule in SKILL.md did not catch a handoff in time): Run TaskList. If ANY task is `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe — send the kickoff message and assign ownership. If NO such task exists, all handoffs are accounted for; reply briefly with what you verified and stop again."
 }
 JSON
 

--- a/plugins/cdt/scripts/check-wave-gate-handoff.sh
+++ b/plugins/cdt/scripts/check-wave-gate-handoff.sh
@@ -2,10 +2,16 @@
 # Stop hook: when the lead is about to go idle during an active CDT dev-team,
 # remind the lead to verify TaskList for unowned wave-gate handoffs.
 #
-# Last-resort safety net. The normal workflow rules (Step 6b in dev-workflow.md
-# + the Lead Verification Rule in SKILL.md) should catch every wave-gate
-# handoff before idle. If a handoff slips through, this hook fires at most
-# once per cooldown window per branch.
+# Last-resort safety net. The normal workflow rules (Step 6a/6b in
+# dev-workflow.md + the Lead Verification Rule in SKILL.md) should catch every
+# wave-gate handoff before idle. If a handoff slips through, this hook fires at
+# most once per cooldown window per branch.
+#
+# I/O channel: this script writes its decision JSON to stdout (Stop hooks
+# consume hook output from stdout). Sibling guard `block-cdt-without-teams.sh`
+# uses a different I/O channel (stderr) for its tool-input warning — the
+# filesystem-marker pattern is shared via `track-team-state.sh`, but the output
+# channel is not. STATE_FILE below points at that shared marker.
 #
 # Scope: dev-team only. plan-team and bugfix-team have different topologies
 # without the same wave-gate handoff shape, so the marker contents (team name
@@ -23,9 +29,17 @@ if [ ! -t 0 ]; then
   PAYLOAD=$(cat)
 fi
 
-if [ -n "$PAYLOAD" ] && command -v jq >/dev/null 2>&1; then
-  if printf '%s' "$PAYLOAD" | jq -e '.stop_hook_active == true' >/dev/null 2>&1; then
-    exit 0
+if [ -n "$PAYLOAD" ]; then
+  if command -v jq >/dev/null 2>&1; then
+    if printf '%s' "$PAYLOAD" | jq -e '.stop_hook_active == true' >/dev/null 2>&1; then
+      exit 0
+    fi
+  else
+    # jq-less fallback: a literal "stop_hook_active": true match is sufficient
+    # because Claude Code emits this field as a top-level boolean only.
+    if printf '%s' "$PAYLOAD" | grep -Eq '"stop_hook_active"[[:space:]]*:[[:space:]]*true'; then
+      exit 0
+    fi
   fi
 fi
 
@@ -60,7 +74,7 @@ COOLDOWN_MIN=$((COOLDOWN_SECONDS / 60))
 cat <<JSON
 {
   "decision": "block",
-  "reason": "WAVE-GATE SAFETY NET (fires at most once per ${COOLDOWN_MIN}min during an active CDT dev-team — if you are seeing this, the Step 6b rules and the Lead Verification Rule in SKILL.md did not catch a handoff in time): Run TaskList. If ANY task is \`status=pending && blockedBy=[] && owner=null\`, that task is a wave-gate handoff you owe — send the kickoff message and assign ownership. If NO such task exists, all handoffs are accounted for; reply briefly with what you verified and stop again."
+  "reason": "WAVE-GATE SAFETY NET (fires at most once per ${COOLDOWN_MIN}min during an active CDT dev-team — if you are seeing this, the Step 6a/6b rules and the Lead Verification Rule in SKILL.md did not catch a handoff in time): Run TaskList. If ANY task is \`status=pending && blockedBy=[] && owner=null\`, that task is a wave-gate handoff you owe — send the kickoff message and assign ownership. If NO such task exists, all handoffs are accounted for; reply briefly with what you verified and stop again."
 }
 JSON
 

--- a/plugins/cdt/scripts/check-wave-gate-handoff.sh
+++ b/plugins/cdt/scripts/check-wave-gate-handoff.sh
@@ -56,10 +56,11 @@ fi
 
 touch "$WARNED_FILE"
 
-cat <<'JSON'
+COOLDOWN_MIN=$((COOLDOWN_SECONDS / 60))
+cat <<JSON
 {
   "decision": "block",
-  "reason": "WAVE-GATE SAFETY NET (fires at most once per 5min during an active CDT dev-team — if you are seeing this, the Step 6b rules and the Lead Verification Rule in SKILL.md did not catch a handoff in time): Run TaskList. If ANY task is `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe — send the kickoff message and assign ownership. If NO such task exists, all handoffs are accounted for; reply briefly with what you verified and stop again."
+  "reason": "WAVE-GATE SAFETY NET (fires at most once per ${COOLDOWN_MIN}min during an active CDT dev-team — if you are seeing this, the Step 6b rules and the Lead Verification Rule in SKILL.md did not catch a handoff in time): Run TaskList. If ANY task is \`status=pending && blockedBy=[] && owner=null\`, that task is a wave-gate handoff you owe — send the kickoff message and assign ownership. If NO such task exists, all handoffs are accounted for; reply briefly with what you verified and stop again."
 }
 JSON
 

--- a/plugins/cdt/scripts/check-wave-gate-handoff.sh
+++ b/plugins/cdt/scripts/check-wave-gate-handoff.sh
@@ -8,10 +8,9 @@
 # most once per cooldown window per branch.
 #
 # I/O channel: this script writes its decision JSON to stdout (Stop hooks
-# consume hook output from stdout). Sibling guard `block-cdt-without-teams.sh`
-# uses a different I/O channel (stderr) for its tool-input warning — the
-# filesystem-marker pattern is shared via `track-team-state.sh`, but the output
-# channel is not. STATE_FILE below points at that shared marker.
+# consume hook output from stdout). The filesystem-marker pattern is shared
+# with sibling guard `block-cdt-without-teams.sh` via `track-team-state.sh`;
+# STATE_FILE below points at that shared marker.
 #
 # Scope: dev-team only. plan-team and bugfix-team have different topologies
 # without the same wave-gate handoff shape, so the marker contents (team name

--- a/plugins/cdt/scripts/check-wave-gate-handoff.sh
+++ b/plugins/cdt/scripts/check-wave-gate-handoff.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Stop hook: when the lead is about to go idle during an active CDT team,
+# emit a system reminder requiring TaskList verification before idling.
+# Pattern follows block-cdt-without-teams.sh — filesystem marker + reminder.
+# Active-team marker is maintained by track-team-state.sh.
+
+BRANCH=$(git branch --show-current 2>/dev/null | tr '/' '-')
+[ -z "$BRANCH" ] && exit 0
+
+STATE_FILE=".dev/cdt/${BRANCH}/.cdt-team-active"
+[ ! -f "$STATE_FILE" ] && exit 0
+
+cat >/dev/null  # drain stdin (hook contract requires consuming JSON event payload)
+
+cat <<'JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "Stop",
+    "additionalContext": "WAVE-GATE CHECK (REQUIRED before continuing): Active CDT team detected. Run TaskList now. If ANY task is `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe — send the kickoff message to the appropriate teammate and assign ownership before going idle. A pending+unblocked+unowned task during an active team is NEVER 'standing by' time."
+  }
+}
+JSON
+
+exit 0

--- a/plugins/cdt/scripts/track-team-state.sh
+++ b/plugins/cdt/scripts/track-team-state.sh
@@ -14,6 +14,9 @@ BRANCH_DIR=".dev/cdt/${BRANCH}"
 case "$ACTION" in
   create)
     mkdir -p "$BRANCH_DIR"
+    # Clear stale wave-gate cooldown marker from a prior team session so each
+    # new team starts with a fresh first-fire window.
+    rm -f "${BRANCH_DIR}/.cdt-wave-gate-warned"
     if command -v jq >/dev/null 2>&1; then
       TEAM_NAME=$(cat | jq -r '.tool_input.team_name // "unknown"' 2>/dev/null)
     else

--- a/plugins/cdt/skills/cdt/SKILL.md
+++ b/plugins/cdt/skills/cdt/SKILL.md
@@ -114,6 +114,8 @@ You are a **coordinator**, not an implementer. During active team phases:
 
 ### Lead Verification Rule
 
-Before replying "standing by" or going idle during an active team session, run TaskList. If any task matches `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe. Send the kickoff message to the appropriate teammate per dev-workflow.md (test tasks → code-tester / qa-tester per Step 6a; `Review all` → reviewer per Step 6b) and assign ownership BEFORE going idle.
+Before replying "standing by" or going idle during an active **dev-team** session, run TaskList. If any task matches `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe. Send the kickoff message to the appropriate teammate per dev-workflow.md (test tasks → code-tester / qa-tester per Step 6a; `Review all` → reviewer per Step 6b) and assign ownership BEFORE going idle.
 
-A pending+unblocked+unowned task during an active team is never "standing by" time — it is always lead action time.
+A pending+unblocked+unowned task during an active dev-team is never "standing by" time — it is always lead action time.
+
+(Plan-team and bugfix-team have different topologies and don't use this same wave-gate handoff shape — their handoffs are covered by their own workflow files.)

--- a/plugins/cdt/skills/cdt/SKILL.md
+++ b/plugins/cdt/skills/cdt/SKILL.md
@@ -111,3 +111,9 @@ You are a **coordinator**, not an implementer. During active team phases:
 
 ### ALLOWED to do directly
 - Git operations: commit, push, branch, PR creation
+
+### Lead Verification Rule
+
+Before replying "standing by" or going idle during an active team session, run TaskList. If any task matches `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe. Send the kickoff message to the appropriate teammate (matching the task's `type`) and assign ownership BEFORE going idle.
+
+A pending+unblocked+unowned task during an active team is never "standing by" time — it is always lead action time.

--- a/plugins/cdt/skills/cdt/SKILL.md
+++ b/plugins/cdt/skills/cdt/SKILL.md
@@ -114,6 +114,6 @@ You are a **coordinator**, not an implementer. During active team phases:
 
 ### Lead Verification Rule
 
-Before replying "standing by" or going idle during an active team session, run TaskList. If any task matches `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe. Send the kickoff message to the appropriate teammate (matching the task's `type`) and assign ownership BEFORE going idle.
+Before replying "standing by" or going idle during an active team session, run TaskList. If any task matches `status=pending && blockedBy=[] && owner=null`, that task is a wave-gate handoff you owe. Send the kickoff message to the appropriate teammate per dev-workflow.md (test tasks → code-tester / qa-tester per Step 6a; `Review all` → reviewer per Step 6b) and assign ownership BEFORE going idle.
 
 A pending+unblocked+unowned task during an active team is never "standing by" time — it is always lead action time.

--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -230,22 +230,22 @@ Within a wave, intervene only on escalation (after 3 failed peer iteration cycle
 ### 6a. Impl→Test Wave Transition
 
 After all impl waves:
-7. Message code-tester teammate: "Implementation complete. Files: [list]. Acceptance criteria to verify: [unchecked VERIFY items from Step 1 — i.e., `- [ ] VERIFY:` items only]. Begin testing. Report failures directly to the developer teammate. Only message me when all tests pass."
-8. Message qa-tester teammate: "Implementation complete. Files changed: [list]. Acceptance criteria to verify: [unchecked VERIFY items from Step 1 — i.e., `- [ ] VERIFY:` items only]. Begin QA testing. Report issues directly to the developer teammate. Only message me when all QA checks pass."
-9. Code-tester and qa-tester run in parallel — they test different aspects.
-10. Developer teammate↔Code-tester teammate and Developer teammate↔QA-tester teammate iterate directly.
+1. Message code-tester teammate: "Implementation complete. Files: [list]. Acceptance criteria to verify: [unchecked VERIFY items from Step 1 — i.e., `- [ ] VERIFY:` items only]. Begin testing. Report failures directly to the developer teammate. Only message me when all tests pass."
+2. Message qa-tester teammate: "Implementation complete. Files changed: [list]. Acceptance criteria to verify: [unchecked VERIFY items from Step 1 — i.e., `- [ ] VERIFY:` items only]. Begin QA testing. Report issues directly to the developer teammate. Only message me when all QA checks pass."
+3. Code-tester and qa-tester run in parallel — they test different aspects.
+4. Developer teammate↔Code-tester teammate and Developer teammate↔QA-tester teammate iterate directly.
 
-### 6b. Wave Transitions
+### 6b. Test→Review Wave Transition
 
-A wave transition is a **lead action**, not a stand-back moment. When the testers' "all green" arrives, you owe the next teammate a kickoff. Work through this checklist linearly — do NOT reply "standing by" until step 14 is done.
+A wave transition is a **lead action**, not a stand-back moment. When the testers' "all green" arrives, you owe the next teammate a kickoff. Work through this checklist linearly — do NOT reply "standing by" until step 4 is done.
 
 After all test tasks complete:
-11. Verify all test tasks are `status=completed` in TaskList.
-12. Confirm the `Review all` task is unblocked (`blockedBy=[]`).
-13. SendMessage to reviewer teammate: "Tests passing. Files: [list]. Begin review. Send fix requests directly to the developer teammate. Only message me when review is approved."
-14. TaskUpdate `Review all` with `owner="reviewer"`.
+1. Verify all test tasks are `status=completed` in TaskList.
+2. Confirm the `Review all` task is unblocked (`blockedBy=[]`).
+3. SendMessage to reviewer teammate: "Tests passing. Files: [list]. Begin review. Send fix requests directly to the developer teammate. Only message me when review is approved."
+4. TaskUpdate `Review all` with `owner="reviewer"`.
 
-After step 14: Developer teammate↔Reviewer teammate iterate directly. Intervene only on escalation.
+After step 4: Developer teammate↔Reviewer teammate iterate directly. Intervene only on escalation.
 
 ### 6c. Post-Kickoff Standby
 

--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -225,17 +225,33 @@ For each wave:
    - If there are staged changes (`! git diff --cached --quiet`), commit: `git commit -m "feat(wave-N): [brief wave description from plan]"`
    - If nothing is staged in this wave (coordination-only), skip the commit
 
+### 6a. Intra-Wave Iteration
+
 After all impl waves:
 7. Message code-tester teammate: "Implementation complete. Files: [list]. Acceptance criteria to verify: [unchecked VERIFY items from Step 1 — i.e., `- [ ] VERIFY:` items only]. Begin testing. Report failures directly to the developer teammate. Only message me when all tests pass."
 8. Message qa-tester teammate: "Implementation complete. Files changed: [list]. Acceptance criteria to verify: [unchecked VERIFY items from Step 1 — i.e., `- [ ] VERIFY:` items only]. Begin QA testing. Report issues directly to the developer teammate. Only message me when all QA checks pass."
 9. Code-tester and qa-tester run in parallel — they test different aspects.
-10. Developer teammate↔Code-tester teammate and Developer teammate↔QA-tester teammate iterate directly. Intervene only on escalation.
+10. Developer teammate↔Code-tester teammate and Developer teammate↔QA-tester teammate iterate directly.
+
+Within a wave, intervene only on escalation (after 3 failed peer iteration cycles). The "stand back" rule in 6c applies once you have completed the wave-transition kickoff in 6b — not before.
+
+### 6b. Wave Transitions
+
+A wave transition is a **lead action**, not a stand-back moment. When the testers' "all green" arrives, you owe the next teammate a kickoff. Work through this checklist linearly — do NOT reply "standing by" until step 4 is done.
 
 After all test tasks complete:
-11. Message reviewer teammate: "Tests passing. Files: [list]. Begin review. Send fix requests directly to the developer teammate. Only message me when review is approved."
-12. Developer teammate↔Reviewer teammate iterate directly. Intervene only on escalation.
+1. Verify all test tasks are `status=completed` in TaskList.
+2. Confirm the `Review all` task is unblocked (`blockedBy=[]`).
+3. SendMessage to reviewer teammate: "Tests passing. Files: [list]. Begin review. Send fix requests directly to the developer teammate. Only message me when review is approved."
+4. TaskUpdate `Review all` with `owner="reviewer"`.
 
-After activating testers/reviewer, stand back:
+After step 4: Developer teammate↔Reviewer teammate iterate directly. Intervene only on escalation.
+
+### 6c. Post-Kickoff Standby
+
+This rule applies **only after** the wave-transition kickoff in 6b has been sent. Before the kickoff, you are not "standing by" — you owe a handoff.
+
+Once the kickoff is sent, stand back:
 - Do NOT expect failure reports — those go Developer↔Tester/Reviewer directly
 - You only receive: "all tests pass", "all QA checks pass", "review approved"
 - Intervene ONLY on escalation (after 3 failed peer iteration cycles)

--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -225,15 +225,15 @@ For each wave:
    - If there are staged changes (`! git diff --cached --quiet`), commit: `git commit -m "feat(wave-N): [brief wave description from plan]"`
    - If nothing is staged in this wave (coordination-only), skip the commit
 
-### 6a. Intra-Wave Iteration
+Within a wave, intervene only on escalation (after 3 failed peer iteration cycles). The "stand back" rule in 6c applies once you have completed the wave-transition kickoff in 6a or 6b — not before.
+
+### 6a. Impl→Test Wave Transition
 
 After all impl waves:
 7. Message code-tester teammate: "Implementation complete. Files: [list]. Acceptance criteria to verify: [unchecked VERIFY items from Step 1 — i.e., `- [ ] VERIFY:` items only]. Begin testing. Report failures directly to the developer teammate. Only message me when all tests pass."
 8. Message qa-tester teammate: "Implementation complete. Files changed: [list]. Acceptance criteria to verify: [unchecked VERIFY items from Step 1 — i.e., `- [ ] VERIFY:` items only]. Begin QA testing. Report issues directly to the developer teammate. Only message me when all QA checks pass."
 9. Code-tester and qa-tester run in parallel — they test different aspects.
 10. Developer teammate↔Code-tester teammate and Developer teammate↔QA-tester teammate iterate directly.
-
-Within a wave, intervene only on escalation (after 3 failed peer iteration cycles). The "stand back" rule in 6c applies once you have completed the wave-transition kickoff in 6b — not before.
 
 ### 6b. Wave Transitions
 
@@ -249,7 +249,7 @@ After step 14: Developer teammate↔Reviewer teammate iterate directly. Interven
 
 ### 6c. Post-Kickoff Standby
 
-This rule applies **only after** the wave-transition kickoff in 6b has been sent. Before the kickoff, you are not "standing by" — you owe a handoff.
+This rule applies **only after** the wave-transition kickoff in 6a or 6b has been sent. Before the kickoff, you are not "standing by" — you owe a handoff.
 
 Once the kickoff is sent, stand back:
 - Do NOT expect failure reports — those go Developer↔Tester/Reviewer directly

--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -237,15 +237,15 @@ Within a wave, intervene only on escalation (after 3 failed peer iteration cycle
 
 ### 6b. Wave Transitions
 
-A wave transition is a **lead action**, not a stand-back moment. When the testers' "all green" arrives, you owe the next teammate a kickoff. Work through this checklist linearly — do NOT reply "standing by" until step 4 is done.
+A wave transition is a **lead action**, not a stand-back moment. When the testers' "all green" arrives, you owe the next teammate a kickoff. Work through this checklist linearly — do NOT reply "standing by" until step 14 is done.
 
 After all test tasks complete:
-1. Verify all test tasks are `status=completed` in TaskList.
-2. Confirm the `Review all` task is unblocked (`blockedBy=[]`).
-3. SendMessage to reviewer teammate: "Tests passing. Files: [list]. Begin review. Send fix requests directly to the developer teammate. Only message me when review is approved."
-4. TaskUpdate `Review all` with `owner="reviewer"`.
+11. Verify all test tasks are `status=completed` in TaskList.
+12. Confirm the `Review all` task is unblocked (`blockedBy=[]`).
+13. SendMessage to reviewer teammate: "Tests passing. Files: [list]. Begin review. Send fix requests directly to the developer teammate. Only message me when review is approved."
+14. TaskUpdate `Review all` with `owner="reviewer"`.
 
-After step 4: Developer teammate↔Reviewer teammate iterate directly. Intervene only on escalation.
+After step 14: Developer teammate↔Reviewer teammate iterate directly. Intervene only on escalation.
 
 ### 6c. Post-Kickoff Standby
 


### PR DESCRIPTION
Closes #217

## Summary

In CDT dev mode, the workflow can stall at the test→review wave gate: testers report "all green" to the lead, but the lead never sends the kickoff message to the reviewer (idle teammates wait for messages — they don't auto-poll TaskList). A task sits `pending && blockedBy=[] && owner=null` indefinitely. Root cause is structural: the lead conflates the intra-wave "stand back" rule with the wave-gate handoff, the handoff is buried in prose, and there is no verification gate before going idle.

This PR ships the spec's "Doc Restructure + Stop-Hook Guardrail" approach (`.dev/pm/specs/2026-04-26-cdt-wave-gate-stall.md`):

- **Doc layer.** Restructure `plugins/cdt/skills/cdt/references/dev-workflow.md` Step 6 into three named subsections — `6a. Intra-Wave Iteration`, `6b. Wave Transitions`, `6c. Post-Kickoff Standby`. Promote the test→review handoff to a numbered checklist. Scope the "stand back" rule to *only after* the kickoff has been sent.
- **Lead invariant.** Add `### Lead Verification Rule` under `## Lead Identity` in `plugins/cdt/skills/cdt/SKILL.md`. Sits alongside other first-class lead rules instead of buried in workflow prose.
- **Runtime guardrail.** New `plugins/cdt/scripts/check-wave-gate-handoff.sh` (`Stop` hook). When the `.dev/cdt/<branch>/.cdt-team-active` marker contains `dev-team`, emits a top-level `{"decision":"block","reason":"WAVE-GATE SAFETY NET …"}` reminder requiring TaskList verification before idling. The hook is dev-team-scoped (plan-team / bugfix-team are skipped), short-circuits when `stop_hook_active=true`, and is rate-limited to one fire per 5 minutes via `.cdt-wave-gate-warned`. Wired in `plugins/cdt/hooks/hooks.json` under a new `Stop` array.

The hook does NOT introspect TaskList in-process (Claude Code hooks can't read in-process Teammate state — see the comment in the dormant `enforce-lead-delegation.sh`). It uses the existing active-team marker as a sufficient signal.

## Test plan

- [x] Hook smoke test — no team active: silent stdout, `exit=0`.
- [x] Hook smoke test — `.cdt-team-active` marker contains `dev-team`: emits valid JSON with top-level `decision: "block"` and `reason` containing "WAVE-GATE SAFETY NET", `exit=0`.
- [x] Hook smoke test — `.cdt-team-active` marker contains `plan-team` or `bugfix-team`: silent stdout, `exit=0` (out of scope for wave-gate semantics).
- [x] Hook smoke test — `stop_hook_active=true` in payload: silent stdout, `exit=0` (avoids continuation-loop traps).
- [x] Hook smoke test — cooldown: second call within 5 min is silent; first call emits the reminder.
- [x] Hook smoke test — outside any git repo (detached-HEAD analog): silent, `exit=0`.
- [x] Output JSON parses cleanly through `jq .`.
- [x] `bun scripts/validate-plugins.mjs` — all checks passed.
- [x] Acceptance-criteria spot checks (`rg` for the three `### 6[abc].` headings, `### Lead Verification Rule`, executable bit on the new script, `Stop` array wired in `hooks.json`).
- [ ] (Post-merge dogfood) Run a real CDT dev-mode session, confirm reminder fires at Stop events during active team, confirm wave-gate handoff is no longer skipped.

## Out of scope

- Auto-kickoff orchestration (rejected per spec — would shift visible failure to invisible failure).
- TaskList persistence (deferred — try Approach B first).
- `bugfix-workflow.md` / `plan-workflow.md` changes (different topology, different bug class).
- Architect↔PM debate-handoff guardrail (separate concern).
- Teammate prompt changes (the lead caused this bug, not the teammates).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a stop-time handoff guard that prompts leads to check and dispatch any pending unowned wave-gate tasks before idling.
  * Enforced a per-branch cooldown to avoid repetitive blocking at session stop.

* **Documentation**
  * Restructured wave coordination into explicit phases and clarified lead-driven transition and reviewer kickoff procedures, including ownership assignment before idling.
  * Added guidance on hook output shapes and cooldown best practices to avoid runtime loops.

* **Chores**
  * Clear previous warning markers when starting a new session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
