### PR TITLE
feat(cdt): append Agent Notes section to PR body in Wrap Up

### DIFF
--- a/plugins/cdt/README.md
+++ b/plugins/cdt/README.md
@@ -63,8 +63,8 @@ Planning Phase                    Development Phase
 |---------|---------|---------------|--------|
 | `/cdt:plan-task` | Planning only | N/A | `.dev/cdt/plans/plan-YYYYMMDD-HHMM.md` |
 | `/cdt:dev-task` | Develop from existing plan | N/A | Updated plan + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` |
-| `/cdt:full-task` | Complete workflow | **Yes** (user choice) | `plan.md` + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` |
-| `/cdt:auto-task` | Autonomous end-to-end | No | `plan.md` + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` |
+| `/cdt:full-task` | Complete workflow | **Yes** (user choice) | `plan.md` + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` + PR body with `Agent Notes` section |
+| `/cdt:auto-task` | Autonomous end-to-end | No | `plan.md` + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` + PR body with `Agent Notes` section |
 
 ### `/cdt:plan-task` — Design Phase
 
@@ -85,6 +85,10 @@ Runs `/cdt:plan-task`, presents the plan to the user for approval (Approve / Rev
 ### `/cdt:auto-task` — Autonomous Mode
 
 Same as `/cdt:full-task` but skips the approval gate. Proceeds directly from planning to development.
+
+### PR body enrichment (full-task and auto-task)
+
+When either command opens a PR during Wrap Up, the PR body is enriched with an `## Agent Notes` block mirroring the handoff's `Open Questions` and `Context for Next Session` sections. This carries the agent's forward-looking signal into the PR (where downstream tooling can consume it) since the handoff file itself lives under gitignored `.dev/`. If both sections are empty, the block is omitted.
 
 ## Hooks
 

--- a/plugins/cdt/README.md
+++ b/plugins/cdt/README.md
@@ -63,8 +63,8 @@ Planning Phase                    Development Phase
 |---------|---------|---------------|--------|
 | `/cdt:plan-task` | Planning only | N/A | `.dev/cdt/plans/plan-YYYYMMDD-HHMM.md` |
 | `/cdt:dev-task` | Develop from existing plan | N/A | Updated plan + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` |
-| `/cdt:full-task` | Complete workflow | **Yes** (user choice) | `plan.md` + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` + PR body with `Agent Notes` section |
-| `/cdt:auto-task` | Autonomous end-to-end | No | `plan.md` + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` + PR body with `Agent Notes` section |
+| `/cdt:full-task` | Complete workflow | **Yes** (user choice) | `plan.md` + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` + PR body with `## Agent Notes` |
+| `/cdt:auto-task` | Autonomous end-to-end | No | `plan.md` + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` + PR body with `## Agent Notes` |
 
 ### `/cdt:plan-task` — Design Phase
 

--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -98,19 +98,19 @@ Automatically finalize without user interaction:
 1. Stage all changed files
 2. Commit with conventional commit message based on task
 3. Push branch to remote
-4. Draft the `Open Questions` and `Context for Next Session` content you will write to the handoff in step 7 — keep both in working memory so the PR body and the handoff carry identical text. Then create PR via `gh pr create`. PR body = plan summary as description, `Closes #$ISSUE_NO` (if applicable, see below), and an `## Agent Notes` block formatted as:
+4. Derive `BRANCH=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only). Draft the *content* (excluding headings) for the `Open Questions` and `Context for Next Session` sections you will write to the handoff in step 7 — keep both in working memory so the PR body and the handoff carry identical body text under their respective headings. Then create PR via `gh pr create`. PR body = plan summary as description, `Closes #$ISSUE_NO` (if applicable), and an `## Agent Notes` block formatted as:
 
     ```markdown
     ## Agent Notes
 
     ### Open Questions
-    [drafted Open Questions content]
+    [drafted Open Questions content — body only, no heading]
 
     ### Context for Next Session
-    [drafted Context for Next Session content]
+    [drafted Context for Next Session content — body only, no heading]
     ```
 
-    If both `Open Questions` and `Context for Next Session` are empty, omit the entire `## Agent Notes` block — do NOT emit an empty heading. Derive `BRANCH=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only), then include `Closes #$ISSUE_NO` in the PR body.
+    If both `Open Questions` and `Context for Next Session` are empty, omit the entire `## Agent Notes` block — do NOT emit an empty heading.
 5. After PR creation, if `".dev/cdt/$BRANCH/.cdt-scripts-path"` exists, move the issue to "In Review":
    `"$(cat ".dev/cdt/$BRANCH/.cdt-scripts-path")/sync-github-issue.sh" review`
 6. Ensure handoff directory exists: `mkdir -p .dev/cdt/handoffs`

