### PR TITLE
feat(cdt): auto-rename Claude Code session per CDT branch

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -473,6 +473,45 @@ The script uses jq regex patterns (`in.progress`, `in.review`) for case-insensit
 
 ---
 
+## Hooks
+
+### Hook output schema validity ≠ runtime effect
+
+Claude Code's hook validator is **permissive** about field names it does not recognise — it accepts unknown keys inside `hookSpecificOutput` without erroring, but the runtime then silently drops them. So an absence of validator errors does not mean a hook output is honoured. To verify a capability actually fires, **grep the resulting session JSONL** (`~/.claude/projects/<slug>/<session-id>.jsonl`) for the on-disk record the feature is supposed to produce.
+
+Concrete example: `hookSpecificOutput.sessionTitle` (added in v2.1.94) only takes effect on `UserPromptSubmit` hooks. On `PreToolUse` and `SessionStart` the validator passes — no error, no warning — but no `{"type":"custom-title", ...}` record is ever written. Only an empirical probe between the two events revealed which one honoured the field.
+
+**Bad pattern (trust validator silence):**
+```text
+hook emits hookSpecificOutput.sessionTitle on PreToolUse
+no validation error appears
+→ assume it works → ship → later discover nothing renamed
+```
+
+**Good pattern (probe with a throwaway session, then grep the JSONL):**
+```bash
+PROBE_UUID=$(uuidgen)
+claude --print --session-id "$PROBE_UUID" --settings ./probe-settings.json "test"
+JSONL=~/.claude/projects/<slug>/$PROBE_UUID.jsonl
+rg '"type":"custom-title"' "$JSONL"   # presence here = real runtime effect
+```
+
+> Source: [`plugins/cdt/scripts/set-session-title.sh`](../plugins/cdt/scripts/set-session-title.sh) — the auto-rename hook discovered the event/field mapping by probing two hook events and comparing the JSONL output between them
+
+### When the docs are wrong, the Claude Code binary tells the truth
+
+Claude Code's public hook docs and SDK type definitions lag behind the binary. When a feature appears missing or misdocumented, search the compiled CLI for the on-disk field names:
+
+```bash
+strings $(readlink -f $(which claude)) | rg '"customTitle"|tengu_session_renamed|setSessionTitle'
+```
+
+This surfaced the rename API (JSONL event types like `custom-title` / `agent-name`, internal setter functions, telemetry event names) when the public docs implied no such mechanism existed, and exposed the **field-name asymmetry** that's easy to miss otherwise: the JSONL stores the title under `customTitle`, but the *hook output* takes it under `sessionTitle`. Reading only the on-disk artifact (or only the hook docs) hides that.
+
+> Source: discovery process behind `set-session-title.sh`; cross-referenced with [issue #44902](https://github.com/anthropics/claude-code/issues/44902) confirming v2.1.94 added the hook field but the public docs are still out of sync
+
+---
+
 ## Common Pitfalls
 
 | Pitfall | Symptom | Fix |

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -559,10 +559,11 @@ Note the **field-name asymmetry**: the hook output API uses `sessionTitle`, but
 the JSONL stores it under `customTitle`. The on-disk name is the stable one —
 that's the contract Claude Code's `/resume` picker reads.
 
-Append-only writes are POSIX-atomic for sub-PIPE_BUF lines (~4KB), so a single
-`jq -nc ... >> "$TRANSCRIPT_PATH"` is safe even with Claude Code writing to the
-same file concurrently. Multiple `custom-title` events with the same value are
-also harmless — the picker reads last-wins.
+`jq -nc` emits the JSON object as a single buffered `write()` syscall, and `>>`
+opens the file with O_APPEND so each `write()` is positioned atomically (the
+kernel sets the offset before writing). Multiple `custom-title` events with the
+same value are also harmless — the picker reads last-wins. Capping the slug
+keeps the line short enough that jq flushes in one `write()` call.
 
 **Pattern:**
 ```bash

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -503,7 +503,7 @@ rg '"type":"custom-title"' "$JSONL"   # presence here = real runtime effect
 Claude Code's public hook docs and SDK type definitions lag behind the binary. When a feature appears missing or misdocumented, search the compiled CLI for the on-disk field names:
 
 ```bash
-strings $(readlink -f $(which claude)) | rg '"customTitle"|tengu_session_renamed|setSessionTitle'
+strings "$(command -v claude)" | rg '"customTitle"|tengu_session_renamed|setSessionTitle'
 ```
 
 This surfaced the rename API (JSONL event types like `custom-title` / `agent-name`, internal setter functions, telemetry event names) when the public docs implied no such mechanism existed, and exposed the **field-name asymmetry** that's easy to miss otherwise: the JSONL stores the title under `customTitle`, but the *hook output* takes it under `sessionTitle`. Reading only the on-disk artifact (or only the hook docs) hides that.

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -498,6 +498,87 @@ rg '"type":"custom-title"' "$JSONL"   # presence here = real runtime effect
 
 > Source: [`plugins/cdt/scripts/set-session-title.sh`](../plugins/cdt/scripts/set-session-title.sh) — the auto-rename hook discovered the event/field mapping by probing two hook events and comparing the JSONL output between them
 
+### Pick the hook event that fires *after* the state change you depend on
+
+When a hook reads dynamic state (current branch, files on disk, env), the same
+script attached to two events can produce wildly different results — not because
+one event is "broken," but because **the state the hook reads exists at one
+event and not the other**.
+
+Concrete failure: an early version of CDT's session-rename hook ran on
+`UserPromptSubmit`. The activation check (`prompt starts with /cdt`) was
+correct, but the *body* read `git branch --show-current` to derive the title.
+The first `/cdt:plan-task` prompt is delivered while the user is still on
+`main` — the workflow only checks out the feature branch as a tool call after
+the prompt is processed. Result: the hook computed a title from `main`,
+producing `cdt-main` and burning the per-branch marker on `main` forever.
+
+The fix wasn't to change the activation logic — it was to **move the trigger
+later**. A `Stop` hook fires after the branch checkout has happened, so
+`git branch --show-current` returns the right answer. The activation guard
+shifts from "prompt matches /cdt" to "a CDT team is currently active for this
+branch" (a marker file written by `PreToolUse:TeamCreate`).
+
+**Bad pattern (state read at wrong event):**
+```text
+UserPromptSubmit fires → script runs → git branch --show-current returns "main"
+→ wrong title "cdt-main" → marker poisoned
+```
+
+**Good pattern (state read after relevant tool calls have completed):**
+```text
+PreToolUse:TeamCreate sets .cdt-team-active marker on the new branch
+Stop fires (any subsequent turn) → git branch --show-current returns feature branch
+→ correct title → marker written
+```
+
+Heuristic: if the hook script reads any state that the model itself manipulates
+during its turn (working dir, branch, files, env), prefer post-turn events
+(`Stop`, `PostToolUse`) over pre-turn (`UserPromptSubmit`, `PreToolUse`). The
+exception is when you specifically need to *block* the action — pre-turn
+events are the only ones that can do that.
+
+> Source: [`plugins/cdt/scripts/set-session-title.sh`](../plugins/cdt/scripts/set-session-title.sh) — moved from UserPromptSubmit to Stop after observing the `cdt-main` failure on the first /cdt:plan-task invocation
+
+### Inject JSONL events directly when the hook output API doesn't reach far enough
+
+Claude Code's `hookSpecificOutput` channel is not symmetric across hook events
+— some fields (e.g. `sessionTitle`) only take effect on one specific event.
+When you need the same effect from a different event (e.g. `Stop`, where
+`sessionTitle` is silently dropped), bypass the API and write directly to the
+session's JSONL transcript. Plan Mode does this internally, and the hook input
+on most events includes `.transcript_path` precisely so external scripts can
+participate.
+
+The on-disk schema for a custom-title event is:
+```json
+{"type":"custom-title","customTitle":"<title>","sessionId":"<uuid>"}
+```
+
+Note the **field-name asymmetry**: the hook output API uses `sessionTitle`, but
+the JSONL stores it under `customTitle`. The on-disk name is the stable one —
+that's the contract Claude Code's `/resume` picker reads.
+
+Append-only writes are POSIX-atomic for sub-PIPE_BUF lines (~4KB), so a single
+`jq -nc ... >> "$TRANSCRIPT_PATH"` is safe even with Claude Code writing to the
+same file concurrently. Multiple `custom-title` events with the same value are
+also harmless — the picker reads last-wins.
+
+**Pattern:**
+```bash
+jq -nc --arg s "$SESSION_ID" --arg t "$TITLE" '{
+  type: "custom-title",
+  customTitle: $t,
+  sessionId: $s
+}' >> "$TRANSCRIPT_PATH"
+```
+
+This pattern generalises: any JSONL event Claude Code writes internally
+(`agent-name`, `permission-mode`, etc.) can be appended from a hook, regardless
+of whether `hookSpecificOutput` exposes a corresponding field.
+
+> Source: [`plugins/cdt/scripts/set-session-title.sh`](../plugins/cdt/scripts/set-session-title.sh) — moved from `hookSpecificOutput.sessionTitle` to direct JSONL append when relocating the trigger to `Stop` (where `sessionTitle` is dropped)
+
 ### When the docs are wrong, the Claude Code binary tells the truth
 
 Claude Code's public hook docs and SDK type definitions lag behind the binary. When a feature appears missing or misdocumented, search the compiled CLI for the on-disk field names:

--- a/plugins/cdt/hooks/hooks.json
+++ b/plugins/cdt/hooks/hooks.json
@@ -16,10 +16,6 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/block-cdt-without-teams.sh"
-          },
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/set-session-title.sh"
           }
         ]
       }
@@ -67,6 +63,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/check-wave-gate-handoff.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/set-session-title.sh"
           }
         ]
       }

--- a/plugins/cdt/hooks/hooks.json
+++ b/plugins/cdt/hooks/hooks.json
@@ -16,6 +16,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/block-cdt-without-teams.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/set-session-title.sh"
           }
         ]
       }

--- a/plugins/cdt/scripts/set-session-title.sh
+++ b/plugins/cdt/scripts/set-session-title.sh
@@ -33,7 +33,7 @@ case "$BRANCH" in
   main|master) exit 0 ;;
 esac
 
-BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
+BRANCH_SLUG=$(printf '%s\n' "$BRANCH" | tr '/' '-')
 BRANCH_DIR=".dev/cdt/${BRANCH_SLUG}"
 TEAM_ACTIVE="${BRANCH_DIR}/.cdt-team-active"
 TITLE_SET="${BRANCH_DIR}/.cdt-session-titled"
@@ -55,11 +55,11 @@ fi
 
 # Fallback to branch name with conventional prefix stripped.
 if [ -z "$TITLE" ]; then
-  TITLE=$(echo "$BRANCH" \
+  TITLE=$(printf '%s\n' "$BRANCH" \
     | sed -E 's#^(feat|feature|bugfix|refactor|cdt|chore|hotfix|test|docs)/##')
 fi
 
-SLUG=$(echo "$TITLE" \
+SLUG=$(printf '%s\n' "$TITLE" \
   | tr '[:upper:]' '[:lower:]' \
   | sed -E 's#[^a-z0-9]+#-#g; s#^-+##; s#-+$##')
 

--- a/plugins/cdt/scripts/set-session-title.sh
+++ b/plugins/cdt/scripts/set-session-title.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# UserPromptSubmit hook: on the first CDT-related prompt for a branch, set the
+# session title once — sourced from the linked GitHub issue title if the branch
+# encodes an issue number, else from the branch name itself. The choice of
+# UserPromptSubmit (vs. PreToolUse:TeamCreate) is forced: hookSpecificOutput.sessionTitle
+# is only honoured on UserPromptSubmit; other hook events accept the field but
+# silently drop it.
+
+INPUT=$(cat)
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // ""')
+
+BRANCH=$(git branch --show-current 2>/dev/null)
+[ -z "$BRANCH" ] && exit 0
+
+BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
+BRANCH_DIR=".dev/cdt/${BRANCH_SLUG}"
+TEAM_ACTIVE="${BRANCH_DIR}/.cdt-team-active"
+TITLE_SET="${BRANCH_DIR}/.cdt-session-titled"
+
+# One-shot per branch: once we've named the session, stay silent forever.
+[ -f "$TITLE_SET" ] && exit 0
+
+# Activation: the prompt invokes /cdt OR a CDT team is already live for this
+# branch. This covers both the first /cdt:plan-task invocation and resumed
+# sessions where the team was created in an earlier process.
+if ! echo "$PROMPT" | grep -qE '^\s*/cdt(\s|:|$)' && [ ! -f "$TEAM_ACTIVE" ]; then
+  exit 0
+fi
+
+# Prefer GitHub issue title if the branch encodes an issue reference. The
+# `issue-N` form is canonical; bare-number prefixes (e.g. `123-foo`) are also
+# accepted because semantic-release-style branch names use them.
+TITLE=""
+ISSUE_NUM=$(echo "$BRANCH" | grep -oE '(^|[/_-])(issue-|#)?[0-9]+' | grep -oE '[0-9]+' | head -1)
+if [ -n "$ISSUE_NUM" ] && command -v gh >/dev/null 2>&1; then
+  TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq .title 2>/dev/null)
+fi
+
+# Fallback to branch name with conventional prefix stripped.
+if [ -z "$TITLE" ]; then
+  TITLE=$(echo "$BRANCH" \
+    | sed -E 's#^(feature|bugfix|refactor|cdt|chore|hotfix|test|docs)/##')
+fi
+
+SLUG=$(echo "$TITLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's#[^a-z0-9]+#-#g; s#^-+##; s#-+$##')
+
+[ -z "$SLUG" ] && exit 0
+
+# Persist the marker BEFORE emitting JSON so a downstream crash can't trigger a
+# rename on every retry.
+mkdir -p "$BRANCH_DIR"
+date +%s > "$TITLE_SET"
+
+jq -n --arg t "cdt-${SLUG}" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    sessionTitle: $t
+  }
+}'

--- a/plugins/cdt/scripts/set-session-title.sh
+++ b/plugins/cdt/scripts/set-session-title.sh
@@ -7,7 +7,7 @@
 # silently drop it.
 
 INPUT=$(cat)
-PROMPT=$(echo "$INPUT" | jq -r '.prompt // ""')
+PROMPT=$(printf '%s\n' "$INPUT" | jq -r '.prompt // ""')
 
 BRANCH=$(git branch --show-current 2>/dev/null)
 [ -z "$BRANCH" ] && exit 0
@@ -23,15 +23,15 @@ TITLE_SET="${BRANCH_DIR}/.cdt-session-titled"
 # Activation: the prompt invokes /cdt OR a CDT team is already live for this
 # branch. This covers both the first /cdt:plan-task invocation and resumed
 # sessions where the team was created in an earlier process.
-if ! echo "$PROMPT" | grep -qE '^\s*/cdt(\s|:|$)' && [ ! -f "$TEAM_ACTIVE" ]; then
+if ! printf '%s\n' "$PROMPT" | grep -qE '^[[:space:]]*/cdt([[:space:]]|:|$)' && [ ! -f "$TEAM_ACTIVE" ]; then
   exit 0
 fi
 
-# Prefer GitHub issue title if the branch encodes an issue reference. The
-# `issue-N` form is canonical; bare-number prefixes (e.g. `123-foo`) are also
-# accepted because semantic-release-style branch names use them.
+# Prefer GitHub issue title if the branch encodes an explicit issue reference.
+# Only matches `issue-N` or `#N` forms to avoid false positives from bare
+# numeric segments (e.g. `feature/release-2026-04` → 2026).
 TITLE=""
