### PR TITLE
fix(cdt): scope team names per run to eliminate TeamCreate collisions

### DIFF
--- a/plugins/cdt/README.md
+++ b/plugins/cdt/README.md
@@ -168,7 +168,7 @@ export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 | Dev-task can't find plan | Wrong path | Pass the timestamped plan path as argument |
 | Stuck in iteration loop | Max cycles exceeded | After 3 cycles, escalates to user automatically |
 | File conflicts between tasks | Parallel task overlap | Tasks in same wave should not touch same files |
-| Stale team dirs accumulating in `~/.claude/teams/` | Workflow exited before Wrap Up | Run [`scripts/clean-stale-teams.sh`](scripts/clean-stale-teams.sh) (dry-run by default; pass `--yes` to delete) |
+| Stale team dirs accumulating in `~/.claude/teams/` | Workflow exited before Wrap Up | Run [`sh scripts/clean-stale-teams.sh`](scripts/clean-stale-teams.sh) (dry-run by default; pass `--yes` to delete). If you hit permission-denied errors removing `~/.claude/teams/`, run it from your local shell outside Claude Code. |
 
 ## References
 

--- a/plugins/cdt/README.md
+++ b/plugins/cdt/README.md
@@ -168,6 +168,7 @@ export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 | Dev-task can't find plan | Wrong path | Pass the timestamped plan path as argument |
 | Stuck in iteration loop | Max cycles exceeded | After 3 cycles, escalates to user automatically |
 | File conflicts between tasks | Parallel task overlap | Tasks in same wave should not touch same files |
+| Stale team dirs accumulating in `~/.claude/teams/` | Workflow exited before Wrap Up | Run [`scripts/clean-stale-teams.sh`](scripts/clean-stale-teams.sh) (dry-run by default; pass `--yes` to delete) |
 
 ## References
 

--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -29,6 +29,8 @@ Phase 1: plan-team                    Phase 2: dev-team
 
 `[tm]` = teammate (Agent Team)  `[sa]` = subagent
 
+The `plan-team` / `dev-team` labels above are role names; the actual team names created by the workflow are scoped per run as `plan-<branch>-<timestamp>` and `dev-<branch>-<timestamp>` to avoid collisions on the global `~/.claude/teams/` namespace.
+
 ## Step 0: Git Check
 
 1. Run `git fetch origin`

--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -29,7 +29,7 @@ Phase 1: plan-team                    Phase 2: dev-team
 
 `[tm]` = teammate (Agent Team)  `[sa]` = subagent
 
-The `plan-team` / `dev-team` labels above are role names; the actual team names created by the workflow are scoped per run as `plan-<branch>-<timestamp>` and `dev-<branch>-<timestamp>` to avoid collisions on the global `~/.claude/teams/` namespace.
+The `plan-team` / `dev-team` labels above are role names; the actual team names created by the workflow are scoped per run as `plan-<branch-slug>-<timestamp>` and `dev-<branch-slug>-<timestamp>` to avoid collisions on the global `~/.claude/teams/` namespace, where `branch-slug` is the current branch name with `/` replaced by `-`.
 
 ## Step 0: Git Check
 

--- a/plugins/cdt/commands/bugfix.md
+++ b/plugins/cdt/commands/bugfix.md
@@ -31,7 +31,7 @@ Flow: Tester → Developer → Tester → Developer → Tester → Reviewer
 
 `[tm]` = teammate (Agent Team)  `[sa]` = subagent
 
-The `bugfix-team` label above is a role name; the actual team name created by the workflow is scoped per run as `bugfix-<branch-slug>-<timestamp>` to avoid collisions on the global `~/.claude/teams/` namespace, where `branch-slug` is the current branch name with `/` replaced by `-`.
+The `bugfix-team` label above is a role name; the actual team name created by the workflow is scoped per run as `bugfix-<branch-slug>-<YYYYMMDD-HHMMSS>-<nonce>` to avoid collisions on the global `~/.claude/teams/` namespace, where `branch-slug` is the current branch name with `/` replaced by `-`.
 
 ## Step 0: Workflow Declaration
 

--- a/plugins/cdt/commands/bugfix.md
+++ b/plugins/cdt/commands/bugfix.md
@@ -31,6 +31,8 @@ Flow: Tester → Developer → Tester → Developer → Tester → Reviewer
 
 `[tm]` = teammate (Agent Team)  `[sa]` = subagent
 
+The `bugfix-team` label above is a role name; the actual team name created by the workflow is scoped per run as `bugfix-<branch>-<timestamp>` to avoid collisions on the global `~/.claude/teams/` namespace.
+
 ## Step 0: Workflow Declaration
 
 Print to the user before proceeding:
@@ -65,7 +67,7 @@ If any role was created but never used: **WARN** "Role {name} was created but ne
 
 ## Rules
 
-- One team: `bugfix-team`
+- One team: the bugfix team (scoped per run as `bugfix-<branch>-<timestamp>`)
 - Bug spec is the single source of truth (no plan file)
 - Researcher is always a subagent — Lead relays
 - All other roles are teammates

--- a/plugins/cdt/commands/bugfix.md
+++ b/plugins/cdt/commands/bugfix.md
@@ -67,7 +67,7 @@ If any role was created but never used: **WARN** "Role {name} was created but ne
 
 ## Rules
 
-- One team: the bugfix team (scoped per run as `bugfix-<branch-slug>-<timestamp>`)
+- One team: the bugfix team (scoped per run as `bugfix-<branch-slug>-<YYYYMMDD-HHMMSS>-<nonce>`)
 - Bug spec is the single source of truth (no plan file)
 - Researcher is always a subagent — Lead relays
 - All other roles are teammates

--- a/plugins/cdt/commands/bugfix.md
+++ b/plugins/cdt/commands/bugfix.md
@@ -31,7 +31,7 @@ Flow: Tester → Developer → Tester → Developer → Tester → Reviewer
 
 `[tm]` = teammate (Agent Team)  `[sa]` = subagent
 
-The `bugfix-team` label above is a role name; the actual team name created by the workflow is scoped per run as `bugfix-<branch>-<timestamp>` to avoid collisions on the global `~/.claude/teams/` namespace.
+The `bugfix-team` label above is a role name; the actual team name created by the workflow is scoped per run as `bugfix-<branch-slug>-<timestamp>` to avoid collisions on the global `~/.claude/teams/` namespace, where `branch-slug` is the current branch name with `/` replaced by `-`.
 
 ## Step 0: Workflow Declaration
 
@@ -67,7 +67,7 @@ If any role was created but never used: **WARN** "Role {name} was created but ne
 
 ## Rules
 
-- One team: the bugfix team (scoped per run as `bugfix-<branch>-<timestamp>`)
+- One team: the bugfix team (scoped per run as `bugfix-<branch-slug>-<timestamp>`)
 - Bug spec is the single source of truth (no plan file)
 - Researcher is always a subagent — Lead relays
 - All other roles are teammates

--- a/plugins/cdt/commands/full-task.md
+++ b/plugins/cdt/commands/full-task.md
@@ -29,6 +29,8 @@ Phase 1: plan-team                    Phase 2: dev-team
 
 `[tm]` = teammate (Agent Team)  `[sa]` = subagent
 
