### PR TITLE
feat(cdt): directives mechanism with auto-task codex baseline review

### DIFF
--- a/plugins/cdt/commands/auto-task.md
+++ b/plugins/cdt/commands/auto-task.md
@@ -55,6 +55,8 @@ Workflow: auto-task
 
 Follow the planning workflow defined in @plan-workflow.md (skip Step 0 — Git Check was already done above). plan-workflow.md generates its own `$TIMESTAMP` for the plan path.
 
+When the Lead executes Step 4a (Initialize Directives) in `plan-workflow.md`, set `auto_task_baseline: true` in the directives file — this command is the trigger for the always-on advisory baseline review (see [../skills/cdt/references/directives-schema.md](../skills/cdt/references/directives-schema.md)).
+
 ## Phase 1: Completion Audit
 
 Before proceeding, log which roles were actually used during Phase 1:

--- a/plugins/cdt/skills/cdt/SKILL.md
+++ b/plugins/cdt/skills/cdt/SKILL.md
@@ -42,6 +42,8 @@ Plan Phase (plan/full/auto)     Dev Phase (dev/full/auto)       Bugfix Phase (bu
 **Teammates** message each other directly (Architect teammate↔PM teammate, Developer teammate↔Code-tester teammate, Developer teammate↔QA-tester teammate, Developer teammate↔Reviewer teammate). In bugfix mode: Tester teammate↔Developer teammate, Reviewer teammate↔Developer teammate.
 **Researcher** is a subagent — Lead relays results.
 
+**Directives mechanism** (plan phase): Lead → teammate control signals (e.g. `auto_task_baseline`, `council_review`) live in a per-run sidecar JSON file at `.dev/cdt/plans/plan-$TIMESTAMP.directives.json`, not in prompt prose. See [references/directives-schema.md](references/directives-schema.md) for schema and lifecycle.
+
 ## Roles
 
 ### Researcher (subagent — spawn via Task without team_name)

--- a/plugins/cdt/skills/cdt/references/directives-schema.md
+++ b/plugins/cdt/skills/cdt/references/directives-schema.md
@@ -32,7 +32,7 @@ Persisting the file alongside the plan also gives an audit trail: which review t
 | Field | Type | Default | Meaning |
 |-------|------|---------|---------|
 | `schema_version` | string | required | Schema version. PM warns and uses safe-defaults (all directives `false`) on unknown values. |
-| `auto_task_baseline` | bool | `false` | If `true`, PM spawns `Task subagent_type: "codex-consultant"` exactly once for advisory baseline review. |
+| `auto_task_baseline` | bool | `false` | If `true`, PM spawns `Task subagent_type: "council:codex-consultant"` exactly once for advisory baseline review. |
 | `council_review` | bool | `false` | If `true`, PM invokes `Skill: council args "plan [plan-path]"` exactly once for 2-consultant deep review. |
 
 Both review tiers are **advisory only** — neither can hard-block. PM remains the single source of feedback to the architect.
@@ -60,13 +60,13 @@ Both review tiers are **advisory only** — neither can hard-block. PM remains t
 
 ## Canonical JSON formatting
 
-The Lead writes the file with this exact formatting (2-space indent, trailing newline). Architect's `Edit` depends on byte-level match:
+The Lead writes the file with this exact formatting (2-space indent, trailing newline). The architect's `Edit` depends on byte-level match of the structure and key order; the boolean values themselves are determined by invocation context (see [Lifecycle](#lifecycle) above). The example below shows the baseline values (both `false`):
 
-```
+```json
 {
   "schema_version": "1",
-  "auto_task_baseline": <bool>,
-  "council_review": <bool>
+  "auto_task_baseline": false,
+  "council_review": false
 }
 ```
 
@@ -96,4 +96,4 @@ Adding a new directive:
 - `plan-workflow.md` Step 5b architect prompt — Edit instruction
 - `plan-workflow.md` Step 5b PM prompt Step 4 — read + dispatch logic
 - `commands/auto-task.md` Phase 1 — sets `auto_task_baseline: true`
-- `council:review-plan/SKILL.md` lines 115-146 — critique prompt template reused by codex-baseline path
+- `council:review-plan/SKILL.md`, the "Consultant Prompt" section under Step 3 — critique prompt template reused by codex-baseline path

--- a/plugins/cdt/skills/cdt/references/directives-schema.md
+++ b/plugins/cdt/skills/cdt/references/directives-schema.md
@@ -1,0 +1,99 @@
+# Directives Schema
+
+Per-run sidecar JSON file carrying Lead → teammate control signals during the cdt planning phase. Replaces three legacy signal carriers (prompt-prose injection, plan-metadata field, undocumented arg flag) with a single structured source of truth.
+
+## Why a sidecar file
+
+Control signals must reach the PM teammate at Step 4 (external review decision). Two failure modes drove this design:
+
+1. **Prompt-prose drift** — historically the Lead injected an English sentence ("The Lead has requested council review via `--review-plan` flag") into the PM prompt; PM matched against that sentence to decide whether to invoke the council. Renaming the flag, rewording the injection, or LLM paraphrasing broke the match silently.
+2. **Adversarial reach** — when control signals live in prompt prose interleaved with untrusted content (research findings, plan body), an injection in the untrusted block can fabricate a signal. The existing research-context sandboxing (`==== BEGIN RESEARCH CONTEXT (REFERENCE ONLY) ====`) keeps untrusted content from being read as instructions; the directives file is the complement — trusted control signals live outside the prompt stream entirely.
+
+Persisting the file alongside the plan also gives an audit trail: which review tiers were enabled for which plan run.
+
+## File path
+
+```
+.dev/cdt/plans/plan-$TIMESTAMP.directives.json
+```
+
+`$TIMESTAMP` is the same minute-resolution `YYYYMMDD-HHMM` value used for `plan-$TIMESTAMP.md` — directives are co-located with their plan.
+
+## Schema v1
+
+```json
+{
+  "schema_version": "1",
+  "auto_task_baseline": false,
+  "council_review": false
+}
+```
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `schema_version` | string | required | Schema version. PM warns and uses safe-defaults (all directives `false`) on unknown values. |
+| `auto_task_baseline` | bool | `false` | If `true`, PM spawns `Task subagent_type: "codex-consultant"` exactly once for advisory baseline review. |
+| `council_review` | bool | `false` | If `true`, PM invokes `Skill: council args "plan [plan-path]"` exactly once for 2-consultant deep review. |
+
+Both review tiers are **advisory only** — neither can hard-block. PM remains the single source of feedback to the architect.
+
+## Lifecycle
+
+| Phase | Actor | Action |
+|-------|-------|--------|
+| 1. Initial write | Lead | Step 4a writes the file with initial values derived from invocation context: `/cdt:auto-task` → `auto_task_baseline: true`; `--review-plan` in `$ARGUMENTS` → `council_review: true`. All other fields default `false`. |
+| 2. Optional mutation | Architect | During design (Step 5b), the architect MAY `Edit` the file to set `council_review: true` if the design judgment warrants it. Architect MUST NOT mutate `auto_task_baseline` or `schema_version`. |
+| 3. Read & dispatch | PM | Step 4 reads the file. Missing file / malformed JSON / unknown `schema_version` → log warning, treat all directives as `false`, proceed (fail-safe). |
+| 4. Persistence | — | File is never deleted by the workflow. It persists alongside the plan as an audit trail. |
+
+## Behavior matrix
+
+| Invocation | `auto_task_baseline` | `council_review` | External review |
+|------------|----------------------|------------------|-----------------|
+| `/cdt:plan-task <task>` | `false` | `false` | none |
+| `/cdt:plan-task <task> --review-plan` | `false` | `true` | council |
+| `/cdt:full-task <task>` | `false` | `false` | none |
+| `/cdt:full-task <task> --review-plan` | `false` | `true` | council |
+| `/cdt:auto-task <task>` | `true` | `false` | codex baseline |
+| `/cdt:auto-task <task> --review-plan` | `true` | `true` | codex baseline + council |
+| any of the above + architect flips `council_review: true` | unchanged | `true` | baseline (if set) + council |
+
+## Canonical JSON formatting
+
+The Lead writes the file with this exact formatting (2-space indent, trailing newline). Architect's `Edit` depends on byte-level match:
+
+```
+{
+  "schema_version": "1",
+  "auto_task_baseline": <bool>,
+  "council_review": <bool>
+}
+```
+
+Architect's mutation uses `Edit` with `old_string: "council_review": false` → `new_string: "council_review": true`. Single-field change; never rewrite the whole file.
+
+## Edge cases
+
+- **codex CLI unavailable.** When `auto_task_baseline: true` but `codex` is missing from `$PATH`, the `Task` call returns an error. PM logs a skip notice in its verdict and proceeds. Auto-task does NOT halt.
+- **Unknown `schema_version`.** PM warns and treats all directives as `false`. Prevents silent breakage when the schema evolves.
+- **Missing directives file.** Same as unknown schema_version — log warning, safe-default, proceed. A Lead-side write failure should not halt planning.
+- **Malformed JSON.** Same fail-safe path.
+- **Architect mutates fields it shouldn't.** Architect prompt restricts mutations to `council_review`. PM's behavior is governed by what it reads — defense in depth would be PM ignoring `auto_task_baseline` writes from the architect, but v1 trusts the architect prompt.
+- **Per-timestamp collision.** Filenames embed `$TIMESTAMP` to minute resolution; collision requires simultaneous invocation on the same branch within the same minute. Not mitigated further in v1 — same risk as the plan file.
+
+## Extension policy
+
+Adding a new directive:
+
+1. **Non-breaking additions** — adding a defaulted-`false` bool field does NOT require a schema-version bump. Older readers tolerate unknown fields; new writers gate behavior on the new field. Document the field here under Schema v1.
+2. **Breaking changes** — renaming, removing, or changing the type of an existing field requires bumping `schema_version` to `"2"` and updating PM's read logic to handle both versions during a deprecation window.
+3. **Architect mutation rights** — by default, new directives are Lead-write-only. To grant the architect mutation rights, document explicitly here AND in the architect prompt in `plan-workflow.md`.
+4. **Update the behavior matrix above** whenever a new invocation path enables a directive automatically.
+
+## Related
+
+- `plan-workflow.md` Step 4a — Lead initialization
+- `plan-workflow.md` Step 5b architect prompt — Edit instruction
+- `plan-workflow.md` Step 5b PM prompt Step 4 — read + dispatch logic
+- `commands/auto-task.md` Phase 1 — sets `auto_task_baseline: true`
+- `council:review-plan/SKILL.md` lines 115-146 — critique prompt template reused by codex-baseline path

--- a/plugins/cdt/skills/cdt/references/plan-workflow.md
+++ b/plugins/cdt/skills/cdt/references/plan-workflow.md
@@ -59,6 +59,26 @@ TaskCreate:
 3. "Validate requirements" — for PM (blocked by Task 2, receives research findings)
 ```
 
+## 4a. Initialize Directives
+
+Write the per-run directives sidecar to `.dev/cdt/plans/plan-$TIMESTAMP.directives.json` using the `Write` tool. Store the path as `$DIRECTIVES_PATH`.
+
+Determine initial values from invocation context:
+- `auto_task_baseline`: `true` if invoked via `/cdt:auto-task` (per `auto-task.md` Phase 1 instruction); else `false`.
+- `council_review`: `true` if `$ARGUMENTS` includes `--review-plan`; else `false`.
+
+File content (canonical formatting — architect's `Edit` depends on exact match):
+
+```json
+{
+  "schema_version": "1",
+  "auto_task_baseline": <bool>,
+  "council_review": <bool>
+}
+```
+
+The file persists alongside the plan as an audit trail. See [references/directives-schema.md](directives-schema.md) for full schema, lifecycle, and extension policy.
+
 ## 5a. Research (if needed)
 
 If the task involves external libraries, APIs, or patterns the architect needs:
@@ -81,10 +101,7 @@ If no research is needed (pure internal refactor, well-known patterns), set `$RE
 
 Spawn architect and PM simultaneously. Inject `$RESEARCH_CONTEXT` into both prompts.
 
-If `$ARGUMENTS` includes `--review-plan`, inject before the `Set \`**Council Review**: true\`` line in the architect prompt below:
-"The Lead has requested council review via `--review-plan` flag — set `**Council Review**: true` in the plan metadata."
-
-**Architect teammate** (substitute `[plan-path]` → `.dev/cdt/plans/plan-$TIMESTAMP.md` and `$TEAM_NAME` → the value from Step 1a):
+**Architect teammate** (substitute `[plan-path]` → `.dev/cdt/plans/plan-$TIMESTAMP.md`, `[directives-path]` → `.dev/cdt/plans/plan-$TIMESTAMP.directives.json`, and `$TEAM_NAME` → the value from Step 1a):
 ```
 Teammate tool:
   team_name: "$TEAM_NAME"
@@ -116,9 +133,11 @@ Teammate tool:
     5. If you need additional library docs beyond the pre-loaded research, message the lead
     6. Design: components, interfaces, file changes, data flow, testing strategy
        Set `**Developer Model**: sonnet` if the implementation is straightforward file modifications. The default `opus` should be used for complex algorithm design, intricate state management, or security-critical code.
-       Set `**Council Review**: true` if the architecture involves security-critical code,
-       complex state management, or novel patterns that benefit from external validation.
-       Default is `false`. When `--review-plan` is passed, the lead will inject an explicit directive above.
+       If the architecture involves security-critical code, complex state management, or
+       novel patterns that benefit from external validation, use `Edit` on `[directives-path]`
+       to change `"council_review": false` to `"council_review": true`. Do NOT mutate any
+       other field. If `--review-plan` was passed, the Lead has already set `council_review: true`
+       at initialization, so no Edit is needed.
     7. **Task sizing**: Each task MUST touch ≤3 files and represent a single independently-verifiable concern. If a change requires >3 files, either: (a) split it into multiple tasks with explicit dependencies, or (b) justify why a single task is necessary and list all files it will touch in the task description. Exception: docs-only tasks (type: docs) may touch more files.
     8. **TDD ordering**: Where feasible, create test-writing tasks BEFORE their corresponding implementation tasks. The developer writes a failing test first, then implements until it passes (red-green-refactor). If a test requires implementation scaffolding first (e.g., new types, interfaces), set `depends_on` on the test task to list the scaffolding task(s).
     9. **Acceptance criteria**: Write every acceptance criterion as a testable assertion using a Markdown checkbox item that begins with `- [ ] VERIFY:` (for example: `- [ ] VERIFY: <condition>`). Each must be verifiable by running a command, checking output, or inspecting code — never subjective prose like "improved performance" or "better UX". Place them in the plan's `## Acceptance Criteria` section.
@@ -136,7 +155,6 @@ Teammate tool:
 
         **Generated**: [Date]  **Target**: [Original request]
         **Developer Model**: [opus|sonnet]
-        **Council Review**: [true|false] (default: false — enable for critical or high-risk features)
 
         ## Overview
         [Architecture, key decisions, research findings — 2-3 paragraphs]
@@ -208,10 +226,7 @@ Teammate tool:
     16. Mark task complete
 ```
 
-**PM teammate** (substitute `[plan-path]` → `.dev/cdt/plans/plan-$TIMESTAMP.md` and `$TEAM_NAME` → the value from Step 1a):
-
-If `$ARGUMENTS` includes `--review-plan`, inject after the `Plan path:` line in the PM prompt below:
-"Council review has been requested via `--review-plan` flag."
+**PM teammate** (substitute `[plan-path]` → `.dev/cdt/plans/plan-$TIMESTAMP.md`, `[directives-path]` → `.dev/cdt/plans/plan-$TIMESTAMP.directives.json`, and `$TEAM_NAME` → the value from Step 1a):
 
 ```text
 Teammate tool:
@@ -242,19 +257,26 @@ Teammate tool:
     If the design has flaws, say so with specifics. Your job is to find real problems. If the design is genuinely sound, approve — but never rubber-stamp.
 
     3. Message the architect teammate directly with initial concerns.
-       If the Lead indicated `--review-plan` was requested, note that additional feedback may follow after council review.
-    4. Opt-in council review:
-       a. After the architect messages you that the plan file is ready and provides its path,
-          read the plan at [plan-path] and parse its metadata
-       b. If the Lead indicated `--review-plan` was passed, OR the plan metadata includes
-          `Council Review: true`:
-          i. Invoke: Skill tool with skill "council", args "plan [plan-path]"
-          ii. Incorporate council findings into your assessment
-          iii. Include council feedback verbatim in your validation report (step 5) when NEEDS_REVISION
-          Note: Council rejection does NOT independently block — synthesize it as advisory input
-          into your own verdict. You remain the single source of feedback to the architect.
-          Invoke council at most once per plan; do not re-run on subsequent revision cycles.
-       c. Otherwise, skip council invocation entirely (no council latency added)
+       After reading the directives file in Step 4, note that additional feedback may follow if external review runs.
+    4. External review (directives-driven):
+       a. Read `[directives-path]` with the Read tool. If the file is missing, malformed JSON,
+          or has an unknown `schema_version`, log a warning and treat all directives as `false`
+          (fail-safe).
+       b. If `auto_task_baseline: true`:
+          i. Spawn `Task subagent_type: "codex-consultant"` exactly once. Pass the critique
+             prompt template from `council:review-plan/SKILL.md` lines 115-146, with
+             `<plan_content>` populated from [plan-path]. Codex returns Critical/Warning/Note
+             findings as JSON.
+          ii. If the Task result indicates codex CLI is unavailable, log a skip notice and
+              proceed — auto-task does NOT halt.
+       c. If `council_review: true`:
+          i. Invoke: Skill tool with skill "council", args "plan [plan-path]" — exactly once.
+       d. Synthesize all returned findings into your single advisory verdict. Both paths are
+          advisory only — neither baseline nor council can hard-block. You remain the single
+          source of feedback to the architect. Include findings verbatim in your validation
+          report (step 5) when NEEDS_REVISION.
+       e. If neither directive is `true`, skip external review entirely (no latency added).
+       f. Invoke each tier at most once per plan; do not re-run on subsequent revision cycles.
     5. Produce validation report: APPROVED or NEEDS_REVISION with specifics
        If NEEDS_REVISION: message the architect teammate directly with the full report,
        including council feedback verbatim when council was invoked
@@ -286,7 +308,6 @@ The architect teammate writes the plan file. Your role is to verify it exists an
 
 **Generated**: [Date]  **Target**: [Original request]
 **Developer Model**: [opus|sonnet]
-**Council Review**: [true|false] (default: false — enable for critical or high-risk features)
 
 ## Overview
 [Architecture, key decisions, research findings — 2-3 paragraphs]

--- a/plugins/cdt/skills/cdt/references/plan-workflow.md
+++ b/plugins/cdt/skills/cdt/references/plan-workflow.md
@@ -61,19 +61,22 @@ TaskCreate:
 
 ## 4a. Initialize Directives
 
-Write the per-run directives sidecar to `.dev/cdt/plans/plan-$TIMESTAMP.directives.json` using the `Write` tool. Store the path as `$DIRECTIVES_PATH`.
+Ensure the plans directory exists, then write the per-run directives sidecar to `.dev/cdt/plans/plan-$TIMESTAMP.directives.json`:
+
+1. Call the Bash tool: `mkdir -p .dev/cdt/plans`
+2. Call the Write tool to create the sidecar file at the path above.
 
 Determine initial values from invocation context:
 - `auto_task_baseline`: `true` if invoked via `/cdt:auto-task` (per `auto-task.md` Phase 1 instruction); else `false`.
 - `council_review`: `true` if `$ARGUMENTS` includes `--review-plan`; else `false`.
 
-File content (canonical formatting — architect's `Edit` depends on exact match):
+Canonical formatting (2-space indent, trailing newline) — the architect's later `Edit` depends on byte-level match of the structure and key order. The example below shows the baseline values (both `false`); substitute `true` where the rules above require it:
 
 ```json
 {
   "schema_version": "1",
-  "auto_task_baseline": <bool>,
-  "council_review": <bool>
+  "auto_task_baseline": false,
+  "council_review": false
 }
 ```
 
@@ -263,10 +266,10 @@ Teammate tool:
           or has an unknown `schema_version`, log a warning and treat all directives as `false`
           (fail-safe).
        b. If `auto_task_baseline: true`:
-          i. Spawn `Task subagent_type: "codex-consultant"` exactly once. Pass the critique
-             prompt template from `council:review-plan/SKILL.md` lines 115-146, with
-             `<plan_content>` populated from [plan-path]. Codex returns Critical/Warning/Note
-             findings as JSON.
+          i. Spawn `Task subagent_type: "council:codex-consultant"` exactly once. Pass the
+             critique prompt template from `council:review-plan/SKILL.md` (the "Consultant
+             Prompt" section under Step 3), with `<plan_content>` populated from [plan-path].
+             Codex returns Critical/Warning/Note findings as JSON.
           ii. If the Task result indicates codex CLI is unavailable, log a skip notice and
               proceed — auto-task does NOT halt.
        c. If `council_review: true`:


### PR DESCRIPTION
Closes #225 · Approved spec: `.dev/pm/specs/2026-04-29-auto-task-codex-baseline-review.md`

## Summary

Replace three fragmented Lead → teammate signal carriers (prompt-prose injection, plan-metadata `Council Review` field, undocumented `--review-plan` arg flag) with a single sidecar JSON file at `.dev/cdt/plans/plan-$TIMESTAMP.directives.json`. Add `auto_task_baseline` as the inaugural directive — always-on advisory `codex-consultant` review for `/cdt:auto-task`, giving autonomous mode at least one external sanity check despite having no user approval gate.

**No user-facing flag changes.** `--review-plan` still works exactly as today; only internal plumbing changes.

## Files Changed

| Path | Action |
|------|--------|
| `plugins/cdt/skills/cdt/references/directives-schema.md` | new file — schema, lifecycle, extension policy |
| `plugins/cdt/skills/cdt/references/plan-workflow.md` | 11 sites + new Step 4a (Initialize Directives) |
| `plugins/cdt/commands/auto-task.md` | one-line instruction setting `auto_task_baseline: true` |
| `plugins/cdt/skills/cdt/SKILL.md` | paragraph under Architecture pointing at the schema doc |

## Behavior Matrix

| Invocation | `auto_task_baseline` | `council_review` | External review |
|---|---|---|---|
| `/cdt:plan-task <task>` | `false` | `false` | none |
| `/cdt:plan-task <task> --review-plan` | `false` | `true` | council |
| `/cdt:full-task <task>` | `false` | `false` | none |
| `/cdt:full-task <task> --review-plan` | `false` | `true` | council |
| `/cdt:auto-task <task>` | `true` | `false` | codex baseline |
| `/cdt:auto-task <task> --review-plan` | `true` | `true` | codex baseline + council |
| any of above + architect flips `council_review: true` | unchanged | `true` | baseline (if set) + council |

## Smoke Tests (simulation)

The cdt skill is not loaded in the PR session, so end-to-end Agent-Teammate orchestration is deferred to manual post-merge verification. Simulated each of the 6 behavior-matrix rows using the same primitive tool calls Lead / architect / PM use (`Write`, `Edit`, `Read`, `Task`).

| # | Mode | Result |
|---|------|--------|
| 1 | `/cdt:plan-task` | **PASS** — JSON content matches; PM skips both review paths |
| 2 | `/cdt:plan-task --review-plan` | **PASS** — `council_review: true`; PM invokes `Skill: council` |
| 3 | `/cdt:auto-task` | **PASS** — cross-plugin `Task subagent_type: \"codex-consultant\"` succeeded on 2026-05-11; codex v0.128.0 returned valid critique-template JSON |
| 4 | `/cdt:auto-task --review-plan` | **PASS** — both paths covered by Tests 2 + 3 |
| 5 | Architect mid-design `Edit` flip | **PASS** — post-Edit file byte-identical to Lead-initial-write of the same state (Edit byte-precision contract holds) |
| 6 | codex CLI unavailable | **PASS (contract review)** — agent's documented fallback at `codex-consultant.md:180` aligned with PM Step 4 fail-safe instruction |

Full results in `.dev/cdt/smoke-test-results.md` (gitignored locally).

## Acceptance Criteria

- [x] `/cdt:plan-task` writes directives with both `false`
- [x] `/cdt:plan-task --review-plan` writes `council_review: true`
- [x] `/cdt:auto-task` writes `auto_task_baseline: true`, `council_review: false`
- [x] `/cdt:auto-task --review-plan` writes both `true`
- [x] Architect `Edit` of `council_review` produces byte-identical result to Lead initial-write of same state
- [x] PM Step 4 spawns `codex-consultant` exactly once when `auto_task_baseline: true` (instruction codified in `plan-workflow.md`; cross-plugin spawn verified via Test 3)
- [x] PM Step 4 invokes `Skill: council` exactly once when `council_review: true`
- [x] Codex CLI unavailable → PM skips and proceeds (contract reviewed; both halves consistent)
- [x] Baseline returning Critical findings does not block auto-task (PM advisory-only verdict semantics preserved)
- [x] Plan template no longer contains `**Council Review**` (both instances removed)
- [x] No `--review-plan` prose injection sites remain in `plan-workflow.md`
- [x] PM no longer matches `--review-plan` signal text or plan-metadata `Council Review: true` — reads directives file as only source of truth
- [x] `directives-schema.md` created at `plugins/cdt/skills/cdt/references/`
- [x] `cdt/SKILL.md` mentions directives mechanism with pointer to schema doc
- [x] `dev-workflow.md` and `bugfix-workflow.md` unchanged (verified clean)
- [x] `bun scripts/validate-plugins.mjs` passes

## Note on Codex's Smoke-Test Finding

While verifying Test 3, codex flagged a real-but-out-of-scope concern: \"no atomic writes, no schema validation, no read/write ordering\" — relevant if the design ever grows concurrent writers. For v1, the Lead is a single sequential agent and PM Step 4's fail-safe (\"missing / malformed / unknown schema_version → all-false defaults\") covers the malformed-read case. Recording for a hypothetical v2.

## Test Plan (Manual Post-Merge)

End-to-end orchestration verification requires the cdt skill to be loaded:

- [ ] Run `/cdt:plan-task \"<trivial task>\"` and confirm `.dev/cdt/plans/plan-*.directives.json` exists with both `false`
- [ ] Run `/cdt:plan-task \"<trivial task>\" --review-plan` and confirm `council_review: true` in the file and council Skill invocation in the team transcript
- [ ] Run `/cdt:auto-task \"<trivial sacrificial task>\"` and confirm codex-consultant spawn appears in PM's transcript; auto-task completes successfully even if codex returns Critical findings
- [ ] Confirm `bun scripts/validate-plugins.mjs` still passes against the merged main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an explicit Phase 1 instruction to set an auto-review baseline flag during plan initialization.
  * Introduced a per-run directives sidecar JSON mechanism for plan-level control signals.
  * Added a directives schema doc describing fields, lifecycle, error handling, and edit policy.
  * Updated the plan workflow and teammate instructions to read/write directives and drive advisory and council reviews accordingly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rube-de/cc-skills/pull/229)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->