-ISSUE_NUM=$(echo "$BRANCH" | grep -oE '(^|[/_-])(issue-|#)?[0-9]+' | grep -oE '[0-9]+' | head -1)
+ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '(issue-|#)[0-9]+' | grep -oE '[0-9]+' | head -1)
 if [ -n "$ISSUE_NUM" ] && command -v gh >/dev/null 2>&1; then
   TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq .title 2>/dev/null)
 fi

--- a/plugins/cdt/scripts/set-session-title.sh
+++ b/plugins/cdt/scripts/set-session-title.sh
@@ -1,31 +1,48 @@
 #!/bin/bash
-# UserPromptSubmit hook: on the first CDT-related prompt for a branch, set the
-# session title once — sourced from the linked GitHub issue title if the branch
-# encodes an issue number, else from the branch name itself. The choice of
-# UserPromptSubmit (vs. PreToolUse:TeamCreate) is forced: hookSpecificOutput.sessionTitle
-# is only honoured on UserPromptSubmit; other hook events accept the field but
-# silently drop it.
+# Stop hook: when a CDT team is active on a feature branch, rename the
+# Claude Code session by appending a `custom-title` event directly to the
+# session's JSONL transcript. Fires once per branch via marker.
+#
+# Why this design (vs. hookSpecificOutput.sessionTitle on UserPromptSubmit):
+#   - UserPromptSubmit fires too early: /cdt:plan-task and friends ship the
+#     first prompt while still on `main`, before the workflow checks out the
+#     feature branch. Naming the session there produces "cdt-main" and burns
+#     the per-branch marker on `main` itself.
+#   - Stop fires after every assistant turn, including the final turn of an
+#     autonomous /auto-task — which is the one prompt that case ever sends.
+#   - hookSpecificOutput.sessionTitle is only honoured on UserPromptSubmit, so
+#     we cannot use the API field from Stop. We instead write the same
+#     `{"type":"custom-title", ...}` JSONL event Plan Mode writes; the
+#     /resume picker indexes that event regardless of who appended it.
 
 INPUT=$(cat)