--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -98,11 +98,23 @@ Automatically finalize without user interaction:
 1. Stage all changed files
 2. Commit with conventional commit message based on task
 3. Push branch to remote
-4. Create PR via `gh pr create` with plan summary as description. Derive `BRANCH=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only), then include `Closes #$ISSUE_NO` in the PR body.
+4. Draft the `Open Questions` and `Context for Next Session` content you will write to the handoff in step 7 — keep both in working memory so the PR body and the handoff carry identical text. Then create PR via `gh pr create`. PR body = plan summary as description, `Closes #$ISSUE_NO` (if applicable, see below), and an `## Agent Notes` block formatted as:
+
+    ```markdown
+    ## Agent Notes
+
+    ### Open Questions
+    [drafted Open Questions content]
+
+    ### Context for Next Session
+    [drafted Context for Next Session content]
+    ```
+
+    If both `Open Questions` and `Context for Next Session` are empty, omit the entire `## Agent Notes` block — do NOT emit an empty heading. Derive `BRANCH=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only), then include `Closes #$ISSUE_NO` in the PR body.
 5. After PR creation, if `".dev/cdt/$BRANCH/.cdt-scripts-path"` exists, move the issue to "In Review":
    `"$(cat ".dev/cdt/$BRANCH/.cdt-scripts-path")/sync-github-issue.sh" review`
 6. Ensure handoff directory exists: `mkdir -p .dev/cdt/handoffs`
-7. Write session handoff to `.dev/cdt/handoffs/handoff-$TIMESTAMP.md` (using `$TIMESTAMP` from Phase 2):
+7. Write session handoff to `.dev/cdt/handoffs/handoff-$TIMESTAMP.md` (using `$TIMESTAMP` from Phase 2). Reuse the same `Open Questions` and `Context for Next Session` content drafted for the PR body in step 4 — do not regenerate or rephrase:
 
     ```markdown
     # Session Handoff

--- a/plugins/cdt/commands/full-task.md
+++ b/plugins/cdt/commands/full-task.md
@@ -113,7 +113,19 @@ If creating PR:
 1. Stage changed files
 2. Commit with conventional commit message based on task
 3. Push branch
-4. Create PR with plan summary as description. Derive `BRANCH=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only), then include `Closes #$ISSUE_NO` in the PR body.
+4. Read `.dev/cdt/handoffs/handoff-$TIMESTAMP.md` (written by `dev-workflow.md` step 9 during Phase 2) and extract its `Open Questions` and `Context for Next Session` sections verbatim. Create PR. PR body = plan summary as description, `Closes #$ISSUE_NO` (if applicable, see below), and an `## Agent Notes` block formatted as:
+
+    ```markdown
+    ## Agent Notes
+
+    ### Open Questions
+    [extracted Open Questions content]
+
+    ### Context for Next Session
+    [extracted Context for Next Session content]
+    ```
+
+    If both extracted sections are empty, omit the entire `## Agent Notes` block — do NOT emit an empty heading. Derive `BRANCH=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only), then include `Closes #$ISSUE_NO` in the PR body.
 5. After PR creation, if `".dev/cdt/$BRANCH/.cdt-scripts-path"` exists, move the issue to "In Review":
    `"$(cat ".dev/cdt/$BRANCH/.cdt-scripts-path")/sync-github-issue.sh" review`
 6. Clean up branch state: `[ -n "$BRANCH" ] && rm -rf ".dev/cdt/$BRANCH"`

--- a/plugins/cdt/commands/full-task.md
+++ b/plugins/cdt/commands/full-task.md
@@ -113,7 +113,7 @@ If creating PR:
 1. Stage changed files
 2. Commit with conventional commit message based on task
 3. Push branch