+The `plan-team` / `dev-team` labels above are role names; the actual team names created by the workflow are scoped per run as `plan-<branch>-<timestamp>` and `dev-<branch>-<timestamp>` to avoid collisions on the global `~/.claude/teams/` namespace.
+
 ## Step 0: Git Check
 
 1. Run `git fetch origin`

--- a/plugins/cdt/commands/full-task.md
+++ b/plugins/cdt/commands/full-task.md
@@ -29,7 +29,7 @@ Phase 1: plan-team                    Phase 2: dev-team
 
 `[tm]` = teammate (Agent Team)  `[sa]` = subagent
 
-The `plan-team` / `dev-team` labels above are role names; the actual team names created by the workflow are scoped per run as `plan-<branch>-<timestamp>` and `dev-<branch>-<timestamp>` to avoid collisions on the global `~/.claude/teams/` namespace.
+The `plan-team` / `dev-team` labels above are role names; the actual team names created by the workflow are scoped per run as `plan-<branch-slug>-<timestamp>` and `dev-<branch-slug>-<timestamp>` to avoid collisions on the global `~/.claude/teams/` namespace, where `branch-slug` is the current branch name with `/` replaced by `-`.
 
 ## Step 0: Git Check
 

--- a/plugins/cdt/scripts/check-wave-gate-handoff.sh
+++ b/plugins/cdt/scripts/check-wave-gate-handoff.sh
@@ -54,7 +54,7 @@ TEAM_NAME=$(cat "$STATE_FILE" 2>/dev/null)
 # "dev-<branch-slug>-<YYYYMMDD>-<HHMM[SS]>[-<nonce>]". A bare "dev-*" prefix
 # match would also fire for unrelated user-named teams (e.g. "dev-foo"),
 # blocking arbitrary sessions every cooldown window.
-echo "$TEAM_NAME" | grep -qE '^dev-team$|^dev-.+-[0-9]{8}-[0-9]{4,6}(-[0-9a-f]{4})?$' || exit 0
+echo "$TEAM_NAME" | grep -qE '^dev-team$|^dev-.+-[0-9]{8}-([0-9]{4}|[0-9]{6})(-[0-9a-f]{4})?$' || exit 0
 
 WARNED_FILE="${BRANCH_DIR}/.cdt-wave-gate-warned"
 COOLDOWN_SECONDS=300

--- a/plugins/cdt/scripts/check-wave-gate-handoff.sh
+++ b/plugins/cdt/scripts/check-wave-gate-handoff.sh
@@ -50,7 +50,11 @@ STATE_FILE="${BRANCH_DIR}/.cdt-team-active"
 [ ! -f "$STATE_FILE" ] && exit 0
 
 TEAM_NAME=$(cat "$STATE_FILE" 2>/dev/null)
-[ "$TEAM_NAME" != "dev-team" ] && exit 0
+# Match both legacy bare "dev-team" and scoped "dev-<branch>-<timestamp>" forms.
+case "$TEAM_NAME" in
+  dev-*) ;;
+  *) exit 0 ;;
+esac
 
 WARNED_FILE="${BRANCH_DIR}/.cdt-wave-gate-warned"
 COOLDOWN_SECONDS=300

--- a/plugins/cdt/scripts/check-wave-gate-handoff.sh
+++ b/plugins/cdt/scripts/check-wave-gate-handoff.sh
@@ -50,11 +50,11 @@ STATE_FILE="${BRANCH_DIR}/.cdt-team-active"
 [ ! -f "$STATE_FILE" ] && exit 0
 
 TEAM_NAME=$(cat "$STATE_FILE" 2>/dev/null)
-# Match both legacy bare "dev-team" and scoped "dev-<branch>-<timestamp>" forms.
-case "$TEAM_NAME" in
-  dev-*) ;;
-  *) exit 0 ;;
-esac
+# Match only the CDT-shaped dev team names — legacy bare "dev-team" or scoped
+# "dev-<branch-slug>-<YYYYMMDD>-<HHMM[SS]>[-<nonce>]". A bare "dev-*" prefix
+# match would also fire for unrelated user-named teams (e.g. "dev-foo"),
+# blocking arbitrary sessions every cooldown window.
+echo "$TEAM_NAME" | grep -qE '^dev-team$|^dev-.+-[0-9]{8}-[0-9]{4,6}(-[0-9a-f]{4})?$' || exit 0
 
 WARNED_FILE="${BRANCH_DIR}/.cdt-wave-gate-warned"
 COOLDOWN_SECONDS=300

--- a/plugins/cdt/scripts/clean-stale-teams.sh
+++ b/plugins/cdt/scripts/clean-stale-teams.sh
@@ -1,13 +1,30 @@
 #!/bin/sh
 # Removes stale CDT team/task dirs from ~/.claude/.
-# Matches ^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4}$
-# Legacy bare names (plan-team / dev-team / bugfix-team) are intentionally not matched.
+# Matches ^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}$ — accepts both minute
+# (HHMM) and second (HHMMSS) resolution timestamps. Legacy bare names
+# (plan-team / dev-team / bugfix-team) are intentionally not matched.
 #
 # Usage:
-#   clean-stale-teams.sh                       # dry-run, default older-than 7 days
-#   clean-stale-teams.sh --yes                 # actually delete
-#   clean-stale-teams.sh --older-than 1 --yes  # delete dirs older than 1 day
-#   clean-stale-teams.sh --help                # print this help
+#   clean-stale-teams.sh                       dry-run, default older-than 7 days
+#   clean-stale-teams.sh --yes                 actually delete
+#   clean-stale-teams.sh --older-than 1 --yes  delete dirs older than 1 day
+#   clean-stale-teams.sh --help                print this help
+
+print_help() {
+  cat <<'HELP_END'
+clean-stale-teams.sh — remove stale CDT team/task dirs under ~/.claude/.
+
+Matches ^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}$ (minute or second
+timestamp). Legacy bare names (plan-team / dev-team / bugfix-team) are
+intentionally not matched.
+
+Usage:
+  clean-stale-teams.sh                       dry-run, default older-than 7 days
+  clean-stale-teams.sh --yes                 actually delete
+  clean-stale-teams.sh --older-than 1 --yes  delete dirs older than 1 day
+  clean-stale-teams.sh --help                print this help
+HELP_END
+}
 
 DRY_RUN=1
 OLDER_THAN_DAYS=7
@@ -27,7 +44,7 @@ while [ $# -gt 0 ]; do
       shift 2
       ;;
     -h|--help)
-      sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'
+      print_help
       exit 0
       ;;
     *)
@@ -37,34 +54,45 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-REGEX='^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4}$'
+REGEX='^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}$'
 SWEPT=0
 REMOVED=0
+FAILED=0
 
 for ROOT in "$HOME/.claude/teams" "$HOME/.claude/tasks"; do
   [ -d "$ROOT" ] || continue