-PROMPT=$(printf '%s\n' "$INPUT" | jq -r '.prompt // ""')
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // ""')
+TRANSCRIPT_PATH=$(printf '%s\n' "$INPUT" | jq -r '.transcript_path // ""')
+
+[ -z "$SESSION_ID" ] && exit 0
+[ -z "$TRANSCRIPT_PATH" ] && exit 0
+[ ! -f "$TRANSCRIPT_PATH" ] && exit 0
 
 BRANCH=$(git branch --show-current 2>/dev/null)
 [ -z "$BRANCH" ] && exit 0
+
+# Skip on the default branch. CDT always cuts a feature branch as step 1, so
+# any Stop firing on main/master means we're outside a CDT run — and writing
+# the marker on main would block renames forever for plain main usage.
+case "$BRANCH" in
+  main|master) exit 0 ;;
+esac
 
 BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
 BRANCH_DIR=".dev/cdt/${BRANCH_SLUG}"
 TEAM_ACTIVE="${BRANCH_DIR}/.cdt-team-active"
 TITLE_SET="${BRANCH_DIR}/.cdt-session-titled"
 
+# Only act when a CDT team has been created on this branch.
+[ ! -f "$TEAM_ACTIVE" ] && exit 0
+
 # One-shot per branch: once we've named the session, stay silent forever.
 [ -f "$TITLE_SET" ] && exit 0