-4. Derive `BRANCH=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only). Read `.dev/cdt/handoffs/handoff-$TIMESTAMP.md` (written by `dev-workflow.md` step 9 during Phase 2) and extract the *content* under its `## Open Questions` and `## Context for Next Session` headings — exclude the heading lines themselves and stop extraction at the next `##` heading. Create PR. PR body = plan summary as description, `Closes #$ISSUE_NO` (if applicable), and an `## Agent Notes` block formatted as:
+4. Derive `BRANCH=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only). Read `.dev/cdt/handoffs/handoff-$TIMESTAMP.md` (written by `dev-workflow.md` step 9 during Phase 2) and extract the *content* under its `## Open Questions` and `## Context for Next Session` headings — exclude the heading lines themselves and stop extraction at the next `## ` heading at the start of a line, or at end-of-file if there is no subsequent `## ` heading. Create PR. PR body = plan summary as description, `Closes #$ISSUE_NO` (if applicable), and an `## Agent Notes` block formatted as:
 
     ```markdown
     ## Agent Notes

--- a/plugins/cdt/commands/full-task.md
+++ b/plugins/cdt/commands/full-task.md
@@ -113,19 +113,19 @@ If creating PR:
 1. Stage changed files
 2. Commit with conventional commit message based on task
 3. Push branch
-4. Read `.dev/cdt/handoffs/handoff-$TIMESTAMP.md` (written by `dev-workflow.md` step 9 during Phase 2) and extract its `Open Questions` and `Context for Next Session` sections verbatim. Create PR. PR body = plan summary as description, `Closes #$ISSUE_NO` (if applicable, see below), and an `## Agent Notes` block formatted as:
+4. Derive `BRANCH=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only). Read `.dev/cdt/handoffs/handoff-$TIMESTAMP.md` (written by `dev-workflow.md` step 9 during Phase 2) and extract the *content* under its `## Open Questions` and `## Context for Next Session` headings — exclude the heading lines themselves and stop extraction at the next `##` heading. Create PR. PR body = plan summary as description, `Closes #$ISSUE_NO` (if applicable), and an `## Agent Notes` block formatted as:
 
     ```markdown
     ## Agent Notes
 
     ### Open Questions
-    [extracted Open Questions content]
+    [extracted Open Questions content — body only, no heading]
 
     ### Context for Next Session
-    [extracted Context for Next Session content]
+    [extracted Context for Next Session content — body only, no heading]
     ```
 
-    If both extracted sections are empty, omit the entire `## Agent Notes` block — do NOT emit an empty heading. Derive `BRANCH=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only), then include `Closes #$ISSUE_NO` in the PR body.
+    If both extracted sections are empty, omit the entire `## Agent Notes` block — do NOT emit an empty heading.
 5. After PR creation, if `".dev/cdt/$BRANCH/.cdt-scripts-path"` exists, move the issue to "In Review":
    `"$(cat ".dev/cdt/$BRANCH/.cdt-scripts-path")/sync-github-issue.sh" review`
 6. Clean up branch state: `[ -n "$BRANCH" ] && rm -rf ".dev/cdt/$BRANCH"`


### PR DESCRIPTION
## Summary

- Extend the Wrap Up step in `plugins/cdt/commands/auto-task.md` and `plugins/cdt/commands/full-task.md` so that when CDT creates a PR, the body gains an `## Agent Notes` section mirroring the handoff's `Open Questions` and `Context for Next Session` content.
- Update `plugins/cdt/README.md` so the commands table and per-command subsections describe the new PR-body output.

## Why

The handoff file (`.dev/cdt/handoffs/handoff-$TIMESTAMP.md`) is gitignored — its forward-looking sections die on the local machine and never reach the PR. A forthcoming GitHub Action (`pr-explainer-action`) will consume PR bodies in CI, so propagating the agent's signal into the PR closes the gap without committing new files.

## Implementation notes

- **`auto-task.md`**: PR is created (step 4) before the handoff is written (step 7). Step 4 now instructs the agent to draft the two sections in working memory first, embed them in the PR body, and reuse them verbatim in step 7. This avoids a reorder that would have broken the handoff's `## References - PR:` link.
- **`full-task.md`**: The handoff already exists at Wrap Up time (`dev-workflow.md` step 9 ran during Phase 2). Step 4 now reads the handoff file and extracts the two sections verbatim.
- **Empty-section rule**: If both `Open Questions` and `Context for Next Session` are empty, the entire `## Agent Notes` block is omitted — no empty heading.
- Prompt-engineering compliance per `docs/learnings.md`: imperatives in numbered steps, single numbered sequence, omission rule lives inside the step (not the preamble).

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [x] `git diff --stat` shows only the three target files changed (+33/-5)
- [x] `rg "Agent Notes" plugins/cdt/` confirms placement in both command templates and README
- [ ] Manual smoke test deferred — exercising `/cdt:auto-task` requires a full multi-agent cycle; correctness here is template-level.

Closes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CDT command docs for /cdt:full-task and /cdt:auto-task. PRs created during Wrap Up now include an "## Agent Notes" section that mirrors Open Questions and Context for Next Session; the block is omitted if both are empty. The same drafted Open Questions/Context content is reused between wrap-up drafting and the handoff to ensure consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->