### PR TITLE
feat(cdt): commit agent notes as branch-scoped append-mode logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,10 @@ See [docs/PLUGIN-AUTHORING.md](./docs/PLUGIN-AUTHORING.md) for the full authorin
 - PRs target `main`; semantic-release handles versioning on merge — never edit versions by hand
 - **Prompt engineering review**: When a change touches agent prompts (`prompt: >` blocks, SKILL.md instructions, `*-workflow.md` teammate prompts, `agents/*.md`), review it against known pitfalls in [`docs/learnings.md`](docs/learnings.md) before creating the PR. Specifically check: no literal actions in preambles before numbered workflow gates, no dual numbered sequences, imperatives over aphorisms, and no terminology mismatches with existing workflow steps.
 
+## Cross-branch agent context
+
+When picking up work in an unfamiliar area, run `rg -l '' .agentnotes/cdt/` (or `ls .agentnotes/cdt/`) to surface prior CDT session logs for related branches. Each file is a committed, append-mode log of `## Session …` blocks with What's Done / Open Questions / Context for Next Session — the canonical surface for cross-branch handoffs that don't reach merged-PR descriptions.
+
 ## Learnings
 
 Accumulated lessons from developing skills and plugins live in [`docs/learnings.md`](docs/learnings.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ See [docs/PLUGIN-AUTHORING.md](./docs/PLUGIN-AUTHORING.md) for the full authorin
 
 ## Cross-branch agent context
 
-When picking up work in an unfamiliar area, run `rg -l '' .agentnotes/cdt/` (or `ls .agentnotes/cdt/`) to surface prior CDT session logs for related branches. Each file is a committed, append-mode log of `## Session …` blocks with What's Done / Open Questions / Context for Next Session — the canonical surface for cross-branch handoffs that don't reach merged-PR descriptions.
+When picking up work in an unfamiliar area, run `rg -l "" .agentnotes/cdt/` (or `ls .agentnotes/cdt/`) to surface prior CDT session logs for related branches. Each file is a committed, append-mode log of `## Session …` blocks with What's Done / Open Questions / Context for Next Session — the canonical surface for cross-branch handoffs that don't reach merged-PR descriptions.
 
 ## Learnings
 

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -364,7 +364,7 @@ Read .agentnotes/cdt/$BRANCH_SLUG.md and extract content under the `### Open Que
 3. Within that slice, extract `### Open Questions` and `### Context for Next Session` content.
 ```
 
-Use start-of-line anchors (`^##`) for both the outer block delimiter and the inner sections — fenced-code-block content can include `## ` mid-line and would otherwise corrupt the slice boundaries.
+Use start-of-line anchors for both the outer block delimiter (`^## `) and the inner sections (`^### `) — fenced-code-block content can include `## ` or `### ` mid-line and would otherwise corrupt the slice boundaries.
 
 > Source: [Issue #221](https://github.com/rube-de/cc-skills/issues/221) — promoted CDT session handoff from per-file (`.dev/cdt/handoffs/handoff-$TIMESTAMP.md`) to per-branch append-mode log (`.agentnotes/cdt/$BRANCH_SLUG.md`); `full-task.md` Wrap Up step 4 must locate the latest `## Session` block before extracting `### Open Questions` and `### Context for Next Session`.
 

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -348,6 +348,49 @@ Draft the *content* (excluding headings) for the `Open Questions` and `Context f
 
 > Source: [Issue #224](https://github.com/rube-de/cc-skills/issues/224) — two hallucinated Open Questions bullets shipped in a real PR; evidence gate added to generation sites.
 
+### Read-extract anchoring: locate the latest of N similar sub-blocks before slicing
+
+When a downstream step extracts content from an append-mode log (sessions, entries, runs), the file may contain many sub-blocks of the same shape. The extraction MUST anchor on the block delimiter to find the *latest* block, then slice within it — not search the whole file with the inner-section heading. Otherwise the first occurrence wins and the extraction silently returns stale data.
+
+**Bad** — search the whole file for `### Open Questions`, get the first match (which is the *oldest* session):
+```markdown
+Read .agentnotes/cdt/$BRANCH_SLUG.md and extract content under the `### Open Questions` heading.
+```
+
+**Good** — anchor on the latest `## Session ` line, slice from there to the next `## ` heading or EOF, then extract within the slice:
+```markdown
+1. Find the **last** line matching `^## Session ` (start-of-line anchor).
+2. Slice from that line to the next `^## ` heading or EOF (whichever is first).
+3. Within that slice, extract `### Open Questions` and `### Context for Next Session` content.
+```
+
+Use start-of-line anchors (`^##`) for both the outer block delimiter and the inner sections — fenced-code-block content can include `## ` mid-line and would otherwise corrupt the slice boundaries.
+
+> Source: [Issue #221](https://github.com/rube-de/cc-skills/issues/221) — promoted CDT session handoff from per-file (`.dev/cdt/handoffs/handoff-$TIMESTAMP.md`) to per-branch append-mode log (`.agentnotes/cdt/$BRANCH_SLUG.md`); `full-task.md` Wrap Up step 4 must locate the latest `## Session` block before extracting `### Open Questions` and `### Context for Next Session`.
+
+### Self-installing host-repo hints from plugins: idempotent grep + append at workflow-end
+
+When a plugin needs a discovery hint (or any one-line marker) in a host repo, append it from the workflow's wrap-up step using an idempotent grep guard. Target the convention file primary (`AGENTS.md`), fall back to a secondary (`CLAUDE.md`), and skip silently if neither exists — never auto-create project docs. Anchor idempotency on a unique literal (path or marker string) in the appended line so re-runs are no-ops.
+
+**Bad** — write unconditionally on every wrap-up (file bloats with N copies of the hint):
+```bash
+echo "$HINT" >> AGENTS.md
+```
+
+**Good** — grep guard with primary/fallback target and silent-skip on missing files:
+```bash
+HINT='When picking up work in an unfamiliar area, run `rg -l "" .agentnotes/cdt/` to surface prior CDT session logs.'
+if [ -f AGENTS.md ] && ! rg -q '\.agentnotes/cdt' AGENTS.md; then
+  printf '\n%s\n' "$HINT" >> AGENTS.md
+elif [ ! -f AGENTS.md ] && [ -f CLAUDE.md ] && ! rg -q '\.agentnotes/cdt' CLAUDE.md; then
+  printf '\n%s\n' "$HINT" >> CLAUDE.md
+fi
+```
+
+The `elif [ ! -f AGENTS.md ]` guard prevents double-install when both files exist (only the primary gets the hint). The unique literal `.agentnotes/cdt` in the append line doubles as the idempotency anchor — there's no separate marker comment to maintain.
+
+> Source: [Issue #221](https://github.com/rube-de/cc-skills/issues/221) — `.agentnotes/cdt/<branch-slug>.md` discoverability needs a hint in the host repo's docs; the cc-skills bootstrap edits `AGENTS.md` directly, but plugin installs in other repos rely on the wrap-up auto-install in `dev-workflow.md` § 9 and `auto-task.md` step 8.
+
 ---
 
 ## Plugin Structure

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -364,7 +364,7 @@ Read .agentnotes/cdt/$BRANCH_SLUG.md and extract content under the `### Open Que
 3. Within that slice, extract `### Open Questions` and `### Context for Next Session` content.
 ```
 
-Use start-of-line anchors for both the outer block delimiter (`^## `) and the inner sections (`^### `) — fenced-code-block content can include `## ` or `### ` mid-line and would otherwise corrupt the slice boundaries.
+Use start-of-line anchors for both the outer block delimiter (`^## `) and the inner sections (`^### `) — this prevents *mid-line* matches against tokens like `## ` or `### `. Anchors do **not** exclude `## `/`### ` tokens that appear at column 0 inside fenced code blocks, so for full robustness also avoid emitting top-level `##`/`###` headings inside fenced examples within these logs, or pick a delimiter that cannot legitimately appear in code (e.g., an HTML-comment sentinel).
 
 > Source: [Issue #221](https://github.com/rube-de/cc-skills/issues/221) — promoted CDT session handoff from per-file (`.dev/cdt/handoffs/handoff-$TIMESTAMP.md`) to per-branch append-mode log (`.agentnotes/cdt/$BRANCH_SLUG.md`); `full-task.md` Wrap Up step 4 must locate the latest `## Session` block before extracting `### Open Questions` and `### Context for Next Session`.
 

--- a/plugins/cdt/README.md
+++ b/plugins/cdt/README.md
@@ -76,7 +76,7 @@ Spawns Architect + PM + Researcher. The Architect designs the solution, the PM v
 
 Spawns Developer + Code-Tester + Reviewer + Researcher + QA-Tester. Executes tasks wave-by-wave from the plan, with parallel tasks within each wave and sequential ordering between waves.
 
-**Output**: Updated plan + `.agentnotes/cdt/<branch-slug>.md` — a committed, branch-scoped, append-mode session log. Each CDT run on the branch appends one `## Session YYYYMMDD-HHMM` block with What's Done / Open Questions / Context for Next Session / References sub-sections, so future agents on other branches can `rg .agentnotes/cdt/` to learn cross-branch context.
+**Output**: Updated plan + `.agentnotes/cdt/<branch-slug>.md` — a committed, branch-scoped, append-mode session log. Each CDT run on the branch appends one `## Session YYYYMMDD-HHMM` block with What's Done / Open Questions / Context for Next Session / References sub-sections, so future agents on other branches can `rg -l "" .agentnotes/cdt/` to learn cross-branch context.
 
 ### `/cdt:full-task` — Plan + Approve + Dev
 

--- a/plugins/cdt/README.md
+++ b/plugins/cdt/README.md
@@ -62,9 +62,9 @@ Planning Phase                    Development Phase
 | Command | Purpose | Approval Gate | Output |
 |---------|---------|---------------|--------|
 | `/cdt:plan-task` | Planning only | N/A | `.dev/cdt/plans/plan-YYYYMMDD-HHMM.md` |
-| `/cdt:dev-task` | Develop from existing plan | N/A | Updated plan + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` |
-| `/cdt:full-task` | Complete workflow | **Yes** (user choice) | `plan.md` + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` + PR body with `## Agent Notes` |
-| `/cdt:auto-task` | Autonomous end-to-end | No | `plan.md` + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` + PR body with `## Agent Notes` |
+| `/cdt:dev-task` | Develop from existing plan | N/A | Updated plan + `.agentnotes/cdt/<branch-slug>.md` |
+| `/cdt:full-task` | Complete workflow | **Yes** (user choice) | `plan.md` + `.agentnotes/cdt/<branch-slug>.md` + PR body with `## Agent Notes` |
+| `/cdt:auto-task` | Autonomous end-to-end | No | `plan.md` + `.agentnotes/cdt/<branch-slug>.md` + PR body with `## Agent Notes` |
 
 ### `/cdt:plan-task` — Design Phase
 
@@ -76,7 +76,7 @@ Spawns Architect + PM + Researcher. The Architect designs the solution, the PM v
 
 Spawns Developer + Code-Tester + Reviewer + Researcher + QA-Tester. Executes tasks wave-by-wave from the plan, with parallel tasks within each wave and sequential ordering between waves.
 
-**Output**: Updated plan + `.dev/cdt/handoffs/handoff-YYYYMMDD-HHMM.md` with session context, open questions, and notes for future sessions.
+**Output**: Updated plan + `.agentnotes/cdt/<branch-slug>.md` — a committed, branch-scoped, append-mode session log. Each CDT run on the branch appends one `## Session YYYYMMDD-HHMM` block with What's Done / Open Questions / Context for Next Session / References sub-sections, so future agents on other branches can `rg .agentnotes/cdt/` to learn cross-branch context.
 
 ### `/cdt:full-task` — Plan + Approve + Dev
 
@@ -88,7 +88,11 @@ Same as `/cdt:full-task` but skips the approval gate. Proceeds directly from pla
 
 ### PR body enrichment (full-task and auto-task)
 
-When either command opens a PR during Wrap Up, the PR body is enriched with an `## Agent Notes` block mirroring the handoff's `Open Questions` and `Context for Next Session` sections. This carries the agent's forward-looking signal into the PR (where downstream tooling can consume it) since the handoff file itself lives under gitignored `.dev/`. If both sections are empty, the block is omitted.
+When either command opens a PR during Wrap Up, the PR body is enriched with an `## Agent Notes` block mirroring the *latest* session's `### Open Questions` and `### Context for Next Session` content from `.agentnotes/cdt/<branch-slug>.md`. The PR body carries only the most recent session for downstream tooling consumers (e.g. `pr-explainer-action`); the full multi-session history lives in the committed branch log. If both sections are empty, the block is omitted.
+
+### Discovery hint auto-install
+
+On every wrap-up that writes a session log, CDT idempotently appends a one-line discovery hint to the host repo's `AGENTS.md` (or `CLAUDE.md` if no `AGENTS.md` exists). The hint instructs future agents to `rg -l "" .agentnotes/cdt/` when picking up unfamiliar work. Idempotency is anchored on the literal string `.agentnotes/cdt` already being present, so re-runs are no-ops. If neither file exists, CDT skips silently — the plugin will never auto-create project docs.
 
 ## Hooks
 

--- a/plugins/cdt/README.md
+++ b/plugins/cdt/README.md
@@ -34,7 +34,7 @@ Planning Phase                    Development Phase
                                  │  Researcher               │
                                  │  (on-demand lookups)      │
                                  ├───────────────────────────┤
-                                 │  Output: session-handoff  │
+                                 │  Output: session log      │
                                  └───────────────────────────┘
 ```
 

--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -100,7 +100,7 @@ Automatically finalize without user interaction:
 1. Stage all changed files
 2. Commit with conventional commit message based on task
 3. Push branch to remote
-4. Derive `BRANCH_SLUG=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH_SLUG/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH_SLUG/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only). Draft the *content* (excluding headings) for the `Open Questions` and `Context for Next Session` sections you will write to the handoff in step 7 — keep both in working memory so the PR body and the handoff carry identical body text under their respective headings. Each bullet MUST cite verified evidence — a grep result, a `file:line` reference, a recent test/build/log output, or a deliberate plan-time decision recorded in the plan file. If you cannot point to specific evidence in the current branch state, drop the bullet. Empty sections are fine; speculative bullets are not. Then create PR via `gh pr create`. PR body = plan summary as description, `Closes #$ISSUE_NO` (if applicable), and an `## Agent Notes` block formatted as:
+4. Derive `BRANCH_SLUG=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH_SLUG/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH_SLUG/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only). Draft the *content* (excluding headings) for the `Open Questions` and `Context for Next Session` sections you will write to the session log in step 7 — keep both in working memory so the PR body and the session log carry identical body text under their respective headings. Each bullet MUST cite verified evidence — a grep result, a `file:line` reference, a recent test/build/log output, or a deliberate plan-time decision recorded in the plan file. If you cannot point to specific evidence in the current branch state, drop the bullet. Empty sections are fine; speculative bullets are not. Then create PR via `gh pr create`. PR body = plan summary as description, `Closes #$ISSUE_NO` (if applicable), and an `## Agent Notes` block formatted as:
 
     ```markdown
     ## Agent Notes
@@ -115,30 +115,55 @@ Automatically finalize without user interaction:
     If both `Open Questions` and `Context for Next Session` are empty, omit the entire `## Agent Notes` block — do NOT emit an empty heading.
 5. After PR creation, if `".dev/cdt/$BRANCH_SLUG/.cdt-scripts-path"` exists, move the issue to "In Review":
    `"$(cat ".dev/cdt/$BRANCH_SLUG/.cdt-scripts-path")/sync-github-issue.sh" review`
-6. Ensure handoff directory exists: `mkdir -p .dev/cdt/handoffs`
-7. Write session handoff to `.dev/cdt/handoffs/handoff-$TIMESTAMP.md` (using `$TIMESTAMP` from Phase 2). Reuse the same `Open Questions` and `Context for Next Session` content drafted for the PR body in step 4 — do not regenerate or rephrase:
+6. Ensure log directory exists: `mkdir -p .agentnotes/cdt`
+7. Write the session log to `.agentnotes/cdt/$BRANCH_SLUG.md` (using `$BRANCH_SLUG` from § 0a and `$TIMESTAMP` from Phase 2). The log is append-mode: each CDT session appends one `## Session $TIMESTAMP` block; the `# Branch:` header stays exactly once at the top. Reuse the same `Open Questions` and `Context for Next Session` content drafted for the PR body in step 4 — do not regenerate or rephrase.
 
-    ```markdown
-    # Session Handoff
+    a. Derive `LOG_PATH=".agentnotes/cdt/$BRANCH_SLUG.md"`.
+    b. If `$LOG_PATH` does NOT exist, write the file as:
 
-    **Task**: [original task from $ARGUMENTS]
-    **Branch**: [branch name]  **Date**: [date]  **Plan**: [plan path from Phase 1]
+        ```markdown
+        # Branch: [branch name]
 
-    ## What's Done
-    [1-2 sentences — what was accomplished]
+        **Created**: [date]
+        **First plan**: [plan path from Phase 1]
 
-    ## Open Questions
-    [Unresolved items, deferred decisions, known limitations]
+        ---
 
-    ## Context for Next Session
-    [What a future session working in this area needs to know that isn't obvious from the code/PR]
+        ## Session $TIMESTAMP
 
-    ## References
-    - PR: [PR URL from step 4]
+        **Task**: [original task from $ARGUMENTS]
+        **Plan**: [plan path from Phase 1]
+
+        ### What's Done
+        [1-2 sentences — what was accomplished]
+
+        ### Open Questions
+        [Unresolved items, deferred decisions, known limitations]
+
+        ### Context for Next Session
+        [What a future session working in this area needs to know that isn't obvious from the code/PR]
+
+        ### References
+        - PR: [PR URL from step 4]
+        ```
+
+    c. If `$LOG_PATH` already exists, read its prior content verbatim into memory, then rewrite the file as `<prior content>` + `\n---\n\n` + a new `## Session $TIMESTAMP` block (same shape as 7b's session block — without the `# Branch:` header).
+
+8. Install the discovery hint into project docs (idempotent, one-shot per host repo):
+
+    ```bash
+    HINT='When picking up work in an unfamiliar area, run `rg -l "" .agentnotes/cdt/` to surface prior CDT session logs.'
+    if [ -f AGENTS.md ] && ! rg -q '\.agentnotes/cdt' AGENTS.md; then
+      printf '\n%s\n' "$HINT" >> AGENTS.md
+    elif [ ! -f AGENTS.md ] && [ -f CLAUDE.md ] && ! rg -q '\.agentnotes/cdt' CLAUDE.md; then
+      printf '\n%s\n' "$HINT" >> CLAUDE.md
+    fi
     ```
 
-8. Clean up branch state: `[ -n "$BRANCH_SLUG" ] && rm -rf ".dev/cdt/$BRANCH_SLUG"`
-9. Print PR URL to user
+   Skip silently if neither file exists — the plugin must NOT auto-create project docs. Idempotency is anchored on the literal string `.agentnotes/cdt` in the host file.
+
+9. Clean up branch state: `[ -n "$BRANCH_SLUG" ] && rm -rf ".dev/cdt/$BRANCH_SLUG"`
+10. Print PR URL to user
 
 ## Bridge
 

--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -160,7 +160,7 @@ Automatically finalize without user interaction:
     fi
     ```
 
-   Skip silently if neither file exists — the plugin must NOT auto-create project docs. Idempotency is anchored on the literal string `.agentnotes/cdt` in the host file.
+    Skip silently if neither file exists — the plugin must NOT auto-create project docs. Idempotency is anchored on the literal string `.agentnotes/cdt` in the host file.
 
 9. Clean up branch state: `[ -n "$BRANCH_SLUG" ] && rm -rf ".dev/cdt/$BRANCH_SLUG"`
 10. Print PR URL to user

--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -8,7 +8,7 @@ description: "Create an agent team for autonomous workflow: plan (Architect team
 > All implementation, testing, review, and documentation MUST be delegated to teammates via SendMessage.
 > If you find yourself about to edit a file, STOP and delegate to the appropriate teammate instead.
 > You verify plan/report artifacts written by teammates.
-> **Narrow exception**: One-shot Bash file-appends for plugin-install side effects (specifically the discovery-hint install — a single idempotent `printf >>` to `AGENTS.md` or `CLAUDE.md`, guarded by `rg -q '\.agentnotes/cdt'`) are explicitly permitted. This exception does NOT extend to Edit/Write/NotebookEdit on any file, nor to broader Bash file edits on source, test, or doc content.
+> **Narrow exception**: One-shot Bash file-appends for plugin-install side effects (specifically the discovery-hint install performed in Wrap Up step 8) are explicitly permitted. This exception does NOT extend to Edit/Write/NotebookEdit on any file, nor to broader Bash file edits on source, test, or doc content.
 
 # /auto-task — Autonomous Workflow
 

--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -8,6 +8,7 @@ description: "Create an agent team for autonomous workflow: plan (Architect team
 > All implementation, testing, review, and documentation MUST be delegated to teammates via SendMessage.
 > If you find yourself about to edit a file, STOP and delegate to the appropriate teammate instead.
 > You verify plan/report artifacts written by teammates.
+> **Narrow exception**: One-shot Bash file-appends for plugin-install side effects (specifically the discovery-hint install — a single idempotent `printf >>` to `AGENTS.md` or `CLAUDE.md`, guarded by `rg -q '\.agentnotes/cdt'`) are explicitly permitted. This exception does NOT extend to Edit/Write/NotebookEdit on any file, nor to broader Bash file edits on source, test, or doc content.
 
 # /auto-task — Autonomous Workflow
 
@@ -162,8 +163,22 @@ Automatically finalize without user interaction:
 
     Skip silently if neither file exists — the plugin must NOT auto-create project docs. Idempotency is anchored on the literal string `.agentnotes/cdt` in the host file.
 
-9. Clean up branch state: `[ -n "$BRANCH_SLUG" ] && rm -rf ".dev/cdt/$BRANCH_SLUG"`
-10. Print PR URL to user
+9. Commit and push the session log and discovery hint. The feature commit (step 2) cannot include these because they are written *after* PR creation; this second commit ensures both artifacts land in the PR's commit history (without it the log + hint stay local-only and the PR never reflects the new branch-scoped log design):
+
+    ```bash
+    git add ".agentnotes/cdt/$BRANCH_SLUG.md"
+    [ -f AGENTS.md ] && git add AGENTS.md
+    [ -f CLAUDE.md ] && git add CLAUDE.md
+    if ! git diff --cached --quiet; then
+      git commit -m "chore(cdt): record session log for $TIMESTAMP"
+      git push origin HEAD
+    fi
+    ```
+
+    The `git diff --cached --quiet` guard is an edge-case safety net — under normal conditions the log file (step 7) always produces a staged change. If both the log write and the hint install were no-ops, the commit is skipped silently rather than failing on an empty commit.
+
+10. Clean up branch state: `[ -n "$BRANCH_SLUG" ] && rm -rf ".dev/cdt/$BRANCH_SLUG"`
+11. Print PR URL to user
 
 ## Bridge
 

--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -116,7 +116,7 @@ Automatically finalize without user interaction:
 5. After PR creation, if `".dev/cdt/$BRANCH_SLUG/.cdt-scripts-path"` exists, move the issue to "In Review":
    `"$(cat ".dev/cdt/$BRANCH_SLUG/.cdt-scripts-path")/sync-github-issue.sh" review`
 6. Ensure log directory exists: `mkdir -p .agentnotes/cdt`
-7. Write the session log to `.agentnotes/cdt/$BRANCH_SLUG.md` (using `$BRANCH_SLUG` from § 0a and `$TIMESTAMP` from Phase 2). The log is append-mode: each CDT session appends one `## Session $TIMESTAMP` block; the `# Branch:` header stays exactly once at the top. Reuse the same `Open Questions` and `Context for Next Session` content drafted for the PR body in step 4 — do not regenerate or rephrase.
+7. Write the session log to `.agentnotes/cdt/$BRANCH_SLUG.md` (using `$BRANCH_SLUG` from step 4 and `$TIMESTAMP` from Phase 2). The log is append-mode: each CDT session appends one `## Session $TIMESTAMP` block; the `# Branch:` header stays exactly once at the top. Reuse the same `Open Questions` and `Context for Next Session` content drafted for the PR body in step 4 — do not regenerate or rephrase.
 
     a. Derive `LOG_PATH=".agentnotes/cdt/$BRANCH_SLUG.md"`.
     b. If `$LOG_PATH` does NOT exist, write the file as:

--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -76,7 +76,7 @@ Log a brief summary of the plan to the user (task count, waves, key decisions), 
 
 ## Phase 2: Development
 
-Follow the development workflow defined in @dev-workflow.md using the plan path from Phase 1 (skip Step 0 — Git Check was already done above; skip sections 9 and 10 — this command handles handoff and wrap-up). dev-workflow.md generates its own timestamp for the session handoff.
+Follow the development workflow defined in @dev-workflow.md using the plan path from Phase 1 (skip Step 0 — Git Check was already done above; skip sections 9 and 10 — this command handles the session log write and wrap-up). dev-workflow.md generates its own timestamp for the session log.
 
 ## Phase 2: Completion Audit
 

--- a/plugins/cdt/commands/dev-task.md
+++ b/plugins/cdt/commands/dev-task.md
@@ -4,6 +4,8 @@ description: "Create an agent team to develop: Developer teammate + Code-tester 
 ---
 
 > **ROLE: Coordinator only.** You do NOT edit source code, test files, or project docs. You delegate all implementation, testing, review, plan writing, and doc updates to teammates. You verify plan/report artifacts written by teammates.
+>
+> **Narrow exception**: One-shot Bash file-appends for plugin-install side effects (specifically the discovery-hint install performed in dev-workflow.md §9 step 6) are explicitly permitted. This exception does NOT extend to Edit/Write/NotebookEdit on any file, nor to broader Bash file edits on source, test, or doc content.
 
 # /dev-task — Development Phase
 

--- a/plugins/cdt/commands/full-task.md
+++ b/plugins/cdt/commands/full-task.md
@@ -8,7 +8,7 @@ description: "Create an agent team for full workflow: plan (Architect teammate +
 > All implementation, testing, review, and documentation MUST be delegated to teammates via SendMessage.
 > If you find yourself about to edit a file, STOP and delegate to the appropriate teammate instead.
 > You verify plan/report artifacts written by teammates.
-> **Narrow exception**: One-shot Bash file-appends for plugin-install side effects (specifically the discovery-hint install in dev-workflow.md §9 step 6 — a single idempotent `printf >>` to `AGENTS.md` or `CLAUDE.md`, guarded by `rg -q '\.agentnotes/cdt'`) are explicitly permitted. This exception does NOT extend to Edit/Write/NotebookEdit on any file, nor to broader Bash file edits on source, test, or doc content.
+> **Narrow exception**: One-shot Bash file-appends for plugin-install side effects (specifically the discovery-hint install performed in dev-workflow.md §9 step 6) are explicitly permitted. This exception does NOT extend to Edit/Write/NotebookEdit on any file, nor to broader Bash file edits on source, test, or doc content.
 
 # /full-task — Complete Workflow
 
@@ -116,7 +116,7 @@ If creating PR:
 1. Stage changed files
 2. Commit with conventional commit message based on task
 3. Push branch
-4. Derive `BRANCH_SLUG=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH_SLUG/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH_SLUG/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only). Read the branch-scoped session log at `.agentnotes/cdt/$BRANCH_SLUG.md` (written by `dev-workflow.md` step 9 during Phase 2) and extract the latest session's `### Open Questions` and `### Context for Next Session` content using this anchored slice:
+4. Derive `BRANCH_SLUG=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH_SLUG/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH_SLUG/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only). If `.agentnotes/cdt/$BRANCH_SLUG.md` is missing, unreadable, or contains no `^## Session ` line, treat the extracted `Open Questions` and `Context for Next Session` as empty (which naturally omits the `## Agent Notes` block via the empty-section rule below) and skip the slice steps. Otherwise, read the branch-scoped session log (written by `dev-workflow.md` step 9 during Phase 2) and extract the latest session's `### Open Questions` and `### Context for Next Session` content using this anchored slice:
 
     a. Find the **last** line in the file matching `^## Session ` (start-of-line anchor). This anchors on the most recent session block.
     b. Slice from that line to the next `^## ` heading at start-of-line, or to EOF if no subsequent `## ` heading exists.

--- a/plugins/cdt/commands/full-task.md
+++ b/plugins/cdt/commands/full-task.md
@@ -8,6 +8,7 @@ description: "Create an agent team for full workflow: plan (Architect teammate +
 > All implementation, testing, review, and documentation MUST be delegated to teammates via SendMessage.
 > If you find yourself about to edit a file, STOP and delegate to the appropriate teammate instead.
 > You verify plan/report artifacts written by teammates.
+> **Narrow exception**: One-shot Bash file-appends for plugin-install side effects (specifically the discovery-hint install in dev-workflow.md §9 step 6 — a single idempotent `printf >>` to `AGENTS.md` or `CLAUDE.md`, guarded by `rg -q '\.agentnotes/cdt'`) are explicitly permitted. This exception does NOT extend to Edit/Write/NotebookEdit on any file, nor to broader Bash file edits on source, test, or doc content.
 
 # /full-task — Complete Workflow
 

--- a/plugins/cdt/commands/full-task.md
+++ b/plugins/cdt/commands/full-task.md
@@ -84,7 +84,7 @@ Do NOT proceed without approval. If revisions: update plan, re-present.
 
 ## Phase 2: Development
 
-Follow the development workflow defined in @dev-workflow.md using the plan path from Phase 1 (skip Step 0 — Git Check was already done above; skip section 10 — this command handles wrap-up). dev-workflow.md generates its own timestamp for the session handoff.
+Follow the development workflow defined in @dev-workflow.md using the plan path from Phase 1 (skip Step 0 — Git Check was already done above; skip section 10 — this command handles wrap-up). dev-workflow.md generates its own timestamp for the session log.
 
 ## Phase 2: Completion Audit
 

--- a/plugins/cdt/commands/full-task.md
+++ b/plugins/cdt/commands/full-task.md
@@ -107,7 +107,7 @@ If any role was created but never used: **WARN** "Role {name} was created but ne
 Ask user:
 ```
 AskUserQuestion:
-  "Development complete. Session handoff written to .dev/cdt/handoffs/handoff-$TIMESTAMP.md. Ready to commit, push, and create a PR?"
+  "Development complete. Session log written to .agentnotes/cdt/$BRANCH_SLUG.md. Ready to commit, push, and create a PR?"
   Options: Create PR (Recommended) | Commit & push only | Skip
 ```
 
@@ -115,7 +115,14 @@ If creating PR:
 1. Stage changed files
 2. Commit with conventional commit message based on task
 3. Push branch
-4. Derive `BRANCH_SLUG=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH_SLUG/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH_SLUG/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only). Read `.dev/cdt/handoffs/handoff-$TIMESTAMP.md` (written by `dev-workflow.md` step 9 during Phase 2) and extract the *content* under its `## Open Questions` and `## Context for Next Session` headings — exclude the heading lines themselves and stop extraction at the next `## ` heading at the start of a line, or at end-of-file if there is no subsequent `## ` heading. If extracted bullets contain claims you cannot verify in the current branch state, drop them rather than copying through. Create PR. PR body = plan summary as description, `Closes #$ISSUE_NO` (if applicable), and an `## Agent Notes` block formatted as:
+4. Derive `BRANCH_SLUG=$(git branch --show-current | tr '/' '-')`; if `".dev/cdt/$BRANCH_SLUG/.cdt-issue"` exists and is non-empty, read `ISSUE_NO="$(cat ".dev/cdt/$BRANCH_SLUG/.cdt-issue")"`; validate ISSUE_NO is numeric (digits only). Read the branch-scoped session log at `.agentnotes/cdt/$BRANCH_SLUG.md` (written by `dev-workflow.md` step 9 during Phase 2) and extract the latest session's `### Open Questions` and `### Context for Next Session` content using this anchored slice:
+
+    a. Find the **last** line in the file matching `^## Session ` (start-of-line anchor). This anchors on the most recent session block.
+    b. Slice from that line to the next `^## ` heading at start-of-line, or to EOF if no subsequent `## ` heading exists.
+    c. Within that slice, extract the content under `### Open Questions` and `### Context for Next Session` — exclude the heading lines themselves and stop extraction at the next `^### ` heading at start-of-line or at end-of-slice.
+    d. If extracted bullets contain claims you cannot verify in the current branch state, drop them rather than copying through.
+
+    Create PR. PR body = plan summary as description, `Closes #$ISSUE_NO` (if applicable), and an `## Agent Notes` block formatted as:
 
     ```markdown
     ## Agent Notes

--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -31,7 +31,7 @@ If missing or not one of `opus`/`sonnet`, default to `opus`.
 
 ## 2. Generate Timestamp
 
-Generate a timestamp in `YYYYMMDD-HHMM` format for the session handoff output path. Store as `$TIMESTAMP`.
+Generate a timestamp in `YYYYMMDD-HHMM` format for the session log output path. Store as `$TIMESTAMP`.
 
 ## 2a. Compose Team Name
 
@@ -284,9 +284,9 @@ After APPROVED:
 2. Wait for all teammates to confirm shutdown (they may approve or reject — if rejected, resolve the issue first)
 3. Once all teammates have stopped, run TeamDelete to clean up the team
 
-## 9. Write Session Handoff
+## 9. Write Session Log
 
-The session handoff is a committed, branch-scoped, append-mode log at `.agentnotes/cdt/$BRANCH_SLUG.md`. Each CDT session appends one `## Session $TIMESTAMP` block; future agents on other branches `rg` against this directory to learn cross-branch context.
+The session log is a committed, branch-scoped, append-mode log at `.agentnotes/cdt/$BRANCH_SLUG.md`. Each CDT session appends one `## Session $TIMESTAMP` block; future agents on other branches `rg` against this directory to learn cross-branch context.
 
 1. Ensure directory exists: `mkdir -p .agentnotes/cdt`
 2. Derive the file path: `LOG_PATH=".agentnotes/cdt/$BRANCH_SLUG.md"` (reuse `$BRANCH_SLUG` from § 0a).
@@ -333,7 +333,7 @@ The session handoff is a committed, branch-scoped, append-mode log at `.agentnot
     fi
     ```
 
-   Skip silently if neither file exists — the plugin must NOT auto-create project docs. Idempotency is anchored on the literal string `.agentnotes/cdt` in the host file; if the user removes the line, the next wrap-up re-adds it.
+    Skip silently if neither file exists — the plugin must NOT auto-create project docs. Idempotency is anchored on the literal string `.agentnotes/cdt` in the host file; if the user removes the line, the next wrap-up re-adds it.
 
 ## 10. Wrap Up
 
@@ -364,7 +364,7 @@ If commit & push only:
 - Fixing bugs yourself when developer↔tester cycles haven't been exhausted
 - Reviewing code yourself instead of messaging reviewer teammate
 - "Quick fixing" a file because it's faster than delegating
-- Skipping the session handoff (section 9) before wrap-up
+- Skipping the session log (section 9) before wrap-up
 - Updating project documentation yourself instead of delegating to developer teammate
 
 ## Rules

--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -365,7 +365,7 @@ If commit & push only:
 - Reviewing code yourself instead of messaging reviewer teammate
 - "Quick fixing" a file because it's faster than delegating
 - Skipping the session log (section 9) before wrap-up
-- Updating project documentation yourself instead of delegating to developer teammate
+- Updating project documentation yourself (other than the § 9 step 6 discovery-hint install, which is the explicit narrow exception per the command preambles) instead of delegating to developer teammate
 
 ## Rules
 

--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -286,34 +286,61 @@ After APPROVED:
 
 ## 9. Write Session Handoff
 
-Ensure directory exists: `mkdir -p .dev/cdt/handoffs`
+The session handoff is a committed, branch-scoped, append-mode log at `.agentnotes/cdt/$BRANCH_SLUG.md`. Each CDT session appends one `## Session $TIMESTAMP` block; future agents on other branches `rg` against this directory to learn cross-branch context.
 
-Write the session handoff to `.dev/cdt/handoffs/handoff-$TIMESTAMP.md`:
+1. Ensure directory exists: `mkdir -p .agentnotes/cdt`
+2. Derive the file path: `LOG_PATH=".agentnotes/cdt/$BRANCH_SLUG.md"` (reuse `$BRANCH_SLUG` from § 0a).
+3. If `$LOG_PATH` does NOT exist, write the file with the header block followed by the first session block:
 
-```markdown
-# Session Handoff
+    ```markdown
+    # Branch: [branch name]
 
-**Task**: [original request from plan's "Target" field]
-**Branch**: [branch name]  **Date**: [date]  **Plan**: [plan path from $ARGUMENTS]
+    **Created**: [date]
+    **First plan**: [plan path from $ARGUMENTS]
 
-## What's Done
-[1-2 sentences — what was accomplished]
+    ---
 
-## Open Questions
-[Unresolved items, deferred decisions, known limitations]
+    ## Session $TIMESTAMP
 
-## Context for Next Session
-[What a future session working in this area needs to know that isn't obvious from the code/PR]
-```
+    **Task**: [original request from plan's "Target" field]
+    **Plan**: [plan path from $ARGUMENTS]
 
-Each `Open Questions` and `Context for Next Session` bullet MUST cite verified evidence — a grep result, a `file:line` reference, a recent test/build/log output, or a deliberate plan-time decision recorded in the plan file. If you cannot point to specific evidence in the current branch state, drop the bullet. Empty sections are fine; speculative bullets are not.
+    ### What's Done
+    [1-2 sentences — what was accomplished]
+
+    ### Open Questions
+    [Unresolved items, deferred decisions, known limitations]
+
+    ### Context for Next Session
+    [What a future session working in this area needs to know that isn't obvious from the code/PR]
+
+    ### References
+    - PR: [PR URL if known, otherwise omit this bullet]
+    ```
+
+4. If `$LOG_PATH` already exists, read its full prior content verbatim into memory, then rewrite the file as `<prior content>` + `\n---\n\n` + a new `## Session $TIMESTAMP` block (same shape as step 3's session block — without the `# Branch:` header, which stays exactly once at the top).
+
+5. Each `### Open Questions` and `### Context for Next Session` bullet MUST cite verified evidence — a grep result, a `file:line` reference, a recent test/build/log output, or a deliberate plan-time decision recorded in the plan file. If you cannot point to specific evidence in the current branch state, drop the bullet. Empty sections are fine; speculative bullets are not.
+
+6. Install the discovery hint into project docs (idempotent, one-shot per host repo). Run:
+
+    ```bash
+    HINT='When picking up work in an unfamiliar area, run `rg -l "" .agentnotes/cdt/` to surface prior CDT session logs.'
+    if [ -f AGENTS.md ] && ! rg -q '\.agentnotes/cdt' AGENTS.md; then
+      printf '\n%s\n' "$HINT" >> AGENTS.md
+    elif [ ! -f AGENTS.md ] && [ -f CLAUDE.md ] && ! rg -q '\.agentnotes/cdt' CLAUDE.md; then
+      printf '\n%s\n' "$HINT" >> CLAUDE.md
+    fi
+    ```
+
+   Skip silently if neither file exists — the plugin must NOT auto-create project docs. Idempotency is anchored on the literal string `.agentnotes/cdt` in the host file; if the user removes the line, the next wrap-up re-adds it.
 
 ## 10. Wrap Up
 
 Ask user:
 ```
 AskUserQuestion:
-  "Development complete. Session handoff written to .dev/cdt/handoffs/handoff-$TIMESTAMP.md. Ready to commit, push, and create a PR?"
+  "Development complete. Session log written to .agentnotes/cdt/$BRANCH_SLUG.md. Ready to commit, push, and create a PR?"
   Options: Create PR (Recommended) | Commit & push only | Skip
 ```
 


### PR DESCRIPTION
## Summary

Promote the CDT session handoff from a gitignored per-session file
(`.dev/cdt/handoffs/handoff-$TIMESTAMP.md`) to a committed, branch-scoped
**append-mode log** at `.agentnotes/cdt/<branch-slug>.md`. Each CDT run on
a branch appends one `## Session $TIMESTAMP` block under a single
`# Branch:` header, so future agents on *other* branches can `rg
.agentnotes/cdt/` to learn cross-branch context without remote queries.

## Why

PR #219 partly addressed this by mirroring the handoff's `Open Questions`
and `Context for Next Session` into the PR body as `## Agent Notes`, but
PR bodies only carry the *latest* session's signal and require a GitHub
round-trip. A future agent picking up adjacent work on a different branch
had no local, greppable surface to learn from prior CDT handoffs. The
existing durable surfaces (`docs/learnings.md`, merged PR descriptions,
CHANGELOG.md) capture only generalized lessons or require remote queries.

## Changes

- **`plugins/cdt/skills/cdt/references/dev-workflow.md` § 9 + § 10** —
  changed write target to `.agentnotes/cdt/$BRANCH_SLUG.md`, switched
  semantics to read-then-rewrite-with-appended-block, demoted internal
  headings (`## What's Done` → `### What's Done`, etc.) to nest under
  `## Session $TIMESTAMP`, added `### References` sub-section. Updated
  user-message string in § 10.
- **`plugins/cdt/commands/auto-task.md` Wrap Up** — mirrors the new write
  semantics and template inline (auto-task skips `dev-workflow.md`
  §§ 9–10 and inlines its own write).
- **`plugins/cdt/commands/full-task.md` Wrap Up step 4** — changed
  read-extract logic to anchor on the **latest** `## Session ` line at
  start-of-line, slice to the next `## ` heading or EOF, then extract
  nested `### Open Questions` and `### Context for Next Session`
  content. Updated user-message string.
- **PR-body `## Agent Notes` block format unchanged** — backward-compat
  with PR #219's contract (downstream `pr-explainer-action` keeps
  parsing correctly). Empty-section omission rule preserved.
- **Cross-repo discovery hint auto-install** — both `dev-workflow.md`
  § 9 and `auto-task.md` step 8 now idempotently append a one-line
  `rg -l '' .agentnotes/cdt/` hint to the host repo's `AGENTS.md` (or
  `CLAUDE.md` fallback). Grep guard anchored on `.agentnotes/cdt`
  literal prevents re-installation. Skip silently if neither file
  exists — the plugin will never auto-create project docs.
- **`plugins/cdt/README.md`** — commands table, `/cdt:dev-task` Output
  paragraph, PR-body subsection rewritten; new "Discovery hint
  auto-install" subsection.
- **`AGENTS.md`** (this repo bootstrap) — new "Cross-branch agent
  context" section with the discovery hint. The auto-install logic
  would have placed the same hint on the next CDT wrap-up; this manual
  edit just front-runs it.
- **`docs/learnings.md`** — two new entries under Agent Teams:
  read-extract anchoring pattern, and self-installing host-repo hints.

## Atomic landing

`dev-workflow.md` § 9 (write) and `full-task.md` step 4 (read-extract)
**must** land together — splitting them would leave one workflow reading
the wrong format. Both edits ship in this single PR.

## Out of scope

- Migration of existing `.dev/cdt/handoffs/*.md` files (local-only state).
- `bugfix-workflow.md` — emits no session handoff today.
- DLC, PM, or other plugins' artifacts.

## Test plan

- [x] `bun scripts/validate-plugins.mjs` passes (10 source paths, no
  orphans, all SKILL.md frontmatter valid).
- [x] `git diff --stat` shows exactly 6 files changed (+149/-39),
  matching the planned set.
- [x] `rg "\.dev/cdt/handoffs|handoff-\$TIMESTAMP" plugins/cdt/
  AGENTS.md docs/learnings.md` returns only the historical reference
  in `docs/learnings.md`'s `> Source:` line for issue #221.
- [x] `rg "\.agentnotes/cdt"` confirms the new path is referenced
  consistently across `dev-workflow.md`, `auto-task.md`,
  `full-task.md`, README, AGENTS.md, and learnings.md.
- [x] `.gitignore` unchanged — `.agentnotes/` reachable by git;
  existing `.dev/` ignore stays for ephemeral state files
  (`.cdt-issue`, `.cdt-scripts-path`).
- [ ] Manual end-to-end smoke test (`/cdt:dev-task` + `/cdt:full-task`)
  is **prompt-template-only** — the change touches LLM instruction
  surfaces, not executable code. Validation script + grep checks are
  the strongest pre-merge signal.
- [x] Prompt-engineering review per `AGENTS.md` rule: no literal
  actions in preambles before numbered gates, no dual numbered
  sequences, imperatives over aphorisms, no terminology mismatches
  with existing workflow steps (preamble equates "session handoff"
  and "session log" explicitly).

Closes #221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for persistent, branch-scoped append-mode session logs and how to discover cross-branch context.
  * Updated autonomous and full-task workflows to source PR agent notes from the latest session entries and to persist session state.
  * Clarified log-extraction anchoring and evidence-only open-question rules.
  * Added an idempotent, one-line discovery hint auto-install for agent docs and a narrowly scoped append exception.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rube-de/cc-skills/pull/228)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->