-
-# Activation: the prompt invokes /cdt OR a CDT team is already live for this
-# branch. This covers both the first /cdt:plan-task invocation and resumed
-# sessions where the team was created in an earlier process.
-if ! printf '%s\n' "$PROMPT" | grep -qE '^[[:space:]]*/cdt([[:space:]]|:|$)' && [ ! -f "$TEAM_ACTIVE" ]; then
-  exit 0
-fi
 
 # Prefer GitHub issue title if the branch encodes an explicit issue reference.
 # Only matches `issue-N` or `#N` forms to avoid false positives from bare
@@ -39,7 +56,7 @@ fi
 # Fallback to branch name with conventional prefix stripped.
 if [ -z "$TITLE" ]; then
   TITLE=$(echo "$BRANCH" \
-    | sed -E 's#^(feature|bugfix|refactor|cdt|chore|hotfix|test|docs)/##')
+    | sed -E 's#^(feat|feature|bugfix|refactor|cdt|chore|hotfix|test|docs)/##')
 fi
 
 SLUG=$(echo "$TITLE" \
@@ -48,14 +65,16 @@ SLUG=$(echo "$TITLE" \
 
 [ -z "$SLUG" ] && exit 0
 
-# Persist the marker BEFORE emitting JSON so a downstream crash can't trigger a
-# rename on every retry.
-mkdir -p "$BRANCH_DIR"
-date +%s > "$TITLE_SET"
+# Append the custom-title event the /resume picker indexes, then mark the
+# branch as titled. Marker writes only on successful append so a transient
+# failure leaves the marker absent and the next Stop firing retries.
+if jq -nc --arg s "$SESSION_ID" --arg t "cdt-${SLUG}" '{
+  type: "custom-title",
+  customTitle: $t,
+  sessionId: $s
+}' >> "$TRANSCRIPT_PATH"; then
+  mkdir -p "$BRANCH_DIR"
+  date +%s > "$TITLE_SET"
+fi
 
-jq -n --arg t "cdt-${SLUG}" '{
-  hookSpecificOutput: {
-    hookEventName: "UserPromptSubmit",
-    sessionTitle: $t
-  }
-}'
+exit 0