-  while IFS= read -r DIR; do
-    [ -z "$DIR" ] && continue
+  # Iterate immediate children only — replaces non-POSIX `find -mindepth/-maxdepth`.
+  for DIR in "$ROOT"/*; do
+    [ -d "$DIR" ] || continue
     NAME=$(basename "$DIR")
     echo "$NAME" | grep -qE "$REGEX" || continue
+    # POSIX-portable mtime check: `find <path> -prune -mtime +N` evaluates only the path itself.
+    AGED=$(find "$DIR" -prune -mtime "+$OLDER_THAN_DAYS" 2>/dev/null)
+    [ -n "$AGED" ] || continue
     SWEPT=$((SWEPT + 1))
     if [ "$DRY_RUN" -eq 1 ]; then
       echo "[DRY-RUN] would remove: $DIR"
     else
-      rm -rf "$DIR"
-      REMOVED=$((REMOVED + 1))
-      echo "removed: $DIR"
+      if rm -rf "$DIR" 2>/dev/null; then
+        REMOVED=$((REMOVED + 1))
+        echo "removed: $DIR"
+      else
+        FAILED=$((FAILED + 1))
+        echo "failed to remove: $DIR" >&2
+      fi
     fi
-  done <<HEREDOC_END
-$(find "$ROOT" -mindepth 1 -maxdepth 1 -type d -mtime "+$OLDER_THAN_DAYS" 2>/dev/null)
-HEREDOC_END
+  done
 done
 
 echo ""
 if [ "$DRY_RUN" -eq 1 ]; then
   echo "[DRY-RUN] $SWEPT dir(s) matched. Re-run with --yes to remove."
+  exit 0
 else
   echo "$REMOVED dir(s) removed."
+  if [ "$FAILED" -gt 0 ]; then
+    echo "$FAILED dir(s) failed to remove (see stderr)." >&2
+    exit 1
+  fi
+  exit 0
 fi
-
-exit 0

--- a/plugins/cdt/scripts/clean-stale-teams.sh
+++ b/plugins/cdt/scripts/clean-stale-teams.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Removes stale CDT team/task dirs from ~/.claude/.
-# Matches ^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}(-[0-9a-f]{4})?$ — accepts
+# Matches ^(plan|dev|bugfix)-.*-[0-9]{8}-([0-9]{4}|[0-9]{6})(-[0-9a-f]{4})?$ — accepts
 # minute (HHMM) and second (HHMMSS) resolution timestamps, with an optional
 # 4-hex per-run nonce. Legacy bare names (plan-team / dev-team / bugfix-team)
 # are intentionally not matched.
@@ -21,7 +21,7 @@ print_help() {
   cat <<'HELP_END'
 clean-stale-teams.sh — remove stale CDT team/task dirs under ~/.claude/.
 
-Matches ^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}(-[0-9a-f]{4})?$ (minute or
+Matches ^(plan|dev|bugfix)-.*-[0-9]{8}-([0-9]{4}|[0-9]{6})(-[0-9a-f]{4})?$ (minute or
 second timestamp, optional 4-hex nonce). Legacy bare names
 (plan-team / dev-team / bugfix-team) are intentionally not matched.
 
@@ -65,7 +65,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-REGEX='^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}(-[0-9a-f]{4})?$'
+REGEX='^(plan|dev|bugfix)-.*-[0-9]{8}-([0-9]{4}|[0-9]{6})(-[0-9a-f]{4})?$'
 SWEPT=0
 REMOVED=0
 FAILED=0

--- a/plugins/cdt/scripts/clean-stale-teams.sh
+++ b/plugins/cdt/scripts/clean-stale-teams.sh
@@ -1,27 +1,38 @@
 #!/bin/sh
 # Removes stale CDT team/task dirs from ~/.claude/.
-# Matches ^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}$ — accepts both minute
-# (HHMM) and second (HHMMSS) resolution timestamps. Legacy bare names
-# (plan-team / dev-team / bugfix-team) are intentionally not matched.
+# Matches ^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}(-[0-9a-f]{4})?$ — accepts
+# minute (HHMM) and second (HHMMSS) resolution timestamps, with an optional
+# 4-hex per-run nonce. Legacy bare names (plan-team / dev-team / bugfix-team)
+# are intentionally not matched.
+#
+# Age semantics: --older-than N selects dirs whose mtime is >= N days old.
+# Internally this maps to find -mtime +(N-1) (POSIX find treats -mtime in
+# integer 24h periods, so +N would actually mean ">N+1 days old"). N=0 skips
+# the age filter and matches every dir whose name fits the regex.
 #
 # Usage:
 #   clean-stale-teams.sh                       dry-run, default older-than 7 days
 #   clean-stale-teams.sh --yes                 actually delete
-#   clean-stale-teams.sh --older-than 1 --yes  delete dirs older than 1 day
+#   clean-stale-teams.sh --older-than 1 --yes  delete dirs >=1 day old
+#   clean-stale-teams.sh --older-than 0 --yes  delete every matching dir (no age filter)
 #   clean-stale-teams.sh --help                print this help
 
 print_help() {
   cat <<'HELP_END'
 clean-stale-teams.sh — remove stale CDT team/task dirs under ~/.claude/.
 
-Matches ^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}$ (minute or second
-timestamp). Legacy bare names (plan-team / dev-team / bugfix-team) are
-intentionally not matched.
+Matches ^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}(-[0-9a-f]{4})?$ (minute or
+second timestamp, optional 4-hex nonce). Legacy bare names
+(plan-team / dev-team / bugfix-team) are intentionally not matched.
+
+Age semantics: --older-than N selects dirs whose mtime is >= N days old.
+N=0 skips the age filter and matches every dir whose name fits the regex.
 
 Usage:
   clean-stale-teams.sh                       dry-run, default older-than 7 days
   clean-stale-teams.sh --yes                 actually delete
-  clean-stale-teams.sh --older-than 1 --yes  delete dirs older than 1 day
+  clean-stale-teams.sh --older-than 1 --yes  delete dirs >=1 day old
+  clean-stale-teams.sh --older-than 0 --yes  delete every matching dir (no age filter)
   clean-stale-teams.sh --help                print this help
 HELP_END
 }
@@ -54,10 +65,19 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-REGEX='^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}$'
+REGEX='^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}(-[0-9a-f]{4})?$'
 SWEPT=0
 REMOVED=0
 FAILED=0
+
+# Map --older-than N → find -mtime arg.
+# `find -mtime +K` matches files where floor(age/86400) > K, i.e. age >= (K+1) days.
+# We want "age >= N days", so K = N-1 for N>=1. N=0 means "no age filter".
+if [ "$OLDER_THAN_DAYS" -gt 0 ]; then
+  MTIME_ARG="-mtime +$((OLDER_THAN_DAYS - 1))"
+else
+  MTIME_ARG=""
+fi
 
 for ROOT in "$HOME/.claude/teams" "$HOME/.claude/tasks"; do
   [ -d "$ROOT" ] || continue
@@ -66,8 +86,9 @@ for ROOT in "$HOME/.claude/teams" "$HOME/.claude/tasks"; do
     [ -d "$DIR" ] || continue
     NAME=$(basename "$DIR")
     echo "$NAME" | grep -qE "$REGEX" || continue
-    # POSIX-portable mtime check: `find <path> -prune -mtime +N` evaluates only the path itself.
-    AGED=$(find "$DIR" -prune -mtime "+$OLDER_THAN_DAYS" 2>/dev/null)
+    # POSIX-portable mtime check: `find <path> -prune -mtime +K` evaluates only the path itself.
+    # Empty MTIME_ARG → no age filter (always matches).
+    AGED=$(find "$DIR" -prune $MTIME_ARG 2>/dev/null)
     [ -n "$AGED" ] || continue
     SWEPT=$((SWEPT + 1))
     if [ "$DRY_RUN" -eq 1 ]; then

--- a/plugins/cdt/scripts/clean-stale-teams.sh
+++ b/plugins/cdt/scripts/clean-stale-teams.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Removes stale CDT team/task dirs from ~/.claude/.
+# Matches ^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4}$
+# Legacy bare names (plan-team / dev-team / bugfix-team) are intentionally not matched.
+#
+# Usage:
+#   clean-stale-teams.sh                       # dry-run, default older-than 7 days
+#   clean-stale-teams.sh --yes                 # actually delete
+#   clean-stale-teams.sh --older-than 1 --yes  # delete dirs older than 1 day
+#   clean-stale-teams.sh --help                # print this help
+
+DRY_RUN=1
+OLDER_THAN_DAYS=7
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --yes)
+      DRY_RUN=0
+      shift
+      ;;
+    --older-than)
+      OLDER_THAN_DAYS="$2"
+      if [ -z "$OLDER_THAN_DAYS" ] || ! echo "$OLDER_THAN_DAYS" | grep -qE '^[0-9]+$'; then
+        echo "clean-stale-teams.sh: --older-than requires a non-negative integer" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "clean-stale-teams.sh: unexpected arg '$1'" >&2
+      exit 1
+      ;;
+  esac
+done
+
+REGEX='^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4}$'
+SWEPT=0
+REMOVED=0
+
+for ROOT in "$HOME/.claude/teams" "$HOME/.claude/tasks"; do
+  [ -d "$ROOT" ] || continue
+  while IFS= read -r DIR; do
+    [ -z "$DIR" ] && continue
+    NAME=$(basename "$DIR")
+    echo "$NAME" | grep -qE "$REGEX" || continue
+    SWEPT=$((SWEPT + 1))
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "[DRY-RUN] would remove: $DIR"
+    else
+      rm -rf "$DIR"
+      REMOVED=$((REMOVED + 1))
+      echo "removed: $DIR"
+    fi
+  done <<HEREDOC_END
+$(find "$ROOT" -mindepth 1 -maxdepth 1 -type d -mtime "+$OLDER_THAN_DAYS" 2>/dev/null)
+HEREDOC_END
+done
+
+echo ""
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "[DRY-RUN] $SWEPT dir(s) matched. Re-run with --yes to remove."
+else
+  echo "$REMOVED dir(s) removed."
+fi
+
+exit 0

--- a/plugins/cdt/skills/cdt/SKILL.md
+++ b/plugins/cdt/skills/cdt/SKILL.md
@@ -78,7 +78,7 @@ Reviews changed files for completeness, correctness, security, quality, and plan
 
 ## Rules
 
-- One team at a time — cleanup plan-team before starting dev-team
+- One team at a time — clean up the plan team before starting the dev team
 - Teammates debate directly (Architect teammate↔PM teammate, Developer teammate↔Code-tester teammate, Developer teammate↔QA-tester teammate, Developer teammate↔Reviewer teammate)
 - Researcher is always a subagent — Lead relays results
 - Plan.md is the single source of truth and handoff artifact

--- a/plugins/cdt/skills/cdt/references/bugfix-workflow.md
+++ b/plugins/cdt/skills/cdt/references/bugfix-workflow.md
@@ -49,7 +49,7 @@ Store the assembled spec as `$BUG_SPEC` for use in teammate messages.
 
 ## 1a. Generate Timestamps & Compose Team Name
 
-Generate a minute-resolution timestamp in `YYYYMMDD-HHMM` format and store as `$TIMESTAMP` (used elsewhere if needed). Then compute a second-resolution `TEAM_TIMESTAMP=$(date +%Y%m%d-%H%M%S)` and compose `$TEAM_NAME` as `bugfix-${BRANCH_SLUG}-${TEAM_TIMESTAMP}` (e.g. `bugfix-bugfix-fix-null-return-getuser-20260207-143052`). Scoping the team name to branch+second-timestamp prevents collisions on the global `~/.claude/teams/` namespace — even when the same branch retries the workflow within the same minute after an orphaned team dir.
+Generate a minute-resolution timestamp in `YYYYMMDD-HHMM` format and store as `$TIMESTAMP` (used elsewhere if needed). Then compute a second-resolution `TEAM_TIMESTAMP=$(date +%Y%m%d-%H%M%S)` and a 4-hex-char per-run nonce `TEAM_NONCE=$(od -An -N2 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')`. Compose `$TEAM_NAME` as `bugfix-${BRANCH_SLUG}-${TEAM_TIMESTAMP}-${TEAM_NONCE}` (e.g. `bugfix-bugfix-fix-null-return-getuser-20260207-143052-9f3a`). The nonce closes the residual same-second collision window that a timestamp alone leaves open.
 
 ## 2. Create Team
 
@@ -333,7 +333,7 @@ If tester reports failures or stub scan finds issues: message developer with det
 - Teammates iterate directly — Tester↔Developer, Reviewer↔Developer
 - Lead only receives: test results summaries, review verdicts, escalations
 - Researcher is a subagent — Lead relays if needed
-- One team only — the bugfix team (named `bugfix-${BRANCH_SLUG}-${TEAM_TIMESTAMP}` per run)
+- One team only — the bugfix team (named `bugfix-${BRANCH_SLUG}-${TEAM_TIMESTAMP}-${TEAM_NONCE}` per run)
 - All three quality checks mandatory (test, verify, review)
 - Always cleanup team before finishing
 - If stuck — abort gracefully and report what was accomplished

--- a/plugins/cdt/skills/cdt/references/bugfix-workflow.md
+++ b/plugins/cdt/skills/cdt/references/bugfix-workflow.md
@@ -47,9 +47,9 @@ If the issue lacks structured fields (no expected/actual behavior sections), not
 
 Store the assembled spec as `$BUG_SPEC` for use in teammate messages.
 
-## 1a. Generate Timestamps & Compose Team Name
+## 1a. Compose Team Name
 
-Generate a minute-resolution timestamp in `YYYYMMDD-HHMM` format and store as `$TIMESTAMP` (used elsewhere if needed). Then compute a second-resolution `TEAM_TIMESTAMP=$(date +%Y%m%d-%H%M%S)` and a 4-hex-char per-run nonce `TEAM_NONCE=$(od -An -N2 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')`. Compose `$TEAM_NAME` as `bugfix-${BRANCH_SLUG}-${TEAM_TIMESTAMP}-${TEAM_NONCE}` (e.g. `bugfix-bugfix-fix-null-return-getuser-20260207-143052-9f3a`). The nonce closes the residual same-second collision window that a timestamp alone leaves open.
+Compute a second-resolution `TEAM_TIMESTAMP=$(date +%Y%m%d-%H%M%S)` and a 4-hex-char per-run nonce `TEAM_NONCE=$(od -An -N2 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')`. Compose `$TEAM_NAME` as `bugfix-${BRANCH_SLUG}-${TEAM_TIMESTAMP}-${TEAM_NONCE}` (e.g. `bugfix-bugfix-fix-null-return-getuser-20260207-143052-9f3a`). The nonce closes the residual same-second collision window that a timestamp alone leaves open.
 
 ## 2. Create Team
 

--- a/plugins/cdt/skills/cdt/references/bugfix-workflow.md
+++ b/plugins/cdt/skills/cdt/references/bugfix-workflow.md
@@ -47,10 +47,16 @@ If the issue lacks structured fields (no expected/actual behavior sections), not
 
 Store the assembled spec as `$BUG_SPEC` for use in teammate messages.
 
+## 1a. Generate Timestamp & Compose Team Name
+
+Generate a timestamp in `YYYYMMDD-HHMM` format. Store as `$TIMESTAMP`. Then compose `$TEAM_NAME` as `bugfix-${BRANCH_SLUG}-${TIMESTAMP}` (e.g. `bugfix-bugfix-fix-null-return-getuser-20260207-1430`). Scoping the team name to branch+timestamp prevents collisions on the global `~/.claude/teams/` namespace if a prior session orphaned a team dir.
+
 ## 2. Create Team
 
+Substitute `$TEAM_NAME` with the value computed in Step 1a.
+
 ```text
-TeamCreate: team_name "bugfix-team"
+TeamCreate: team_name "$TEAM_NAME"
 ```
 
 ## 3. Create Tasks
@@ -68,10 +74,12 @@ Use `addBlockedBy` to enforce sequencing.
 
 ## 4. Spawn Teammates
 
+Substitute `$TEAM_NAME` with the value from Step 1a in every spawn block below.
+
 **Tester teammate**:
 ```yaml
 Teammate tool:
-  team_name: "bugfix-team"
+  team_name: "$TEAM_NAME"
   name: "tester"
   model: sonnet
   prompt: >
@@ -119,7 +127,7 @@ Teammate tool:
 **Developer teammate**:
 ```yaml
 Teammate tool:
-  team_name: "bugfix-team"
+  team_name: "$TEAM_NAME"
   name: "developer"
   model: opus
   prompt: >
@@ -169,7 +177,7 @@ Teammate tool:
 **Reviewer teammate**:
 ```yaml
 Teammate tool:
-  team_name: "bugfix-team"
+  team_name: "$TEAM_NAME"
   name: "reviewer"
   model: opus
   prompt: >
@@ -325,7 +333,7 @@ If tester reports failures or stub scan finds issues: message developer with det
 - Teammates iterate directly — Tester↔Developer, Reviewer↔Developer
 - Lead only receives: test results summaries, review verdicts, escalations
 - Researcher is a subagent — Lead relays if needed
-- One team only — `bugfix-team`
+- One team only — the bugfix team (named `bugfix-${BRANCH_SLUG}-${TIMESTAMP}` per run)
 - All three quality checks mandatory (test, verify, review)
 - Always cleanup team before finishing
 - If stuck — abort gracefully and report what was accomplished

--- a/plugins/cdt/skills/cdt/references/bugfix-workflow.md
+++ b/plugins/cdt/skills/cdt/references/bugfix-workflow.md
@@ -47,9 +47,9 @@ If the issue lacks structured fields (no expected/actual behavior sections), not
 
 Store the assembled spec as `$BUG_SPEC` for use in teammate messages.
 
-## 1a. Generate Timestamp & Compose Team Name
+## 1a. Generate Timestamps & Compose Team Name
 
-Generate a timestamp in `YYYYMMDD-HHMM` format. Store as `$TIMESTAMP`. Then compose `$TEAM_NAME` as `bugfix-${BRANCH_SLUG}-${TIMESTAMP}` (e.g. `bugfix-bugfix-fix-null-return-getuser-20260207-1430`). Scoping the team name to branch+timestamp prevents collisions on the global `~/.claude/teams/` namespace if a prior session orphaned a team dir.
+Generate a minute-resolution timestamp in `YYYYMMDD-HHMM` format and store as `$TIMESTAMP` (used elsewhere if needed). Then compute a second-resolution `TEAM_TIMESTAMP=$(date +%Y%m%d-%H%M%S)` and compose `$TEAM_NAME` as `bugfix-${BRANCH_SLUG}-${TEAM_TIMESTAMP}` (e.g. `bugfix-bugfix-fix-null-return-getuser-20260207-143052`). Scoping the team name to branch+second-timestamp prevents collisions on the global `~/.claude/teams/` namespace — even when the same branch retries the workflow within the same minute after an orphaned team dir.
 
 ## 2. Create Team
 
@@ -333,7 +333,7 @@ If tester reports failures or stub scan finds issues: message developer with det
 - Teammates iterate directly — Tester↔Developer, Reviewer↔Developer
 - Lead only receives: test results summaries, review verdicts, escalations
 - Researcher is a subagent — Lead relays if needed
-- One team only — the bugfix team (named `bugfix-${BRANCH_SLUG}-${TIMESTAMP}` per run)
+- One team only — the bugfix team (named `bugfix-${BRANCH_SLUG}-${TEAM_TIMESTAMP}` per run)
 - All three quality checks mandatory (test, verify, review)
 - Always cleanup team before finishing
 - If stuck — abort gracefully and report what was accomplished

--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -35,7 +35,7 @@ Generate a timestamp in `YYYYMMDD-HHMM` format for the session handoff output pa
 
 ## 2a. Compose Team Name
 
-Compose `$TEAM_NAME` as `dev-${BRANCH}-${TIMESTAMP}` (e.g. `dev-feat-rate-limiting-20260207-1430`). Scoping the team name to branch+timestamp prevents collisions on the global `~/.claude/teams/` namespace if a prior session orphaned a team dir.
+Compute a second-resolution timestamp `TEAM_TIMESTAMP=$(date +%Y%m%d-%H%M%S)` (separate from the minute-resolution `$TIMESTAMP` used for the handoff path). Compose `$TEAM_NAME` as `dev-${BRANCH}-${TEAM_TIMESTAMP}` (e.g. `dev-feat-rate-limiting-20260207-143052`). Scoping the team name to branch+second-timestamp prevents collisions on the global `~/.claude/teams/` namespace — even when the same branch retries the workflow within the same minute after an orphaned team dir.
 
 ## 3. Create Team
 

--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -12,11 +12,11 @@ Detailed execution steps for the development phase. The Lead reads this before r
 
 ## 0a. Issue Detection
 
-**Branch-scoped state**: CDT state lives in `.dev/cdt/<branch-slug>/` where `<branch-slug>` is the current branch with `/` replaced by `-`. Derive with: `BRANCH=$(git branch --show-current | tr '/' '-')`; if empty (detached HEAD), checkout a branch before proceeding.
+**Branch-scoped state**: CDT state lives in `.dev/cdt/<branch-slug>/` where `<branch-slug>` is the current branch with `/` replaced by `-`. Derive with: `BRANCH_SLUG=$(git branch --show-current | tr '/' '-')`; if empty (detached HEAD), checkout a branch before proceeding.
 
 1. First, check `$ARGUMENTS` and the plan file for GitHub issue references (`#N`, URL).
-2. If found, extract the number into `$ISSUE_NUM` and write/overwrite: `mkdir -p ".dev/cdt/$BRANCH" && echo "$ISSUE_NUM" > ".dev/cdt/$BRANCH/.cdt-issue"`
-3. Otherwise, if `".dev/cdt/$BRANCH/.cdt-issue"` exists → read the issue number from it into `$ISSUE_NUM`.
+2. If found, extract the number into `$ISSUE_NUM` and write/overwrite: `mkdir -p ".dev/cdt/$BRANCH_SLUG" && echo "$ISSUE_NUM" > ".dev/cdt/$BRANCH_SLUG/.cdt-issue"`
+3. Otherwise, if `".dev/cdt/$BRANCH_SLUG/.cdt-issue"` exists → read the issue number from it into `$ISSUE_NUM`.
 4. If an issue is linked (`$ISSUE_NUM` is set), fetch details for context: `gh issue view "$ISSUE_NUM" --json title,body`
 
 The team creation hook will attempt to assign and move to "In Progress" (best-effort — may no-op if no project item exists).
@@ -35,7 +35,7 @@ Generate a timestamp in `YYYYMMDD-HHMM` format for the session handoff output pa
 
 ## 2a. Compose Team Name
 
-Compute a second-resolution timestamp `TEAM_TIMESTAMP=$(date +%Y%m%d-%H%M%S)` (separate from the minute-resolution `$TIMESTAMP` used for the handoff path). Compose `$TEAM_NAME` as `dev-${BRANCH}-${TEAM_TIMESTAMP}` (e.g. `dev-feat-rate-limiting-20260207-143052`). Scoping the team name to branch+second-timestamp prevents collisions on the global `~/.claude/teams/` namespace — even when the same branch retries the workflow within the same minute after an orphaned team dir.
+Compute a second-resolution timestamp `TEAM_TIMESTAMP=$(date +%Y%m%d-%H%M%S)` (separate from the minute-resolution `$TIMESTAMP` used for the handoff path) and a 4-hex-char per-run nonce `TEAM_NONCE=$(od -An -N2 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')`. Compose `$TEAM_NAME` as `dev-${BRANCH_SLUG}-${TEAM_TIMESTAMP}-${TEAM_NONCE}` (e.g. `dev-feat-rate-limiting-20260207-143052-9f3a`). The nonce closes the residual same-second collision window that a timestamp alone leaves open.
 
 ## 3. Create Team
 
@@ -319,9 +319,9 @@ If creating PR:
 1. Stage all remaining changes (doc updates and any post-wave fixes from test/review cycles)
 2. Commit with conventional commit message based on task (this is the final wrap-up commit)
 3. Push branch (includes all per-wave commits plus this wrap-up commit)
-4. Create PR with plan summary as description. Derive `BRANCH=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only), then include `Closes #$ISSUE_NO` in the PR body.
-5. After PR creation, if `".dev/cdt/$BRANCH/.cdt-scripts-path"` exists, move the issue to "In Review":
-   `"$(cat ".dev/cdt/$BRANCH/.cdt-scripts-path")/sync-github-issue.sh" review`
+4. Create PR with plan summary as description. Derive `BRANCH_SLUG=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH_SLUG/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH_SLUG/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only), then include `Closes #$ISSUE_NO` in the PR body.
+5. After PR creation, if `".dev/cdt/$BRANCH_SLUG/.cdt-scripts-path"` exists, move the issue to "In Review":
+   `"$(cat ".dev/cdt/$BRANCH_SLUG/.cdt-scripts-path")/sync-github-issue.sh" review`
 
 If commit & push only:
 1. Stage all remaining changes (doc updates and any post-wave fixes from test/review cycles)

--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -33,10 +33,16 @@ If missing or not one of `opus`/`sonnet`, default to `opus`.
 
 Generate a timestamp in `YYYYMMDD-HHMM` format for the session handoff output path. Store as `$TIMESTAMP`.
 
+## 2a. Compose Team Name
+
+Compose `$TEAM_NAME` as `dev-${BRANCH}-${TIMESTAMP}` (e.g. `dev-feat-rate-limiting-20260207-1430`). Scoping the team name to branch+timestamp prevents collisions on the global `~/.claude/teams/` namespace if a prior session orphaned a team dir.
+
 ## 3. Create Team
 
+Substitute `$TEAM_NAME` with the value computed in Step 2a.
+
 ```
-TeamCreate: team_name "dev-team"
+TeamCreate: team_name "$TEAM_NAME"
 ```
 
 ## 4. Create Tasks
@@ -48,10 +54,12 @@ TaskCreate for each plan task (preserve `depends_on` via `addBlockedBy`). Also c
 
 ## 5. Spawn Teammates
 
+Substitute `$TEAM_NAME` with the value from Step 2a in every spawn block below.
+
 **Developer teammate**:
 ```
 Teammate tool:
-  team_name: "dev-team"
+  team_name: "$TEAM_NAME"
   name: "developer"
   model: [developer_model from plan, default opus]
   prompt: >
@@ -82,7 +90,7 @@ Teammate tool:
 **Code-tester teammate** (always spawned):
 ```
 Teammate tool:
-  team_name: "dev-team"
+  team_name: "$TEAM_NAME"
   name: "code-tester"
   model: sonnet
   prompt: >
@@ -112,7 +120,7 @@ Teammate tool:
 **QA-tester teammate** (always spawned):
 ```
 Teammate tool:
-  team_name: "dev-team"
+  team_name: "$TEAM_NAME"
   name: "qa-tester"
   model: sonnet
   prompt: >
@@ -162,7 +170,7 @@ Teammate tool:
 **Reviewer teammate**:
 ```
 Teammate tool:
-  team_name: "dev-team"
+  team_name: "$TEAM_NAME"
   name: "reviewer"
   model: opus
   prompt: >

--- a/plugins/cdt/skills/cdt/references/plan-workflow.md
+++ b/plugins/cdt/skills/cdt/references/plan-workflow.md
@@ -12,14 +12,14 @@ Detailed execution steps for the planning phase. The Lead reads this before runn
 
 ## 0a. Derive Branch Slug
 
-**Unconditional** — every subsequent step relies on `$BRANCH`, regardless of whether the user supplied an issue reference. CDT state lives in `.dev/cdt/<branch-slug>/` where `<branch-slug>` is the current branch with `/` replaced by `-`. Derive with: `BRANCH=$(git branch --show-current | tr '/' '-')`; if empty (detached HEAD), checkout a branch before proceeding.
+**Unconditional** — every subsequent step relies on `$BRANCH_SLUG`, regardless of whether the user supplied an issue reference. CDT state lives in `.dev/cdt/<branch-slug>/` where `<branch-slug>` is the current branch with `/` replaced by `-`. Derive with: `BRANCH_SLUG=$(git branch --show-current | tr '/' '-')`; if empty (detached HEAD), checkout a branch before proceeding.
 
 ## 0b. Issue Detection
 
 If `$ARGUMENTS` contains a GitHub issue reference (`#N`, `#N description`, or `https://github.com/OWNER/REPO/issues/N`):
 
 1. Extract the issue number (digits only) and store it in `$ISSUE_NUM`
-2. Write: `mkdir -p ".dev/cdt/$BRANCH" && echo "$ISSUE_NUM" > ".dev/cdt/$BRANCH/.cdt-issue"`
+2. Write: `mkdir -p ".dev/cdt/$BRANCH_SLUG" && echo "$ISSUE_NUM" > ".dev/cdt/$BRANCH_SLUG/.cdt-issue"`
 3. Fetch issue context: `gh issue view "$ISSUE_NUM" --json title,body,labels,assignees`
 4. Use the issue title and body as additional context for planning
 
@@ -33,7 +33,7 @@ Generate a timestamp in `YYYYMMDD-HHMM` format (e.g. `20260207-1430`). Use this 
 
 ## 1a. Compose Team Name
 
-Compute a second-resolution timestamp `TEAM_TIMESTAMP=$(date +%Y%m%d-%H%M%S)` (separate from the minute-resolution `$TIMESTAMP` used for the plan path). Compose `$TEAM_NAME` as `plan-${BRANCH}-${TEAM_TIMESTAMP}` (e.g. `plan-feat-rate-limiting-20260207-143052`). Scoping the team name to branch+second-timestamp prevents collisions on the global `~/.claude/teams/` namespace — even when the same branch retries the workflow within the same minute after an orphaned team dir.
+Compute a second-resolution timestamp `TEAM_TIMESTAMP=$(date +%Y%m%d-%H%M%S)` (separate from the minute-resolution `$TIMESTAMP` used for the plan path) and a 4-hex-char per-run nonce `TEAM_NONCE=$(od -An -N2 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')`. Compose `$TEAM_NAME` as `plan-${BRANCH_SLUG}-${TEAM_TIMESTAMP}-${TEAM_NONCE}` (e.g. `plan-feat-rate-limiting-20260207-143052-9f3a`). The nonce closes the residual same-second collision window that a timestamp alone leaves open.
 
 ## 2. Orient
 
@@ -361,7 +361,7 @@ The architect teammate writes the plan file. Your role is to verify it exists an
 2. Wait for all teammates to confirm shutdown (they may approve or reject — if rejected, resolve the issue first)
 3. Once all teammates have stopped, run TeamDelete to clean up the team
 
-> **State lifecycle**: TeamDelete removes `.cdt-team-active` only. The `.cdt-issue` and `.cdt-scripts-path` files persist in `.dev/cdt/$BRANCH/` for the dev phase and Wrap Up. The full branch directory is cleaned up during the command-level Wrap Up (`/full-task`, `/auto-task`).
+> **State lifecycle**: TeamDelete removes `.cdt-team-active` only. The `.cdt-issue` and `.cdt-scripts-path` files persist in `.dev/cdt/$BRANCH_SLUG/` for the dev phase and Wrap Up. The full branch directory is cleaned up during the command-level Wrap Up (`/full-task`, `/auto-task`).
 
 ## 9. Present
 

--- a/plugins/cdt/skills/cdt/references/plan-workflow.md
+++ b/plugins/cdt/skills/cdt/references/plan-workflow.md
@@ -10,9 +10,11 @@ Detailed execution steps for the planning phase. The Lead reads this before runn
 4. Run `git checkout -b <branch> origin/<default-branch>` to create the feature branch from the latest remote default branch
 5. Run `git pull` to ensure up-to-date
 
-## 0a. Issue Detection
+## 0a. Derive Branch Slug
 
-**Branch-scoped state**: CDT state lives in `.dev/cdt/<branch-slug>/` where `<branch-slug>` is the current branch with `/` replaced by `-`. Derive with: `BRANCH=$(git branch --show-current | tr '/' '-')`; if empty (detached HEAD), checkout a branch before proceeding.
+**Unconditional** — every subsequent step relies on `$BRANCH`, regardless of whether the user supplied an issue reference. CDT state lives in `.dev/cdt/<branch-slug>/` where `<branch-slug>` is the current branch with `/` replaced by `-`. Derive with: `BRANCH=$(git branch --show-current | tr '/' '-')`; if empty (detached HEAD), checkout a branch before proceeding.
+
+## 0b. Issue Detection
 
 If `$ARGUMENTS` contains a GitHub issue reference (`#N`, `#N description`, or `https://github.com/OWNER/REPO/issues/N`):
 
@@ -31,7 +33,7 @@ Generate a timestamp in `YYYYMMDD-HHMM` format (e.g. `20260207-1430`). Use this 
 
 ## 1a. Compose Team Name
 
-Compose `$TEAM_NAME` as `plan-${BRANCH}-${TIMESTAMP}` (e.g. `plan-feat-rate-limiting-20260207-1430`). Scoping the team name to branch+timestamp prevents collisions on the global `~/.claude/teams/` namespace if a prior session orphaned a team dir.
+Compute a second-resolution timestamp `TEAM_TIMESTAMP=$(date +%Y%m%d-%H%M%S)` (separate from the minute-resolution `$TIMESTAMP` used for the plan path). Compose `$TEAM_NAME` as `plan-${BRANCH}-${TEAM_TIMESTAMP}` (e.g. `plan-feat-rate-limiting-20260207-143052`). Scoping the team name to branch+second-timestamp prevents collisions on the global `~/.claude/teams/` namespace — even when the same branch retries the workflow within the same minute after an orphaned team dir.
 
 ## 2. Orient
 

--- a/plugins/cdt/skills/cdt/references/plan-workflow.md
+++ b/plugins/cdt/skills/cdt/references/plan-workflow.md
@@ -29,6 +29,10 @@ If no issue reference is found, skip this step.
 
 Generate a timestamp in `YYYYMMDD-HHMM` format (e.g. `20260207-1430`). Use this for the plan output path. Store as `$TIMESTAMP`.
 
+## 1a. Compose Team Name
+
+Compose `$TEAM_NAME` as `plan-${BRANCH}-${TIMESTAMP}` (e.g. `plan-feat-rate-limiting-20260207-1430`). Scoping the team name to branch+timestamp prevents collisions on the global `~/.claude/teams/` namespace if a prior session orphaned a team dir.
+
 ## 2. Orient
 
 Read project context files (`CLAUDE.md`, `AGENTS.md`) to understand conventions and stack.
@@ -38,8 +42,10 @@ Do NOT explore the codebase with Glob/Grep — that is the architect's job in St
 
 ## 3. Create Team
 
+Substitute `$TEAM_NAME` with the value computed in Step 1a.
+
 ```
-TeamCreate: team_name "plan-team"
+TeamCreate: team_name "$TEAM_NAME"
 ```
 
 ## 4. Create Tasks
@@ -76,10 +82,10 @@ Spawn architect and PM simultaneously. Inject `$RESEARCH_CONTEXT` into both prom
 If `$ARGUMENTS` includes `--review-plan`, inject before the `Set \`**Council Review**: true\`` line in the architect prompt below:
 "The Lead has requested council review via `--review-plan` flag — set `**Council Review**: true` in the plan metadata."
 
-**Architect teammate** (substitute `[plan-path]` → `.dev/cdt/plans/plan-$TIMESTAMP.md` from Step 1):
+**Architect teammate** (substitute `[plan-path]` → `.dev/cdt/plans/plan-$TIMESTAMP.md` and `$TEAM_NAME` → the value from Step 1a):
 ```
 Teammate tool:
-  team_name: "plan-team"
+  team_name: "$TEAM_NAME"
   name: "architect"
   model: opus
   prompt: >
@@ -200,14 +206,14 @@ Teammate tool:
     16. Mark task complete
 ```
 
-**PM teammate** (substitute `[plan-path]` → `.dev/cdt/plans/plan-$TIMESTAMP.md` from Step 1):
+**PM teammate** (substitute `[plan-path]` → `.dev/cdt/plans/plan-$TIMESTAMP.md` and `$TEAM_NAME` → the value from Step 1a):
 
 If `$ARGUMENTS` includes `--review-plan`, inject after the `Plan path:` line in the PM prompt below:
 "Council review has been requested via `--review-plan` flag."
 
 ```text
 Teammate tool:
-  team_name: "plan-team"
+  team_name: "$TEAM_NAME"
   name: "product-manager"
   model: sonnet
   prompt: >


### PR DESCRIPTION
## Summary

CDT workflows hardcoded literal team names (`plan-team`, `dev-team`, `bugfix-team`) when calling `TeamCreate`. Because Claude Code stores teams globally at `~/.claude/teams/<name>/`, any abnormal workflow exit before Wrap Up orphans the team dir, and the next run stalls on `Team "<name>" already exists`. Recovery is impossible from inside Claude Code: `TeamDelete` only operates on the *current* session's team, and `rm -rf ~/.claude/teams/<name>` is blocked by recent permission tightening on `~/.claude/`.

This PR introduces scoped team names of the form `<phase>-<branch-slug>-<YYYYMMDD-HHMMSS>-<nonce>` and a standalone cleanup script for orphans that still accumulate in normal use.

## Changes

- **plan-workflow.md / dev-workflow.md / bugfix-workflow.md** — new "Compose Team Name" step computes `TEAM_NAME="<phase>-${BRANCH_SLUG}-${TEAM_TIMESTAMP}-${TEAM_NONCE}"` (separate `TEAM_TIMESTAMP=$(date +%Y%m%d-%H%M%S)` for second resolution; 4-hex `TEAM_NONCE` from `od -An -N2 -tx1 /dev/urandom` for per-run entropy). Every `TeamCreate` + spawn block uses `$TEAM_NAME`. `bugfix-workflow.md` also gains the `$TIMESTAMP` step it was missing. `plan-workflow.md` Step 0a was split into "Derive Branch Slug" (unconditional) + "Issue Detection" (conditional) so `$BRANCH_SLUG` is guaranteed before Step 1a runs. Variable name unified to `BRANCH_SLUG` across plan/dev/bugfix workflows for consistency.
- **SKILL.md / command files** — rule lines and diagram legends generalised so `plan-team` / `dev-team` / `bugfix-team` read as role labels while the actual `team_name` is scoped per run (placeholders use `<branch-slug>` to make the `/`→`-` substitution explicit).
- **scripts/check-wave-gate-handoff.sh** — the `[ "$TEAM_NAME" != "dev-team" ] && exit 0` guard would silently disable the safety net once team names became scoped. Converted to a regex match on the actual CDT shape (`^dev-team$|^dev-.+-[0-9]{8}-[0-9]{4,6}(-[0-9a-f]{4})?$`) so unrelated user-named `dev-foo` teams don't trigger CDT-specific wave-gate prompts.
- **scripts/clean-stale-teams.sh** (new) — POSIX cleanup script for `~/.claude/teams/` and `~/.claude/tasks/`. Dry-run default; `--yes` to delete; `--older-than N` for the age threshold (with corrected `find -mtime` integer-day math: `--older-than N` now selects dirs >=N days old, with `N=0` skipping the age filter entirely). Regex `^(plan|dev|bugfix)-.*-[0-9]{8}-[0-9]{4,6}(-[0-9a-f]{4})?$` accepts both minute and second-resolution timestamps with an optional 4-hex nonce, and deliberately won't match legacy bare names or unrelated team dirs. Help is generated by a `print_help()` heredoc (no fragile sed line numbers); traversal uses POSIX-portable shell glob + `find -prune -mtime` (no GNU/BSD-only `-mindepth`/`-maxdepth`); `rm -rf` exit codes are checked and `--yes` exits non-zero on partial failure.
- **README.md** — Troubleshooting table row points at the cleanup script with `sh scripts/...` invocation (no executable-bit dependency) and a note about running from a local shell outside Claude Code if `~/.claude/teams/` deletion hits permission-denied errors.

## Why this works

`<phase>-<branch-slug>-<YYYYMMDD-HHMMSS>-<nonce>` collapses the collision window from a minute (per the original design) to effectively zero: the second-resolution timestamp shrinks the window to ~1 second, and the 4-hex `od /dev/urandom` nonce reduces same-second probability to ~1/65536. Branch-slug makes orphans traceable to the work they came from. All variables are computed locally per run — the change adds zero persistent state.

The cleanup script is intentionally conservative: dry-run default, age threshold, regex matches only the new scoped format. Legacy `plan-team` / `dev-team` / `bugfix-team` orphans (and any non-CDT dirs like `demo-team`, `research-team`) are out of scope per the issue and require manual cleanup.

## Verification

- [x] `bun scripts/validate-plugins.mjs` — all 10 plugins pass
- [x] `sh -n plugins/cdt/scripts/clean-stale-teams.sh` — POSIX syntax OK
- [x] `sh -n plugins/cdt/scripts/check-wave-gate-handoff.sh` — POSIX syntax OK after edit
- [x] `rg -n 'team_name: "(plan\|dev\|bugfix)-team"\|team_name "(plan\|dev\|bugfix)-team"' plugins/cdt/` — zero residual literal team_name arguments
- [x] Cleanup script smoke-tested: dry-run + `--yes` against fixture dirs validates new regex (matches both nonced and non-nonced names; correctly excludes legacy bare names, invalid hex, and non-CDT names) and corrected mtime math (`--older-than 7` now matches >=7 days, not >=8); `--help` and bad-arg paths return expected exit codes
- [ ] Manual smoke test: run `/cdt:plan-task` end-to-end and confirm `~/.claude/teams/plan-<branch-slug>-<YYYYMMDD-HHMMSS>-<nonce>/` is created and cleaned up at Wrap Up

## Out of scope

- Renaming or deleting the legacy stale dirs that motivated the issue — the cleanup script's regex deliberately won't match them; one-time manual cleanup can be done by the user
- A CDT-specific ownership marker (e.g., a sentinel file inside CDT-created team dirs) to constrain the cleanup script and wave-gate hook to CDT-managed dirs only — flagged by Codex as a P2 concern, deferred as a follow-up architectural decision
- A slash-command wrapper for the cleanup script
- Changes to `track-team-state.sh` and `enforce-lead-delegation.sh` (already operate on whatever `team_name` value the hook receives)
- `TeamDelete` narrative — already correct (no-arg, session-scoped)

Closes #209


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cleanup script for removing stale CDT-related directories, with dry-run mode enabled by default.

* **Documentation**
  * Extended troubleshooting guide with stale Agent Teams cleanup instructions.
  * Clarified team naming conventions across workflow documentation to distinguish static role labels from dynamically generated per-run identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->