--- a/plugins/cdt/scripts/set-session-title.sh
+++ b/plugins/cdt/scripts/set-session-title.sh
@@ -15,9 +15,13 @@
 #     `{"type":"custom-title", ...}` JSONL event Plan Mode writes; the
 #     /resume picker indexes that event regardless of who appended it.
 
+# Guard: skip interactive invocations and environments without jq.
+[ -t 0 ] && exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
 INPUT=$(cat)
-SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // ""')
-TRANSCRIPT_PATH=$(printf '%s\n' "$INPUT" | jq -r '.transcript_path // ""')
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
+TRANSCRIPT_PATH=$(printf '%s\n' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)
 
 [ -z "$SESSION_ID" ] && exit 0
 [ -z "$TRANSCRIPT_PATH" ] && exit 0
@@ -48,7 +52,7 @@ TITLE_SET="${BRANCH_DIR}/.cdt-session-titled"
 # Only matches `issue-N` or `#N` forms to avoid false positives from bare
 # numeric segments (e.g. `feature/release-2026-04` → 2026).
 TITLE=""
-ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '(issue-|#)[0-9]+' | grep -oE '[0-9]+' | head -1)
+ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '(^|[/_-])(issue-|#)[0-9]+' | grep -oE '[0-9]+' | head -1)
 if [ -n "$ISSUE_NUM" ] && command -v gh >/dev/null 2>&1; then
   TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq .title 2>/dev/null)
 fi
@@ -61,7 +65,9 @@ fi
 
 SLUG=$(printf '%s\n' "$TITLE" \
   | tr '[:upper:]' '[:lower:]' \
-  | sed -E 's#[^a-z0-9]+#-#g; s#^-+##; s#-+$##')
+  | sed -E 's#[^a-z0-9]+#-#g; s#^-+##; s#-+$##' \
+  | cut -c1-120 \
+  | sed -E 's#-+$##')
 
 [ -z "$SLUG" ] && exit 0
 

--- a/plugins/cdt/scripts/set-session-title.sh
+++ b/plugins/cdt/scripts/set-session-title.sh
@@ -52,7 +52,7 @@ TITLE_SET="${BRANCH_DIR}/.cdt-session-titled"
 # Only matches `issue-N` or `#N` forms to avoid false positives from bare
 # numeric segments (e.g. `feature/release-2026-04` → 2026).
 TITLE=""
-ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '(^|[/_-])(issue-|#)[0-9]+' | grep -oE '[0-9]+' | head -1)
+ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '(^|[/_-])(issue-|#)[0-9]+($|[/_-])' | grep -oE '[0-9]+' | head -1)
 if [ -n "$ISSUE_NUM" ] && command -v gh >/dev/null 2>&1; then
   TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq .title 2>/dev/null)
 fi


### PR DESCRIPTION
## Summary

- Adds a `Stop` hook (`plugins/cdt/scripts/set-session-title.sh`) that renames the Claude Code session by appending a `{"type":"custom-title", ...}` event directly to the session's JSONL transcript (the same mechanism Plan Mode uses).
- Activation guards: the hook only acts when (a) the current branch is **not** `main`/`master`, (b) a `.cdt-team-active` marker exists for the branch, and (c) the per-branch `.cdt-session-titled` marker has not yet been written. One-shot per branch, no per-team churn.
- Title sources from the linked GitHub issue when the branch encodes an issue number (e.g. `feature/issue-220-x`); falls back to the slugified branch name with the conventional prefix stripped (`feat/`, `feature/`, `bugfix/`, etc.). Result is prefixed `cdt-` so runs are filterable in `/resume`.
- Documents the underlying design lessons in `docs/learnings.md`:
  - "Pick the hook event that fires *after* the state change you depend on" — why Stop instead of UserPromptSubmit.
  - "Inject JSONL events directly when the hook output API doesn't reach far enough" — why direct append instead of `hookSpecificOutput.sessionTitle`.
  - The earlier two findings ("schema validity ≠ runtime effect", "the binary tells the truth").

## Why this design

Two failure modes in the obvious "UserPromptSubmit + `sessionTitle`" approach forced the redesign:

1. **Wrong state at trigger time.** `/cdt:plan-task` is delivered while the user is still on `main`; the workflow only checks out the feature branch as a tool call *after* the prompt is processed. A UserPromptSubmit hook reads `git branch --show-current` → `main`, produces `cdt-main`, and burns the per-branch marker on `main` itself.
2. **`/auto-task` has no second prompt.** The autonomous flow takes one prompt and runs to completion. Any "next-prompt fallback" never fires.

`Stop` solves both: it fires after every assistant turn (including the final turn of `/auto-task`) and runs *after* branch checkout. The trade-off is that `hookSpecificOutput.sessionTitle` is only honoured on `UserPromptSubmit` — so we bypass the API and write the JSONL `custom-title` event directly. The `/resume` picker indexes this event regardless of who appended it; Plan Mode itself uses the same mechanism.

The on-disk schema (`customTitle`) and the hook-output API (`sessionTitle`) use **different field names** for the same concept — that asymmetry is documented in `learnings.md` as a trap for future plugin authors.

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes
- [x] Bash syntax check on the new script (`bash -n`) passes
- [ ] Manual confirmation in a fresh `/cdt:plan-task` flow: sidebar label updates to `cdt-<branch-slug>` once the planning team is live (not before branch creation)
- [ ] Manual confirmation in a fresh `/cdt:auto-task` flow: sidebar label is set by the time the run finishes (key case the previous design missed)
- [ ] Verify the per-branch marker (`.dev/cdt/<branch>/.cdt-session-titled`) is written exactly once per branch — subsequent CDT phases on the same branch do not re-rename
- [ ] Confirm no JSONL corruption: a non-CDT session (no `.cdt-team-active`) sees no `custom-title` events appended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sessions now automatically receive computed titles derived from Git branch names and associated issue information where available.

* **Documentation**
  * Enhanced hook documentation with comprehensive verification patterns, event timing guidance, troubleshooting strategies, and direct event logging techniques.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->