### PR TITLE
feat(dlc): add update-review-checklist skill (closes #216)

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -544,16 +544,16 @@ When a shell loop produces N JSON records and you want a single JSON array on st
 
 **Bad** — manual array assembly:
 ```bash
-echo "[" > out.jsonl
+echo "[" > out.json
 first=1
 for x in ...; do
   if some_step; then
-    if [ "$first" = 1 ]; then jq -c '.' result >> out.jsonl; first=0
-    else printf "," >> out.jsonl; jq -c '.' result >> out.jsonl
+    if [ "$first" = 1 ]; then jq -c '.' result >> out.json; first=0
+    else printf "," >> out.json; jq -c '.' result >> out.json
     fi
   fi
 done
-echo "]" >> out.jsonl
+echo "]" >> out.json
 ```
 
 **Good** — JSONL per iteration, slurp at the end:

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -508,6 +508,70 @@ Skills that make 3–4 sequential `gh` CLI calls waste context window space on r
 
 > Source: [Issue #74](https://github.com/rube-de/cc-skills/issues/74) — `pr-check` and `pm:next` batched into `pr-comments.sh` and `open-issues.sh` respectively.
 
+### `jq` function parameters are filters, not values — rebind to a local var
+
+`def f(p): ...` looks like a function with a value parameter, but jq parameters are *filters* substituted at call sites. Inside the body, every reference to `p` re-evaluates the filter against the current `.`. When `p` is itself a path expression (e.g. `$first_c.createdAt`), and the function body shifts `.` to a different value (e.g. iterating over an array of strings), the filter is re-evaluated in the new scope and breaks.
+
+**Bad** — `created` is re-evaluated each time `.` shifts:
+```jq
+def resolved(created):
+  [ $author_commit_dates[] | select(. > created) ] | length > 0;
+
+# Call site:
+resolved($first_c.createdAt)
+```
+
+Inside `select`, `.` is now an item from `$author_commit_dates` (a date string), and `created` re-evaluates as `<string>.createdAt` → `Cannot index string with string "createdAt"`.
+
+**Good** — bind the parameter to a `$`-variable on entry so the value is captured once:
+```jq
+def resolved(created_filter):
+  (created_filter) as $created |
+  [ $author_commit_dates[] | select(. > $created) ] | length > 0;
+```
+
+This is the canonical pattern any time a jq function:
+- Takes a parameter that is a path expression (`$x.foo`, `.bar.baz`), AND
+- Uses that parameter inside a context where `.` is something other than the original input.
+
+Functions whose parameter is *purely* a `$`-variable (e.g. `f($pr_author)`) are safe — variable references do not depend on `.`. Functions that only use the parameter on the original `.` are safe — `.` hasn't shifted yet.
+
+> Source: `fetch-merged-pr-comments.sh` — initial implementation defined `def resolved(created)` and `def detect_severity(body)` with raw filter parameters. The first smoke test produced `jq: error: Cannot index string with string "createdAt"` because the parameter filter was re-evaluated inside `select(. > created)`. Fixed by rebinding to `(created) as $created` on entry. Same fix applied prophylactically to `detect_severity`.
+
+### JSON-array assembly: prefer JSONL + `--slurpfile` to manual `[`/`,`/`]`
+
+When a shell loop produces N JSON records and you want a single JSON array on stdout, the obvious "open with `[`, separator `,`, close with `]`" approach is brittle: any per-iteration failure (mid-loop `continue`, jq error, network blip) leaves a malformed file (`[,]`, trailing comma, missing close).
+
+**Bad** — manual array assembly:
+```bash
+echo "[" > out.jsonl
+first=1
+for x in ...; do
+  if some_step; then
+    if [ "$first" = 1 ]; then jq -c '.' result >> out.jsonl; first=0
+    else printf "," >> out.jsonl; jq -c '.' result >> out.jsonl
+    fi
+  fi
+done
+echo "]" >> out.jsonl
+```
+
+**Good** — JSONL per iteration, slurp at the end:
+```bash
+: > out.jsonl
+for x in ...; do
+  if some_step; then
+    jq -c '.' result >> out.jsonl
+  fi
+done
+
+jq -n --slurpfile prs out.jsonl '{prs: $prs}'
+```
+
+`--slurpfile` reads N newline-separated JSON values into an array natively. Per-iteration failures are no-ops; an empty file slurps to `[]`. No special-case for the first element, no comma bookkeeping, no malformed-file risk.
+
+> Source: `fetch-merged-pr-comments.sh` — first draft used manual `[`/`,`/`]` assembly and hit `jq: Bad JSON: Expected value before ','` whenever a per-PR transform failed mid-loop. Switched to JSONL + `--slurpfile`; the special-case logic and the `_sep` marker hack both disappeared. ~15 fewer lines and one less failure mode.
+
 ---
 
 ## GitHub Issue Integration in Agent Teams

--- a/plugins/dlc/scripts/fetch-merged-pr-comments.sh
+++ b/plugins/dlc/scripts/fetch-merged-pr-comments.sh
@@ -214,7 +214,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
           }
         }
       }
-      commits(first: 250) {
+      commits(last: 100) {
         totalCount
         nodes {
           commit {

--- a/plugins/dlc/scripts/fetch-merged-pr-comments.sh
+++ b/plugins/dlc/scripts/fetch-merged-pr-comments.sh
@@ -318,10 +318,12 @@ while [ "$_idx" -lt "$_pr_count" ]; do
       (created_filter) as $created |
       [ $author_commit_dates[] | select(. > $created) ] | length > 0;
 
-    # Threads → comments[].
+    # Threads → comments[]. Exclude threads started by the PR author — these
+    # are typically self-notes or questions, not reviewer feedback.
     [ $pr.reviewThreads.nodes[] |
       . as $thread |
       ($thread.comments.nodes[0]) as $first_c |
+      select($first_c != null and ($first_c.author.login // "ghost") != $pr_author) |
       {
         id:                 $thread.id,
         type:               "thread",
@@ -336,9 +338,13 @@ while [ "$_idx" -lt "$_pr_count" ]; do
       }
     ] as $thread_comments |
 
-    # Review bodies → comments[].
+    # Review bodies → comments[]. Exclude PR-author review bodies and DLC
+    # reply sentinels — same rule as issue comments below; neither carries
+    # reviewer signal.
     [ $pr.reviews.nodes[] |
       select(.body != null and (.body | gsub("\\s"; "") | length > 0)) |
+      select((.author.login // "ghost") != $pr_author) |
+      select(.body | contains("<!-- dlc-reply:") | not) |
       {
         id:                 .id,
         type:               "review_body",

--- a/plugins/dlc/scripts/fetch-merged-pr-comments.sh
+++ b/plugins/dlc/scripts/fetch-merged-pr-comments.sh
@@ -14,7 +14,8 @@
 #     "repo": "owner/name",
 #     "lookback_days": 30,
 #     "cutoff_date": "YYYY-MM-DD",
-#     "merged_prs_inspected": N,
+#     "merged_prs_inspected": N,   // PRs actually analyzed (post-skip, post-fetch)
+#     "merged_prs_listed": N,       // raw `gh pr list` count before --skip-prefix filtering
 #     "skipped_own_prs": N,
 #     "prs": [
 #       {
@@ -140,8 +141,6 @@ CUTOFF_DATE=$(date -u -v-"${LOOKBACK_DAYS}"d +%Y-%m-%d 2>/dev/null \
 
 _tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/fetch-merged-pr-comments.XXXXXX") || die_json "Failed to create temporary directory" "TMPDIR_CREATE"
 trap 'rm -rf "$_tmpdir"' EXIT
-
-MAX_PAGES=20  # safety cap, matches pr-comments.sh
 
 # --- list merged PRs in window ---------------------------------------------
 #
@@ -428,7 +427,7 @@ jq -n \
   --arg repo "$OWNER/$REPO" \
   --argjson lookback "$LOOKBACK_DAYS" \
   --arg cutoff "$CUTOFF_DATE" \
-  --argjson total "$_total_merged" \
+  --argjson listed "$_total_merged" \
   --argjson skipped "$_skipped" \
   --argjson sum_total "$_sum_comments" \
   --argjson sum_bots "$_sum_bot_filtered" \
@@ -440,7 +439,8 @@ jq -n \
     repo:                  $repo,
     lookback_days:         $lookback,
     cutoff_date:           $cutoff,
-    merged_prs_inspected:  $total,
+    merged_prs_inspected:  ($prs | length),
+    merged_prs_listed:     $listed,
     skipped_own_prs:       $skipped,
     prs:                   $prs,
     summary: {
@@ -450,6 +450,6 @@ jq -n \
       comments_resolved_by_commit: $sum_resolved,
       comments_with_severity:     $sum_severity,
       truncated:                  $truncated,
-      list_limit_hit:             ($total >= 200)
+      list_limit_hit:             ($listed >= 200)
     }
   }'

--- a/plugins/dlc/scripts/fetch-merged-pr-comments.sh
+++ b/plugins/dlc/scripts/fetch-merged-pr-comments.sh
@@ -294,11 +294,24 @@ while [ "$_idx" -lt "$_pr_count" ]; do
     # resolved_by_commit: a comment is "resolved by commit" iff ≥1 author commit
     # lands AFTER the comment.created_at. We compare ISO strings — safe because
     # ISO8601 is lexicographically orderable.
-    [ $pr.commits.nodes[] |
-      .commit |
-      select((.author.user.login // null) == $pr_author) |
-      .committedDate
-    ] | sort as $author_commit_dates |
+    #
+    # Primary identity: commit.author.user.login (the GitHub-linked identity).
+    # Fallback: GitHub returns author.user = null when the commit email is not
+    # linked to a GitHub account, which would otherwise zero out the signal for
+    # the whole PR. In that case we fall back to using ALL commit dates —
+    # degraded mode (a co-author commit could resolve a comment) but better
+    # than dropping every comment as unresolved-by-commit in Step 3.
+    ( [ $pr.commits.nodes[] |
+        .commit |
+        select((.author.user.login // null) == $pr_author) |
+        .committedDate
+      ] | sort
+    ) as $strict_author_dates |
+    ( if ($strict_author_dates | length) > 0
+        then $strict_author_dates
+        else [ $pr.commits.nodes[] | .commit.committedDate ] | sort
+      end
+    ) as $author_commit_dates |
 
     # Severity detection regex applied across two formats:
     #   * council / deep-review prose:  "Severity: High" / "Confidence: Medium"

--- a/plugins/dlc/scripts/fetch-merged-pr-comments.sh
+++ b/plugins/dlc/scripts/fetch-merged-pr-comments.sh
@@ -16,7 +16,7 @@
 #     "cutoff_date": "YYYY-MM-DD",
 #     "merged_prs_inspected": N,   // PRs actually analyzed (post-skip, post-fetch)
 #     "merged_prs_listed": N,       // raw `gh pr list` count before --skip-prefix filtering
-#     "skipped_own_prs": N,
+#     "skipped_own_prs": N,         // PRs dropped by --skip-prefix (head branch startswith match, NOT author-based)
 #     "prs": [
 #       {
 #         "number": 123,
@@ -428,6 +428,7 @@ jq -n \
   --argjson lookback "$LOOKBACK_DAYS" \
   --arg cutoff "$CUTOFF_DATE" \
   --argjson listed "$_total_merged" \
+  --argjson list_limit "$LIST_LIMIT" \
   --argjson skipped "$_skipped" \
   --argjson sum_total "$_sum_comments" \
   --argjson sum_bots "$_sum_bot_filtered" \
@@ -450,6 +451,6 @@ jq -n \
       comments_resolved_by_commit: $sum_resolved,
       comments_with_severity:     $sum_severity,
       truncated:                  $truncated,
-      list_limit_hit:             ($listed >= 200)
+      list_limit_hit:             ($listed >= $list_limit)
     }
   }'

--- a/plugins/dlc/scripts/fetch-merged-pr-comments.sh
+++ b/plugins/dlc/scripts/fetch-merged-pr-comments.sh
@@ -36,7 +36,7 @@
 #             "line": 42 | null,
 #             "created_at": "ISO8601",
 #             "resolved_by_commit": true,
-#             "severity": "high|medium|low|null"
+#             "severity": "high" | "medium" | "low" | null  // string or JSON null (unquoted)
 #           }
 #         ]
 #       }

--- a/plugins/dlc/scripts/fetch-merged-pr-comments.sh
+++ b/plugins/dlc/scripts/fetch-merged-pr-comments.sh
@@ -265,13 +265,17 @@ while [ "$_idx" -lt "$_pr_count" ]; do
     continue
   fi
 
-  # Track if any nested totalCount exceeded what we fetched (data is incomplete).
+  # Track if any nested totalCount exceeded what we fetched (comment/review/thread
+  # data is incomplete). Commits are intentionally capped at the last 100 because
+  # only recent commits matter for `resolved_by_commit` scoring, so commit
+  # truncation is NOT a signal of missing comment data and is excluded here —
+  # otherwise every >100-commit PR would trigger a spurious "comments may be
+  # missing" warning in downstream consumers.
   _pr_trunc=$(jq -r '
     .data.repository.pullRequest as $pr |
     ( ($pr.comments.totalCount       > ($pr.comments.nodes       | length)) or
       ($pr.reviews.totalCount        > ($pr.reviews.nodes        | length)) or
       ($pr.reviewThreads.totalCount  > ($pr.reviewThreads.nodes  | length)) or
-      ($pr.commits.totalCount        > ($pr.commits.nodes        | length)) or
       ([ $pr.reviewThreads.nodes[] | (.comments.totalCount > (.comments.nodes | length)) ] | any)
     )
   ' "$_tmpdir/pr-$_pr_number.json")

--- a/plugins/dlc/scripts/fetch-merged-pr-comments.sh
+++ b/plugins/dlc/scripts/fetch-merged-pr-comments.sh
@@ -190,14 +190,14 @@ query($owner: String!, $repo: String!, $number: Int!) {
       comments(first: 100) {
         totalCount
         nodes {
-          id databaseId body createdAt
+          id body createdAt
           author { login __typename }
         }
       }
       reviews(first: 100) {
         totalCount
         nodes {
-          id databaseId body state createdAt
+          id body state createdAt
           author { login __typename }
         }
       }
@@ -208,13 +208,13 @@ query($owner: String!, $repo: String!, $number: Int!) {
           comments(first: 50) {
             totalCount
             nodes {
-              id databaseId body createdAt
+              id body createdAt
               author { login __typename }
             }
           }
         }
       }
-      commits(first: 100) {
+      commits(first: 250) {
         totalCount
         nodes {
           commit {

--- a/plugins/dlc/scripts/fetch-merged-pr-comments.sh
+++ b/plugins/dlc/scripts/fetch-merged-pr-comments.sh
@@ -110,12 +110,12 @@ case "$LOOKBACK" in
   *d)
     _lb_n="${LOOKBACK%d}"
     if ! printf '%s' "$_lb_n" | grep -qE '^[1-9][0-9]*$'; then
-      die_json "Invalid --lookback value: $LOOKBACK (expected NNd, e.g. 30d)" "ARG_LOOKBACK"
+      die_json "Invalid --lookback value: $LOOKBACK (expected Nd, e.g. 30d)" "ARG_LOOKBACK"
     fi
     LOOKBACK_DAYS="$_lb_n"
     ;;
   *)
-    die_json "Invalid --lookback value: $LOOKBACK (expected NNd, e.g. 30d)" "ARG_LOOKBACK"
+    die_json "Invalid --lookback value: $LOOKBACK (expected Nd, e.g. 30d)" "ARG_LOOKBACK"
     ;;
 esac
 

--- a/plugins/dlc/scripts/fetch-merged-pr-comments.sh
+++ b/plugins/dlc/scripts/fetch-merged-pr-comments.sh
@@ -240,6 +240,9 @@ _sum_bot_filtered=0
 _sum_resolved=0
 _sum_severity=0
 _truncated_any=false
+# Count per-PR GraphQL / transform failures so the summary distinguishes
+# "no PRs/comments found" from "every fetch failed silently".
+_failures=0
 
 # Iterate the filtered PR list.
 _pr_count=$(jq 'length' "$_tmpdir/pr-list-filtered.json")
@@ -252,11 +255,13 @@ while [ "$_idx" -lt "$_pr_count" ]; do
     -F owner="$OWNER" -F repo="$REPO" -F number="$_pr_number" \
     > "$_tmpdir/pr-$_pr_number.json" 2>"$_tmpdir/pr-$_pr_number-err.txt"; then
     echo "Warning: GraphQL query for PR #$_pr_number failed, skipping: $(tr '"' "'" < "$_tmpdir/pr-$_pr_number-err.txt")" >&2
+    _failures=$((_failures + 1))
     continue
   fi
 
   if jq -e '(.errors // []) | length > 0' "$_tmpdir/pr-$_pr_number.json" >/dev/null 2>&1; then
     echo "Warning: PR #$_pr_number returned GraphQL errors, skipping: $(jq -r '[.errors[].message] | join("; ")' "$_tmpdir/pr-$_pr_number.json")" >&2
+    _failures=$((_failures + 1))
     continue
   fi
 
@@ -404,6 +409,7 @@ while [ "$_idx" -lt "$_pr_count" ]; do
 
   if [ ! -s "$_tmpdir/pr-$_pr_number-out.json" ]; then
     echo "Warning: jq transform for PR #$_pr_number produced no output, skipping: $(cat "$_tmpdir/pr-$_pr_number-jq-err.txt")" >&2
+    _failures=$((_failures + 1))
     continue
   fi
 
@@ -421,6 +427,14 @@ while [ "$_idx" -lt "$_pr_count" ]; do
   jq -c '.' "$_tmpdir/pr-$_pr_number-out.json" >> "$_tmpdir/prs.jsonl"
 done
 
+# If we had PRs to process but every one failed, exit non-zero so callers can
+# distinguish "no PRs/comments found" from "every fetch errored". A silent
+# empty-array would otherwise look like "no clusters to propose" in unattended
+# runs and the issue would never surface.
+if [ "$_kept" -gt 0 ] && [ ! -s "$_tmpdir/prs.jsonl" ]; then
+  die_json "all $_failures per-PR fetches/transforms failed; no PR data produced" "ALL_FETCHES_FAILED"
+fi
+
 # --- assemble final document ----------------------------------------------
 
 jq -n \
@@ -434,6 +448,7 @@ jq -n \
   --argjson sum_bots "$_sum_bot_filtered" \
   --argjson sum_resolved "$_sum_resolved" \
   --argjson sum_severity "$_sum_severity" \
+  --argjson failures "$_failures" \
   --argjson truncated "$([ "$_truncated_any" = true ] && echo true || echo false)" \
   --slurpfile prs "$_tmpdir/prs.jsonl" \
   '{
@@ -450,6 +465,7 @@ jq -n \
       bot_comments:               $sum_bots,
       comments_resolved_by_commit: $sum_resolved,
       comments_with_severity:     $sum_severity,
+      pr_fetch_failures:          $failures,
       truncated:                  $truncated,
       list_limit_hit:             ($listed >= $list_limit)
     }

--- a/plugins/dlc/scripts/fetch-merged-pr-comments.sh
+++ b/plugins/dlc/scripts/fetch-merged-pr-comments.sh
@@ -207,6 +207,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
         nodes {
           id isResolved path line
           comments(first: 50) {
+            totalCount
             nodes {
               id databaseId body createdAt
               author { login __typename }
@@ -266,7 +267,8 @@ while [ "$_idx" -lt "$_pr_count" ]; do
     ( ($pr.comments.totalCount       > ($pr.comments.nodes       | length)) or
       ($pr.reviews.totalCount        > ($pr.reviews.nodes        | length)) or
       ($pr.reviewThreads.totalCount  > ($pr.reviewThreads.nodes  | length)) or
-      ($pr.commits.totalCount        > ($pr.commits.nodes        | length))
+      ($pr.commits.totalCount        > ($pr.commits.nodes        | length)) or
+      ([ $pr.reviewThreads.nodes[] | (.comments.totalCount > (.comments.nodes | length)) ] | any)
     )
   ' "$_tmpdir/pr-$_pr_number.json")
   if [ "$_pr_trunc" = "true" ]; then
@@ -318,23 +320,26 @@ while [ "$_idx" -lt "$_pr_count" ]; do
       (created_filter) as $created |
       [ $author_commit_dates[] | select(. > $created) ] | length > 0;
 
-    # Threads → comments[]. Exclude threads started by the PR author — these
-    # are typically self-notes or questions, not reviewer feedback.
-    [ $pr.reviewThreads.nodes[] |
-      . as $thread |
-      ($thread.comments.nodes[0]) as $first_c |
-      select($first_c != null and ($first_c.author.login // "ghost") != $pr_author) |
+    # Threads → per-comment entries. Iterate all non-author comments per
+    # thread so reviewer follow-ups (not just the root) reach clustering.
+    # Filter PR-author comments and DLC reply sentinels with the same rules
+    # used by the review-bodies and issue-comments blocks below.
+    [ $pr.reviewThreads.nodes[] as $thread |
+      $thread.comments.nodes[] |
+      . as $c |
+      select(($c.author.login // "ghost") != $pr_author) |
+      select(($c.body // "") | contains("<!-- dlc-reply:") | not) |
       {
-        id:                 $thread.id,
+        id:                 ($c.id // $thread.id),
         type:               "thread",
-        author:             ($first_c.author.login // "ghost"),
-        is_bot:             (($first_c.author.__typename // "") == "Bot"),
-        body:               ($first_c.body // ""),
+        author:             ($c.author.login // "ghost"),
+        is_bot:             (($c.author.__typename // "") == "Bot"),
+        body:               (($c.body // "") | .[0:2000]),
         path:               $thread.path,
         line:               $thread.line,
-        created_at:         $first_c.createdAt,
-        resolved_by_commit: resolved($first_c.createdAt),
-        severity:           detect_severity($first_c.body)
+        created_at:         $c.createdAt,
+        resolved_by_commit: resolved($c.createdAt),
+        severity:           detect_severity($c.body // "")
       }
     ] as $thread_comments |
 
@@ -350,7 +355,7 @@ while [ "$_idx" -lt "$_pr_count" ]; do
         type:               "review_body",
         author:             (.author.login // "ghost"),
         is_bot:             ((.author.__typename // "") == "Bot"),
-        body:               .body,
+        body:               (.body | .[0:2000]),
         path:               null,
         line:               null,
         created_at:         .createdAt,
@@ -370,7 +375,7 @@ while [ "$_idx" -lt "$_pr_count" ]; do
         type:               "issue_comment",
         author:             (.author.login // "ghost"),
         is_bot:             ((.author.__typename // "") == "Bot"),
-        body:               .body,
+        body:               (.body | .[0:2000]),
         path:               null,
         line:               null,
         created_at:         .createdAt,

--- a/plugins/dlc/scripts/fetch-merged-pr-comments.sh
+++ b/plugins/dlc/scripts/fetch-merged-pr-comments.sh
@@ -1,0 +1,444 @@
+#!/bin/sh
+# fetch-merged-pr-comments.sh — Fetch merged PRs in a window + their review comments
+# for the update-review-checklist skill.
+#
+# Usage:
+#   fetch-merged-pr-comments.sh [OWNER/REPO] [--lookback Nd] [--skip-prefix PREFIX]
+#
+# Defaults:
+#   --lookback     30d
+#   --skip-prefix  chore/update-review-checklist-
+#
+# Emits a single JSON document on stdout with this shape:
+#   {
+#     "repo": "owner/name",
+#     "lookback_days": 30,
+#     "cutoff_date": "YYYY-MM-DD",
+#     "merged_prs_inspected": N,
+#     "skipped_own_prs": N,
+#     "prs": [
+#       {
+#         "number": 123,
+#         "title": "...",
+#         "url": "...",
+#         "merged_at": "ISO8601",
+#         "author": "login",
+#         "head_branch": "feat/...",
+#         "comments": [
+#           {
+#             "id": "...",
+#             "type": "thread|review_body|issue_comment",
+#             "author": "login",
+#             "is_bot": false,
+#             "body": "...",
+#             "path": "src/foo.ts" | null,
+#             "line": 42 | null,
+#             "created_at": "ISO8601",
+#             "resolved_by_commit": true,
+#             "severity": "high|medium|low|null"
+#           }
+#         ]
+#       }
+#     ],
+#     "summary": { ... }
+#   }
+
+set -u
+
+# --- helpers ---------------------------------------------------------------
+
+die_json() {
+  _code="${2:-UNKNOWN}"
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --arg err "$1" --arg code "$_code" '{error: $err, code: $code}' >&2
+  else
+    _err_escaped=$(printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr '\n' ' ')
+    printf '{"error":"%s","code":"%s"}\n' "$_err_escaped" "$_code" >&2
+  fi
+  exit 1
+}
+
+# --- prerequisites ---------------------------------------------------------
+
+command -v gh >/dev/null 2>&1  || die_json "gh CLI not found — install from https://cli.github.com" "GH_NOT_FOUND"
+command -v jq >/dev/null 2>&1  || die_json "jq not found — install from https://jqlang.github.io/jq" "JQ_NOT_FOUND"
+gh auth status >/dev/null 2>&1 || die_json "gh not authenticated — run: gh auth login" "GH_AUTH"
+
+# --- arg parsing -----------------------------------------------------------
+
+OWNER_REPO=""
+LOOKBACK="30d"
+SKIP_PREFIX="chore/update-review-checklist-"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --lookback)
+      [ -n "${2:-}" ] || die_json "--lookback requires a value (e.g. 30d, 60d)" "ARG_LOOKBACK"
+      LOOKBACK="$2"
+      shift 2
+      ;;
+    --lookback=*)
+      LOOKBACK="${1#--lookback=}"
+      shift
+      ;;
+    --skip-prefix)
+      [ -n "${2:-}" ] || die_json "--skip-prefix requires a value" "ARG_SKIP_PREFIX"
+      SKIP_PREFIX="$2"
+      shift 2
+      ;;
+    --skip-prefix=*)
+      SKIP_PREFIX="${1#--skip-prefix=}"
+      shift
+      ;;
+    --help|-h)
+      sed -n '2,40p' "$0" >&2
+      exit 0
+      ;;
+    */*)
+      OWNER_REPO="$1"
+      shift
+      ;;
+    *)
+      die_json "Unknown argument: $1" "ARG_UNKNOWN"
+      ;;
+  esac
+done
+
+# Validate --lookback format: a positive integer followed by 'd'.
+case "$LOOKBACK" in
+  *d)
+    _lb_n="${LOOKBACK%d}"
+    if ! printf '%s' "$_lb_n" | grep -qE '^[1-9][0-9]*$'; then
+      die_json "Invalid --lookback value: $LOOKBACK (expected NNd, e.g. 30d)" "ARG_LOOKBACK"
+    fi
+    LOOKBACK_DAYS="$_lb_n"
+    ;;
+  *)
+    die_json "Invalid --lookback value: $LOOKBACK (expected NNd, e.g. 30d)" "ARG_LOOKBACK"
+    ;;
+esac
+
+# --- repo detection --------------------------------------------------------
+
+if [ -n "$OWNER_REPO" ]; then
+  OWNER=$(printf '%s\n' "$OWNER_REPO" | cut -d/ -f1)
+  REPO=$(printf '%s\n' "$OWNER_REPO" | cut -d/ -f2)
+else
+  _repo_json=$(gh repo view --json owner,name 2>/dev/null) || die_json "Could not detect repository — pass OWNER/REPO as argument" "REPO_DETECT"
+  OWNER=$(printf '%s\n' "$_repo_json" | jq -r '.owner.login')
+  REPO=$(printf '%s\n' "$_repo_json" | jq -r '.name')
+fi
+[ -n "$OWNER" ] && [ -n "$REPO" ] || die_json "Could not parse owner/repo" "REPO_PARSE"
+
+# --- compute cutoff date (BSD + GNU date compatible) -----------------------
+
+CUTOFF_DATE=$(date -u -v-"${LOOKBACK_DAYS}"d +%Y-%m-%d 2>/dev/null \
+  || date -u --date="${LOOKBACK_DAYS} days ago" +%Y-%m-%d 2>/dev/null) \
+  || die_json "Failed to compute cutoff date" "DATE_FAIL"
+
+# --- temp files ------------------------------------------------------------
+
+_tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/fetch-merged-pr-comments.XXXXXX") || die_json "Failed to create temporary directory" "TMPDIR_CREATE"
+trap 'rm -rf "$_tmpdir"' EXIT
+
+MAX_PAGES=20  # safety cap, matches pr-comments.sh
+
+# --- list merged PRs in window ---------------------------------------------
+#
+# Use `gh pr list` with a search query. `--limit` upper-bounds the page;
+# very busy repos can blow past it — flag in summary if hit.
+
+LIST_LIMIT=200
+
+if ! gh pr list \
+  --repo "$OWNER/$REPO" \
+  --state merged \
+  --search "merged:>=$CUTOFF_DATE" \
+  --json number,title,url,headRefName,author,mergedAt \
+  --limit "$LIST_LIMIT" \
+  > "$_tmpdir/pr-list.json" 2>"$_tmpdir/list_err.txt"; then
+  die_json "gh pr list failed: $(tr '"' "'" < "$_tmpdir/list_err.txt")" "PR_LIST_FAIL"
+fi
+
+_total_merged=$(jq 'length' "$_tmpdir/pr-list.json")
+
+# Drop PRs whose branch starts with SKIP_PREFIX so we never re-ingest our own
+# previous update PRs (acceptance criterion #8 in issue #216).
+
+jq --arg prefix "$SKIP_PREFIX" '
+  [ .[] | select(.headRefName | startswith($prefix) | not) ]
+' "$_tmpdir/pr-list.json" > "$_tmpdir/pr-list-filtered.json"
+
+_kept=$(jq 'length' "$_tmpdir/pr-list-filtered.json")
+_skipped=$((_total_merged - _kept))
+
+# --- per-PR fetch ----------------------------------------------------------
+#
+# For each PR we need:
+#   * review threads (inline comments) — author, body, path, line, created_at
+#   * review bodies — top-level review comments (Copilot/CodeRabbit/Codex summaries, council reports)
+#   * issue comments — general PR-level comments
+#   * commits with author login + committed_at — for the resolved-by-commit heuristic
+#
+# Use a single GraphQL query per PR (with nested connections) to minimise round trips.
+
+PR_DETAIL_QUERY='
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      number title url headRefName mergedAt
+      author { login }
+      comments(first: 100) {
+        totalCount
+        nodes {
+          id databaseId body createdAt
+          author { login __typename }
+        }
+      }
+      reviews(first: 100) {
+        totalCount
+        nodes {
+          id databaseId body state createdAt
+          author { login __typename }
+        }
+      }
+      reviewThreads(first: 100) {
+        totalCount
+        nodes {
+          id isResolved path line
+          comments(first: 50) {
+            nodes {
+              id databaseId body createdAt
+              author { login __typename }
+            }
+          }
+        }
+      }
+      commits(first: 100) {
+        totalCount
+        nodes {
+          commit {
+            oid
+            committedDate
+            author { user { login } email name }
+          }
+        }
+      }
+    }
+  }
+}
+'
+
+# Collect per-PR results as JSON Lines; `--slurpfile` at the end converts the
+# whole thing into an array. Avoids manual comma-and-bracket assembly.
+: > "$_tmpdir/prs.jsonl"
+_idx=0
+
+# Counters for the summary block.
+_sum_comments=0
+_sum_bot_filtered=0
+_sum_resolved=0
+_sum_severity=0
+_truncated_any=false
+
+# Iterate the filtered PR list.
+_pr_count=$(jq 'length' "$_tmpdir/pr-list-filtered.json")
+while [ "$_idx" -lt "$_pr_count" ]; do
+  _pr_number=$(jq -r ".[$_idx].number" "$_tmpdir/pr-list-filtered.json")
+  _idx=$((_idx + 1))
+
+  if ! gh api graphql \
+    -f query="$PR_DETAIL_QUERY" \
+    -F owner="$OWNER" -F repo="$REPO" -F number="$_pr_number" \
+    > "$_tmpdir/pr-$_pr_number.json" 2>"$_tmpdir/pr-$_pr_number-err.txt"; then
+    echo "Warning: GraphQL query for PR #$_pr_number failed, skipping: $(tr '"' "'" < "$_tmpdir/pr-$_pr_number-err.txt")" >&2
+    continue
+  fi
+
+  if jq -e '(.errors // []) | length > 0' "$_tmpdir/pr-$_pr_number.json" >/dev/null 2>&1; then
+    echo "Warning: PR #$_pr_number returned GraphQL errors, skipping: $(jq -r '[.errors[].message] | join("; ")' "$_tmpdir/pr-$_pr_number.json")" >&2
+    continue
+  fi
+
+  # Track if any nested totalCount exceeded what we fetched (data is incomplete).
+  _pr_trunc=$(jq -r '
+    .data.repository.pullRequest as $pr |
+    ( ($pr.comments.totalCount       > ($pr.comments.nodes       | length)) or
+      ($pr.reviews.totalCount        > ($pr.reviews.nodes        | length)) or
+      ($pr.reviewThreads.totalCount  > ($pr.reviewThreads.nodes  | length)) or
+      ($pr.commits.totalCount        > ($pr.commits.nodes        | length))
+    )
+  ' "$_tmpdir/pr-$_pr_number.json")
+  if [ "$_pr_trunc" = "true" ]; then
+    _truncated_any=true
+  fi
+
+  # Transform the raw GraphQL response into the canonical per-PR shape.
+  # The jq program does three things:
+  #   1. Pulls the latest "author commit timestamp" for the PR — used to gate resolved_by_commit.
+  #   2. Flattens threads / review_bodies / issue_comments into a single comments array.
+  #   3. Per comment: marks is_bot (author.__typename == "Bot"), detects severity from body,
+  #      and stamps resolved_by_commit when ≥1 PR-author commit landed AFTER the comment.
+
+  jq '
+    .data.repository.pullRequest as $pr |
+    ($pr.author.login // "ghost") as $pr_author |
+
+    # Commits by the PR author, sorted by committedDate ascending. Used to score
+    # resolved_by_commit: a comment is "resolved by commit" iff ≥1 author commit
+    # lands AFTER the comment.created_at. We compare ISO strings — safe because
+    # ISO8601 is lexicographically orderable.
+    [ $pr.commits.nodes[] |
+      .commit |
+      select((.author.user.login // null) == $pr_author) |
+      .committedDate
+    ] | sort as $author_commit_dates |
+
+    # Severity detection regex applied across two formats:
+    #   * council / deep-review prose:  "Severity: High" / "Confidence: Medium"
+    #   * label-style mentions in body: "[severity/high]", "deep-review/critical"
+    # Returns "high" | "medium" | "low" | null.
+    # NOTE: jq parameters are filters, not values — rebind to a local var first
+    # so we do not accidentally re-evaluate the filter against the inner `.`.
+    def detect_severity(body_filter):
+      (body_filter // "") as $body |
+      ($body | ascii_downcase) as $b |
+      if ($b | test("severity:\\s*(critical|high)|confidence:\\s*high|severity/(high|critical)|deep-review/critical"))
+        then "high"
+      elif ($b | test("severity:\\s*medium|confidence:\\s*medium|severity/medium"))
+        then "medium"
+      elif ($b | test("severity:\\s*low|confidence:\\s*low|severity/low"))
+        then "low"
+      else null
+      end;
+
+    # Marks a comment as resolved_by_commit when ≥1 PR-author commit landed
+    # after the comment was created.
+    def resolved(created_filter):
+      (created_filter) as $created |
+      [ $author_commit_dates[] | select(. > $created) ] | length > 0;
+
+    # Threads → comments[].
+    [ $pr.reviewThreads.nodes[] |
+      . as $thread |
+      ($thread.comments.nodes[0]) as $first_c |
+      {
+        id:                 $thread.id,
+        type:               "thread",
+        author:             ($first_c.author.login // "ghost"),
+        is_bot:             (($first_c.author.__typename // "") == "Bot"),
+        body:               ($first_c.body // ""),
+        path:               $thread.path,
+        line:               $thread.line,
+        created_at:         $first_c.createdAt,
+        resolved_by_commit: resolved($first_c.createdAt),
+        severity:           detect_severity($first_c.body)
+      }
+    ] as $thread_comments |
+
+    # Review bodies → comments[].
+    [ $pr.reviews.nodes[] |
+      select(.body != null and (.body | gsub("\\s"; "") | length > 0)) |
+      {
+        id:                 .id,
+        type:               "review_body",
+        author:             (.author.login // "ghost"),
+        is_bot:             ((.author.__typename // "") == "Bot"),
+        body:               .body,
+        path:               null,
+        line:               null,
+        created_at:         .createdAt,
+        resolved_by_commit: resolved(.createdAt),
+        severity:           detect_severity(.body)
+      }
+    ] as $review_bodies |
+
+    # Issue comments → comments[]. Exclude PR-author comments and DLC reply
+    # sentinels — neither carries reviewer signal.
+    [ $pr.comments.nodes[] |
+      select(.body != null and (.body | gsub("\\s"; "") | length > 0)) |
+      select((.author.login // "ghost") != $pr_author) |
+      select(.body | contains("<!-- dlc-reply:") | not) |
+      {
+        id:                 .id,
+        type:               "issue_comment",
+        author:             (.author.login // "ghost"),
+        is_bot:             ((.author.__typename // "") == "Bot"),
+        body:               .body,
+        path:               null,
+        line:               null,
+        created_at:         .createdAt,
+        resolved_by_commit: resolved(.createdAt),
+        severity:           detect_severity(.body)
+      }
+    ] as $issue_comments |
+
+    ($thread_comments + $review_bodies + $issue_comments) as $all_comments |
+
+    {
+      number:      $pr.number,
+      title:       $pr.title,
+      url:         $pr.url,
+      merged_at:   $pr.mergedAt,
+      author:      $pr_author,
+      head_branch: $pr.headRefName,
+      comments:    $all_comments,
+      counts: {
+        total:              ($all_comments | length),
+        bots:               ([ $all_comments[] | select(.is_bot) ] | length),
+        resolved_by_commit: ([ $all_comments[] | select(.resolved_by_commit) ] | length),
+        with_severity:      ([ $all_comments[] | select(.severity != null) ] | length)
+      }
+    }
+  ' "$_tmpdir/pr-$_pr_number.json" > "$_tmpdir/pr-$_pr_number-out.json" 2>"$_tmpdir/pr-$_pr_number-jq-err.txt"
+
+  if [ ! -s "$_tmpdir/pr-$_pr_number-out.json" ]; then
+    echo "Warning: jq transform for PR #$_pr_number produced no output, skipping: $(cat "$_tmpdir/pr-$_pr_number-jq-err.txt")" >&2
+    continue
+  fi
+
+  # Tally counters by inspecting the transformed per-PR record.
+  _c_total=$(jq -r '.counts.total // 0 | tostring' "$_tmpdir/pr-$_pr_number-out.json")
+  _c_bots=$(jq -r '.counts.bots // 0 | tostring' "$_tmpdir/pr-$_pr_number-out.json")
+  _c_res=$(jq -r '.counts.resolved_by_commit // 0 | tostring' "$_tmpdir/pr-$_pr_number-out.json")
+  _c_sev=$(jq -r '.counts.with_severity // 0 | tostring' "$_tmpdir/pr-$_pr_number-out.json")
+  _sum_comments=$((_sum_comments + _c_total))
+  _sum_bot_filtered=$((_sum_bot_filtered + _c_bots))
+  _sum_resolved=$((_sum_resolved + _c_res))
+  _sum_severity=$((_sum_severity + _c_sev))
+
+  # One JSON object per line; --slurpfile turns this back into a JSON array.
+  jq -c '.' "$_tmpdir/pr-$_pr_number-out.json" >> "$_tmpdir/prs.jsonl"
+done
+
+# --- assemble final document ----------------------------------------------
+
+jq -n \
+  --arg repo "$OWNER/$REPO" \
+  --argjson lookback "$LOOKBACK_DAYS" \
+  --arg cutoff "$CUTOFF_DATE" \
+  --argjson total "$_total_merged" \
+  --argjson skipped "$_skipped" \
+  --argjson sum_total "$_sum_comments" \
+  --argjson sum_bots "$_sum_bot_filtered" \
+  --argjson sum_resolved "$_sum_resolved" \
+  --argjson sum_severity "$_sum_severity" \
+  --argjson truncated "$([ "$_truncated_any" = true ] && echo true || echo false)" \
+  --slurpfile prs "$_tmpdir/prs.jsonl" \
+  '{
+    repo:                  $repo,
+    lookback_days:         $lookback,
+    cutoff_date:           $cutoff,
+    merged_prs_inspected:  $total,
+    skipped_own_prs:       $skipped,
+    prs:                   $prs,
+    summary: {
+      total_prs:                  ($prs | length),
+      total_comments:             $sum_total,
+      bot_comments:               $sum_bots,
+      comments_resolved_by_commit: $sum_resolved,
+      comments_with_severity:     $sum_severity,
+      truncated:                  $truncated,
+      list_limit_hit:             ($total >= 200)
+    }
+  }'

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -62,19 +62,22 @@ Initialise two counters that other steps mutate:
 
 ## Step 1: Precondition Check
 
-Verify the target repo has `docs/code-review-checklist.md`:
+Verify the target repo has `docs/code-review-checklist.md`. Capture stderr so a 404 (missing file — expected) can be distinguished from real failures (auth, rate limit, network):
 
 ```bash
-gh api "repos/$REPO/contents/docs/code-review-checklist.md" --silent >/dev/null 2>&1
+if ! gh_err=$(gh api "repos/$REPO/contents/docs/code-review-checklist.md" --silent 2>&1 >/dev/null); then
+  if printf '%s\n' "$gh_err" | grep -q "HTTP 404"; then
+    echo "$REPO has no docs/code-review-checklist.md — create one first, then re-run /dlc:update-review-checklist. See issue cc-skills#216 for the shape."
+    exit 0
+  fi
+  # Real failure — auth, rate limit, network. Surface the message and notify.
+  printf 'Precondition check failed for %s: %s\n' "$REPO" "$gh_err" >&2
+  # Caller should fire PushNotification with $gh_err and exit non-zero.
+  exit 1
+fi
 ```
 
-**If the file does not exist (404):** Print one line to stdout and exit 0. Do **not** fire `PushNotification` — this is not an error, just an unmet prerequisite:
-
-```text
-$REPO has no docs/code-review-checklist.md — create one first, then re-run /dlc:update-review-checklist. See issue cc-skills#216 for the shape.
-```
-
-**If the API call fails for any other reason** (auth, rate limit, network): emit one line, fire `PushNotification` with the error, exit non-zero.
+The `HTTP 404` substring match is the documented `gh api` error format — `gh api` prints `gh: ... (HTTP 404)` to stderr on missing resources.
 
 ## Step 1.5: Guard Against an Existing Open Update PR
 
@@ -82,9 +85,8 @@ The `--skip-prefix` filter in the helper script only excludes *merged* prior run
 
 ```bash
 OPEN_PRIOR=$(gh pr list --repo "$REPO" --state open \
-  --search "head:chore/update-review-checklist-" \
-  --json url \
-  --jq '.[0].url // empty')
+  --json headRefName,url \
+  --jq '[ .[] | select(.headRefName | startswith("chore/update-review-checklist-")) ][0].url // empty')
 ```
 
 **If `OPEN_PRIOR` is non-empty:**
@@ -102,10 +104,14 @@ This rule applies in both attended and unattended modes. Dry-run is the one exce
 Run the helper script that lists merged PRs in window, fetches review-thread + review-body + issue-comment data per PR, applies the resolved-by-commit heuristic, and detects severity labels:
 
 ```bash
-sh ../../scripts/fetch-merged-pr-comments.sh "$REPO" --lookback "$LOOKBACK"
+PR_DATA=$(sh ../../scripts/fetch-merged-pr-comments.sh "$REPO" --lookback "$LOOKBACK" 2>/tmp/fetch-err.json) || {
+  err_msg=$(jq -r '.error // .'  /tmp/fetch-err.json 2>/dev/null || cat /tmp/fetch-err.json)
+  echo "fetch-merged-pr-comments.sh failed: $err_msg" >&2
+  exit 1
+}
 ```
 
-Capture the JSON output into `PR_DATA`. Validate the response shape — abort with the error message if `.error` is present, or if `.prs` is missing.
+The helper uses `die_json` to write `{error, code}` JSON to **stderr** and exit non-zero, so validation must check the exit code and parse stderr (not look for `.error` in `$PR_DATA`). Also abort if `.prs` is missing from `$PR_DATA`.
 
 **If `.summary.truncated == true`:** Warn on stdout that the helper hit a per-PR pagination cap and some comments may be missing. Continue with the partial data.
 
@@ -219,7 +225,7 @@ Use a temporary work directory unconditionally — even when the target repo *is
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/update-review-checklist.XXXXXX")"
 trap 'rm -rf "$WORKDIR"' EXIT
 
-BRANCH="chore/update-review-checklist-$(date -u +%Y-%m-%d-%H%M)"
+BRANCH="chore/update-review-checklist-$(date -u +%Y-%m-%d-%H%M%S)"
 
 gh repo clone "$REPO" "$WORKDIR" -- --depth 50 >/dev/null
 cd "$WORKDIR"

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -127,10 +127,11 @@ if ! printf '%s' "$PR_DATA" | jq -e '.prs and .summary' >/dev/null; then
   exit 1
 fi
 
-# Replay per-PR warnings (GraphQL skips, jq-transform failures) on stdout when
+# Replay per-PR warnings (GraphQL skips, jq-transform failures) on stderr when
 # the helper succeeded — useful for operators in scheduled runs. The script
 # uses stderr for *both* fatal errors (already handled above) and these soft
-# warnings; we surface the warnings here rather than silently discarding them.
+# warnings; we re-emit them to stderr so they reach the same destination an
+# operator would inspect, rather than silently discarding them.
 if [ -s "$FETCH_ERR" ]; then
   echo "fetch-merged-pr-comments.sh warnings:" >&2
   cat "$FETCH_ERR" >&2
@@ -151,6 +152,7 @@ The helper uses `die_json` to write `{error, code}` JSON to **stderr** and exit 
 
 ```bash
 CURRENT_CHECKLIST="$(mktemp "${TMPDIR:-/tmp}/update-review-checklist-existing.XXXXXX")"
+trap 'rm -f "$CURRENT_CHECKLIST"' EXIT  # clean up on any exit path — important for scheduled recurring runs
 
 # Capture gh api output separately so a fetch failure (auth, rate limit, 404)
 # is not masked by a successful base64 exit status in a pipeline.
@@ -336,13 +338,13 @@ Pick `STATUS` and `LAST_PR_URL` based on what actually happened, so the state fi
 ```bash
 SLUG=$(printf '%s' "$REPO" | tr '/' '-')
 mkdir -p "$ORIG_CWD/.dev/dlc"
-PENDING_COUNT=$(printf '%s' "$PENDING_HUMAN" | jq 'length // 0')
+PENDING_HUMAN_COUNT=$(printf '%s' "$PENDING_HUMAN" | jq 'length // 0')
 
 if [ "$DRY_RUN" = "true" ]; then
   STATUS="dry_run"; LAST_PR_URL=""
 elif [ -n "$PR_URL" ]; then
   STATUS="pr_opened"; LAST_PR_URL="$PR_URL"
-elif [ "$PENDING_COUNT" -gt 0 ]; then
+elif [ "$PENDING_HUMAN_COUNT" -gt 0 ]; then
   STATUS="pending_human_only"; LAST_PR_URL=""
 else
   STATUS="no_entries"; LAST_PR_URL=""
@@ -355,7 +357,7 @@ cat > "$ORIG_CWD/.dev/dlc/update-review-checklist-$SLUG.state" <<EOF
   "lookback": "$LOOKBACK",
   "threshold": $THRESHOLD,
   "entries_added": $ENTRIES_ADDED,
-  "pending_human": $PENDING_COUNT,
+  "pending_human": $PENDING_HUMAN_COUNT,
   "status": "$STATUS"
 }
 EOF

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -49,15 +49,20 @@ Read `$ARGUMENTS` and extract:
 
 - `REPO` — optional positional `owner/name`. If absent, default to `gh repo view --json owner,name` for the current working directory.
 - `LOOKBACK` — `--lookback <Nd>` (default `30d`). Format is a positive integer followed by `d`.
-- `THRESHOLD` — `--threshold <N>` (default `2`). Minimum number of **distinct PRs** a cluster must span to be promoted.
+- `THRESHOLD` — `--threshold <N>` (default `2`). Minimum number of **distinct PRs** a cluster must span to be promoted. Must be a positive integer ≥1.
 - `DRY_RUN` — `--dry-run` flag. When present, set `DRY_RUN=true`.
 - `UNATTENDED` — `--unattended` flag. When present, suppress `AskUserQuestion` calls; ambiguous clusters and ambiguous dedup matches become Pending-Human items reported in the final summary instead of prompting the user.
 
-Reject unknown flags with a one-line error and exit non-zero.
+Reject unknown flags, non-`Nd` LOOKBACK values, and non-positive-integer THRESHOLD values with a one-line error and exit non-zero. THRESHOLD validation matters because it is emitted unquoted into the state-file JSON in Step 8 — a malformed value corrupts the file.
 
-Initialise two counters that other steps mutate:
+Initialise two counters that other steps mutate. `PENDING_HUMAN` is a **JSON array** because Step 8 pipes it to `jq` (`jq 'length // 0'`) and Steps 4/5 mutate it via `jq` appends — an unset or non-JSON value breaks the pipeline:
 
-- `PENDING_HUMAN` — list of `{theme, source_prs, reason}` records (clusters held back from the PR because they needed a human call). Used in Step 9 to emit the `Pending-Human:` line.
+```bash
+PENDING_HUMAN='[]'   # JSON array; append records via `jq '. + [$new]'`
+ENTRIES_ADDED=0
+```
+
+- `PENDING_HUMAN` — JSON array of `{theme, source_prs, reason}` records (clusters held back from the PR because they needed a human call). Used in Step 9 to emit the `Pending-Human:` line.
 - `ENTRIES_ADDED` — count of clusters actually written to the checklist file (distinct from "clusters that survived clustering" — Pending-Human clusters are *not* counted here).
 
 ## Step 1: Precondition Check
@@ -104,14 +109,17 @@ This rule applies in both attended and unattended modes. Dry-run is the one exce
 Run the helper script that lists merged PRs in window, fetches review-thread + review-body + issue-comment data per PR, applies the resolved-by-commit heuristic, and detects severity labels:
 
 ```bash
-PR_DATA=$(sh ../../scripts/fetch-merged-pr-comments.sh "$REPO" --lookback "$LOOKBACK" 2>/tmp/fetch-err.json) || {
-  err_msg=$(jq -r '.error // .'  /tmp/fetch-err.json 2>/dev/null || cat /tmp/fetch-err.json)
+FETCH_ERR="$(mktemp "${TMPDIR:-/tmp}/update-review-checklist-fetch-err.XXXXXX")"
+PR_DATA=$(sh ../../scripts/fetch-merged-pr-comments.sh "$REPO" --lookback "$LOOKBACK" 2>"$FETCH_ERR") || {
+  err_msg=$(jq -r '.error // .' "$FETCH_ERR" 2>/dev/null || cat "$FETCH_ERR")
+  rm -f "$FETCH_ERR"
   echo "fetch-merged-pr-comments.sh failed: $err_msg" >&2
   exit 1
 }
+rm -f "$FETCH_ERR"
 ```
 
-The helper uses `die_json` to write `{error, code}` JSON to **stderr** and exit non-zero, so validation must check the exit code and parse stderr (not look for `.error` in `$PR_DATA`). Also abort if `.prs` is missing from `$PR_DATA`.
+The helper uses `die_json` to write `{error, code}` JSON to **stderr** and exit non-zero, so validation must check the exit code and parse stderr (not look for `.error` in `$PR_DATA`). Also abort if `.prs` is missing from `$PR_DATA`. The `mktemp` path mirrors the `CURRENT_CHECKLIST` pattern below — concurrent scheduled runs against the same `$TMPDIR` cannot collide on a fixed `/tmp/fetch-err.json` path.
 
 **If `.summary.truncated == true`:** Warn on stdout that the helper hit a per-PR pagination cap and some comments may be missing. Continue with the partial data.
 

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -110,16 +110,19 @@ Run the helper script that lists merged PRs in window, fetches review-thread + r
 
 ```bash
 FETCH_ERR="$(mktemp "${TMPDIR:-/tmp}/update-review-checklist-fetch-err.XXXXXX")"
-PR_DATA=$(sh ../../scripts/fetch-merged-pr-comments.sh "$REPO" --lookback "$LOOKBACK" 2>"$FETCH_ERR") || {
+PR_DATA=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/fetch-merged-pr-comments.sh" "$REPO" --lookback "$LOOKBACK" 2>"$FETCH_ERR") || {
   err_msg=$(jq -r '.error // .' "$FETCH_ERR" 2>/dev/null || cat "$FETCH_ERR")
   rm -f "$FETCH_ERR"
   echo "fetch-merged-pr-comments.sh failed: $err_msg" >&2
   exit 1
 }
 rm -f "$FETCH_ERR"
+
+# Extract cutoff_date from the helper response — used in the Step 9 summary.
+CUTOFF_DATE=$(printf '%s' "$PR_DATA" | jq -r '.cutoff_date')
 ```
 
-The helper uses `die_json` to write `{error, code}` JSON to **stderr** and exit non-zero, so validation must check the exit code and parse stderr (not look for `.error` in `$PR_DATA`). Also abort if `.prs` is missing from `$PR_DATA`. The `mktemp` path mirrors the `CURRENT_CHECKLIST` pattern below — concurrent scheduled runs against the same `$TMPDIR` cannot collide on a fixed `/tmp/fetch-err.json` path.
+The helper uses `die_json` to write `{error, code}` JSON to **stderr** and exit non-zero, so validation must check the exit code and parse stderr (not look for `.error` in `$PR_DATA`). Also abort if `.prs` is missing from `$PR_DATA`. The `mktemp` path mirrors the `CURRENT_CHECKLIST` pattern below — concurrent scheduled runs against the same `$TMPDIR` cannot collide on a fixed `/tmp/fetch-err.json` path. The script path uses `${CLAUDE_PLUGIN_ROOT}` (set by the Claude Code plugin runtime — same convention as `plugins/cdt/hooks/hooks.json`) so the helper resolves correctly when the skill runs against another repo's working directory.
 
 **If `.summary.truncated == true`:** Warn on stdout that the helper hit a per-PR pagination cap and some comments may be missing. Continue with the partial data.
 

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -163,9 +163,14 @@ ENCODED=$(gh api "repos/$REPO/contents/docs/code-review-checklist.md" --jq '.con
 
 # Portable base64 decode: GNU/macOS Big Sur+ accept --decode; older BSD/macOS
 # use -D. Fall back across both so the skill works on every reviewer-supported
-# runtime without forcing a coreutils dependency.
+# runtime without forcing a coreutils dependency. Fail fast if BOTH fail —
+# otherwise Step 5 would dedup against an empty/corrupt checklist and propose
+# duplicates of entries that already exist.
 if ! printf '%s' "$ENCODED" | base64 --decode > "$CURRENT_CHECKLIST" 2>/dev/null; then
-  printf '%s' "$ENCODED" | base64 -D > "$CURRENT_CHECKLIST"
+  if ! printf '%s' "$ENCODED" | base64 -D > "$CURRENT_CHECKLIST" 2>/dev/null; then
+    echo "Failed to base64-decode docs/code-review-checklist.md from $REPO (neither --decode nor -D succeeded)" >&2
+    exit 1
+  fi
 fi
 ```
 
@@ -268,7 +273,11 @@ Use a temporary work directory unconditionally — even when the target repo *is
 
 ```bash
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/update-review-checklist.XXXXXX")"
-trap 'rm -rf "$WORKDIR"' EXIT
+# Compose with the Step 2 cleanup so both temp resources are removed. Bash
+# `trap '...' EXIT` REPLACES the previous EXIT trap, so a bare
+# `trap 'rm -rf "$WORKDIR"' EXIT` here would silently strand the checklist
+# tempfile created in Step 2. Compose both cleanups into one handler.
+trap 'rm -rf "$WORKDIR"; rm -f "$CURRENT_CHECKLIST"' EXIT
 
 BRANCH="chore/update-review-checklist-$(date -u +%Y-%m-%d-%H%M%S)"
 

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -111,10 +111,11 @@ Capture the JSON output into `PR_DATA`. Validate the response shape — abort wi
 
 **If `.summary.list_limit_hit == true`:** Warn that the merged-PR list cap (200) was reached and recent PRs may be missing from analysis. Continue with what was returned.
 
-**Existing checklist read.** Also fetch the current checklist content for the dedup step in Step 5:
+**Existing checklist read.** Also fetch the current checklist content for the dedup step in Step 5. Use `mktemp` so concurrent scheduled runs against different repos cannot overwrite each other's dedup input:
 
 ```bash
-gh api "repos/$REPO/contents/docs/code-review-checklist.md" --jq '.content' | base64 -d > /tmp/current-checklist.md
+CURRENT_CHECKLIST="$(mktemp "${TMPDIR:-/tmp}/update-review-checklist-existing.XXXXXX")"
+gh api "repos/$REPO/contents/docs/code-review-checklist.md" --jq '.content' | base64 -d > "$CURRENT_CHECKLIST"
 ```
 
 ## Step 3: Filter Comments
@@ -220,7 +221,7 @@ trap 'rm -rf "$WORKDIR"' EXIT
 
 BRANCH="chore/update-review-checklist-$(date -u +%Y-%m-%d-%H%M)"
 
-gh repo clone "$REPO" "$WORKDIR" -- --depth 50 --branch main >/dev/null
+gh repo clone "$REPO" "$WORKDIR" -- --depth 50 >/dev/null
 cd "$WORKDIR"
 git checkout -b "$BRANCH"
 ```
@@ -229,7 +230,7 @@ The `trap ... EXIT` ensures the work dir is cleaned up whether the step succeeds
 
 ### Re-read the checklist from the clone
 
-The `/tmp/current-checklist.md` cache from Step 2 may be stale relative to the freshly cloned HEAD. Re-read in-place so Step 5's dedup is sound against the *actual* file you're about to edit:
+The `$CURRENT_CHECKLIST` cache from Step 2 may be stale relative to the freshly cloned HEAD. Re-read in-place so Step 5's dedup is sound against the *actual* file you're about to edit:
 
 ```bash
 CHECKLIST_PATH="$WORKDIR/docs/code-review-checklist.md"

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -108,21 +108,40 @@ This rule applies in both attended and unattended modes. Dry-run is the one exce
 
 Run the helper script that lists merged PRs in window, fetches review-thread + review-body + issue-comment data per PR, applies the resolved-by-commit heuristic, and detects severity labels:
 
+The skill's bash blocks run with cwd at the skill's base directory (`plugins/dlc/skills/update-review-checklist/`) — same convention as `dlc:pr-check`, documented in `docs/learnings.md:505`. The LLM consumer should `cd` into the skill directory before executing this block. The `../../scripts/` prefix then resolves to `plugins/dlc/scripts/`.
+
 ```bash
 FETCH_ERR="$(mktemp "${TMPDIR:-/tmp}/update-review-checklist-fetch-err.XXXXXX")"
-PR_DATA=$(sh "${CLAUDE_PLUGIN_ROOT}/scripts/fetch-merged-pr-comments.sh" "$REPO" --lookback "$LOOKBACK" 2>"$FETCH_ERR") || {
+PR_DATA=$(sh ../../scripts/fetch-merged-pr-comments.sh "$REPO" --lookback "$LOOKBACK" 2>"$FETCH_ERR") || {
   err_msg=$(jq -r '.error // .' "$FETCH_ERR" 2>/dev/null || cat "$FETCH_ERR")
   rm -f "$FETCH_ERR"
   echo "fetch-merged-pr-comments.sh failed: $err_msg" >&2
   exit 1
 }
+
+# Validate response shape — the helper writes errors to stderr (handled above)
+# but the success path must still contain the expected JSON keys.
+if ! printf '%s' "$PR_DATA" | jq -e '.prs and .summary' >/dev/null; then
+  echo "fetch-merged-pr-comments.sh: response missing .prs or .summary" >&2
+  rm -f "$FETCH_ERR"
+  exit 1
+fi
+
+# Replay per-PR warnings (GraphQL skips, jq-transform failures) on stdout when
+# the helper succeeded — useful for operators in scheduled runs. The script
+# uses stderr for *both* fatal errors (already handled above) and these soft
+# warnings; we surface the warnings here rather than silently discarding them.
+if [ -s "$FETCH_ERR" ]; then
+  echo "fetch-merged-pr-comments.sh warnings:" >&2
+  cat "$FETCH_ERR" >&2
+fi
 rm -f "$FETCH_ERR"
 
 # Extract cutoff_date from the helper response — used in the Step 9 summary.
 CUTOFF_DATE=$(printf '%s' "$PR_DATA" | jq -r '.cutoff_date')
 ```
 
-The helper uses `die_json` to write `{error, code}` JSON to **stderr** and exit non-zero, so validation must check the exit code and parse stderr (not look for `.error` in `$PR_DATA`). Also abort if `.prs` is missing from `$PR_DATA`. The `mktemp` path mirrors the `CURRENT_CHECKLIST` pattern below — concurrent scheduled runs against the same `$TMPDIR` cannot collide on a fixed `/tmp/fetch-err.json` path. The script path uses `${CLAUDE_PLUGIN_ROOT}` (set by the Claude Code plugin runtime — same convention as `plugins/cdt/hooks/hooks.json`) so the helper resolves correctly when the skill runs against another repo's working directory.
+The helper uses `die_json` to write `{error, code}` JSON to **stderr** and exit non-zero, so validation must check the exit code and parse stderr (not look for `.error` in `$PR_DATA`). The `jq -e '.prs and .summary'` check enforces the documented schema on the success path. The `mktemp` path mirrors the `CURRENT_CHECKLIST` pattern below — concurrent scheduled runs against the same `$TMPDIR` cannot collide on a fixed `/tmp/fetch-err.json` path.
 
 **If `.summary.truncated == true`:** Warn on stdout that the helper hit a per-PR pagination cap and some comments may be missing. Continue with the partial data.
 
@@ -307,18 +326,37 @@ cd "$ORIG_CWD"
 
 Write a small JSON state file in the **calling repo** (the place this skill was invoked from), not the cloned target. This file is informational; it does not gate future runs.
 
+Pick `STATUS` and `LAST_PR_URL` based on what actually happened, so the state file truthfully reflects the run instead of always claiming `pr_opened`:
+
+- `pr_opened` — `DRY_RUN=false`, a PR was created, `$PR_URL` is set
+- `no_entries` — `DRY_RUN=false` but no clusters survived dedup (Step 7 was a no-op); `$PR_URL` empty
+- `dry_run` — `DRY_RUN=true` (Step 6 exit path); `$PR_URL` empty
+- `pending_human_only` — only Pending-Human clusters; no PR opened; `$PR_URL` empty
+
 ```bash
 SLUG=$(printf '%s' "$REPO" | tr '/' '-')
 mkdir -p "$ORIG_CWD/.dev/dlc"
+PENDING_COUNT=$(printf '%s' "$PENDING_HUMAN" | jq 'length // 0')
+
+if [ "$DRY_RUN" = "true" ]; then
+  STATUS="dry_run"; LAST_PR_URL=""
+elif [ -n "$PR_URL" ]; then
+  STATUS="pr_opened"; LAST_PR_URL="$PR_URL"
+elif [ "$PENDING_COUNT" -gt 0 ]; then
+  STATUS="pending_human_only"; LAST_PR_URL=""
+else
+  STATUS="no_entries"; LAST_PR_URL=""
+fi
+
 cat > "$ORIG_CWD/.dev/dlc/update-review-checklist-$SLUG.state" <<EOF
 {
   "last_run_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "last_pr_url": "$PR_URL",
+  "last_pr_url": "$LAST_PR_URL",
   "lookback": "$LOOKBACK",
   "threshold": $THRESHOLD,
   "entries_added": $ENTRIES_ADDED,
-  "pending_human": $(printf '%s' "$PENDING_HUMAN" | jq 'length // 0'),
-  "status": "pr_opened"
+  "pending_human": $PENDING_COUNT,
+  "status": "$STATUS"
 }
 EOF
 ```

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -67,9 +67,17 @@ ENTRIES_ADDED=0
 
 ## Step 1: Precondition Check
 
-Verify the target repo has `docs/code-review-checklist.md`. Capture stderr so a 404 (missing file — expected) can be distinguished from real failures (auth, rate limit, network):
+Verify the target repo has `docs/code-review-checklist.md`. Capture stderr so a 404 (missing file — expected) can be distinguished from real failures (auth, rate limit, network).
+
+First confirm the repo itself is accessible, because `gh api` returns the same `HTTP 404` for "repo not found / no access" as it does for "file not found". Without this disambiguation, an auth or typo failure would be silently treated as "missing checklist" and exit 0 in a scheduled run — masking real problems:
 
 ```bash
+if ! repo_err=$(gh api "repos/$REPO" --silent 2>&1 >/dev/null); then
+  printf 'Cannot access repo %s: %s\n' "$REPO" "$repo_err" >&2
+  # Caller should fire PushNotification with $repo_err and exit non-zero.
+  exit 1
+fi
+
 if ! gh_err=$(gh api "repos/$REPO/contents/docs/code-review-checklist.md" --silent 2>&1 >/dev/null); then
   if printf '%s\n' "$gh_err" | grep -q "HTTP 404"; then
     echo "$REPO has no docs/code-review-checklist.md — create one first, then re-run /dlc:update-review-checklist. See issue cc-skills#216 for the shape."
@@ -82,7 +90,7 @@ if ! gh_err=$(gh api "repos/$REPO/contents/docs/code-review-checklist.md" --sile
 fi
 ```
 
-The `HTTP 404` substring match is the documented `gh api` error format — `gh api` prints `gh: ... (HTTP 404)` to stderr on missing resources.
+The `HTTP 404` substring match is the documented `gh api` error format — `gh api` prints `gh: ... (HTTP 404)` to stderr on missing resources. The repo-level check above ensures that a 404 reaching the file check is unambiguously "file missing" rather than "repo inaccessible".
 
 ## Step 1.5: Guard Against an Existing Open Update PR
 

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -121,9 +121,10 @@ gh api "repos/$REPO/contents/docs/code-review-checklist.md" --jq '.content' | ba
 
 Apply these filters in order; keep counters so the final summary can report what was dropped and why.
 
-1. **Drop bots** (`.is_bot == true`). Reviewer signal lives in human comments; bot comments are summaries, not new findings. *Council/codex findings posted via the GitHub CLI as a non-bot account are kept.*
-2. **Drop unresolved-by-commit** (`.resolved_by_commit == false`). A reviewer comment that did not provoke a code change from the PR author is either (a) a wishlist item ignored or deferred, or (b) something the reviewer themselves resolved as not-needed. Either way, it is not a pattern worth promoting to the checklist.
-3. **Drop hard-skip patterns** — read [`references/clustering-rubric.md`](references/clustering-rubric.md) now and apply its explicit blocklist (typos, formatting nits, "consider" wishlists with no specific action).
+1. **Drop unresolved-by-commit** (`.resolved_by_commit == false`). A reviewer comment that did not provoke a code change from the PR author is either (a) a wishlist item ignored or deferred, or (b) something the reviewer themselves resolved as not-needed. Either way, it is not a pattern worth promoting to the checklist.
+2. **Drop hard-skip patterns** — read [`references/clustering-rubric.md`](references/clustering-rubric.md) now and apply its explicit blocklist (typos, formatting nits, "consider" wishlists with no specific action, automated review-summary comments with zero findings).
+
+The `.is_bot` field on each comment is retained as metadata for the PR body's "Derived from" table, but is **not** a filter input. Substantive reviewers in many repos are bot accounts (Copilot, CodeRabbit, Codex, Gemini, Qodo); filtering on author type would discard the primary signal. Noise from automated reviewers is content-defined and handled by the hard-skip patterns instead.
 
 Record the per-step drop counts. They surface in the Step 9 summary.
 

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -89,7 +89,7 @@ The `HTTP 404` substring match is the documented `gh api` error format — `gh a
 The `--skip-prefix` filter in the helper script only excludes *merged* prior runs. An open prior PR is still in flight; opening a second one stacks duplicates and pollutes the review queue.
 
 ```bash
-OPEN_PRIOR=$(gh pr list --repo "$REPO" --state open \
+OPEN_PRIOR=$(gh pr list --repo "$REPO" --state open --limit 200 \
   --json headRefName,url \
   --jq '[ .[] | select(.headRefName | startswith("chore/update-review-checklist-")) ][0].url // empty')
 ```

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -1,0 +1,341 @@
+---
+name: update-review-checklist
+description: >-
+  Audit review checklist for a repo: cluster recurring review-comment themes
+  across merged PRs in a window, diff against docs/code-review-checklist.md,
+  and open a PR proposing new entries with PR traceability. Designed for
+  /schedule monthly cadence. Pass --dry-run to print clusters without
+  opening a PR. Trigger phrases: audit review checklist, update review
+  checklist, cluster PR findings.
+allowed-tools: [Bash, Read, Write, Edit, AskUserQuestion, PushNotification]
+---
+
+# DLC: Update Review Checklist
+
+Cluster recurring reviewer themes across recent merged PRs and open a PR that proposes new entries for the target repo's `docs/code-review-checklist.md`. The skill never auto-merges — every proposal is human-reviewed.
+
+**Standalone:** `/dlc:update-review-checklist [<owner>/<repo>] [--lookback 30d] [--threshold 2] [--dry-run] [--unattended]`
+
+**Scheduled (recommended monthly cadence):**
+```text
+/schedule '0 0 1 * *' /dlc:update-review-checklist <owner>/<repo>
+```
+
+## Why This Matters
+
+A `docs/code-review-checklist.md` doc decays without a forcing function. Manual curation lapses after the first few months and the checklist drifts away from what reviewers are actually catching in PRs. Reviewer attention is the most expensive resource on the team — when the same class of finding shows up in two or more PRs, the checklist deserves an entry so the next author catches it before review.
+
+The recurring nature is the entire signal. A one-off finding is noise; a finding that recurs across multiple PRs is a pattern. Monthly cadence gives enough signal to cluster without flooding the checklist with low-recurrence entries. A run that finds zero promotable clusters is a healthy result — it means recent reviews have surfaced novel issues, not the same ones again.
+
+## Notification Rules
+
+Fire `PushNotification` only for **terminal states that benefit the user knowing about**:
+
+- `pr_opened` — a checklist update PR was opened (include the PR URL)
+- `pending_human` — under `--unattended`, clusters that need a human call were skipped
+- Errors that block the run (missing prerequisites, GitHub API failures)
+
+Routine outcomes (no clusters found, missing checklist file, dry-run with nothing to propose) are silent — printed to stdout but not pushed. This keeps the monthly scheduled cadence quiet by default and noisy only when there is something to act on.
+
+## Step 0: Parse Arguments
+
+Capture the original calling directory once, before any later step changes cwd into a clone:
+
+```bash
+ORIG_CWD="$(pwd)"
+```
+
+Read `$ARGUMENTS` and extract:
+
+- `REPO` — optional positional `owner/name`. If absent, default to `gh repo view --json owner,name` for the current working directory.
+- `LOOKBACK` — `--lookback <Nd>` (default `30d`). Format is a positive integer followed by `d`.
+- `THRESHOLD` — `--threshold <N>` (default `2`). Minimum number of **distinct PRs** a cluster must span to be promoted.
+- `DRY_RUN` — `--dry-run` flag. When present, set `DRY_RUN=true`.
+- `UNATTENDED` — `--unattended` flag. When present, suppress `AskUserQuestion` calls; ambiguous clusters and ambiguous dedup matches become Pending-Human items reported in the final summary instead of prompting the user.
+
+Reject unknown flags with a one-line error and exit non-zero.
+
+Initialise two counters that other steps mutate:
+
+- `PENDING_HUMAN` — list of `{theme, source_prs, reason}` records (clusters held back from the PR because they needed a human call). Used in Step 9 to emit the `Pending-Human:` line.
+- `ENTRIES_ADDED` — count of clusters actually written to the checklist file (distinct from "clusters that survived clustering" — Pending-Human clusters are *not* counted here).
+
+## Step 1: Precondition Check
+
+Verify the target repo has `docs/code-review-checklist.md`:
+
+```bash
+gh api "repos/$REPO/contents/docs/code-review-checklist.md" --silent >/dev/null 2>&1
+```
+
+**If the file does not exist (404):** Print one line to stdout and exit 0. Do **not** fire `PushNotification` — this is not an error, just an unmet prerequisite:
+
+```text
+$REPO has no docs/code-review-checklist.md — create one first, then re-run /dlc:update-review-checklist. See issue cc-skills#216 for the shape.
+```
+
+**If the API call fails for any other reason** (auth, rate limit, network): emit one line, fire `PushNotification` with the error, exit non-zero.
+
+## Step 1.5: Guard Against an Existing Open Update PR
+
+The `--skip-prefix` filter in the helper script only excludes *merged* prior runs. An open prior PR is still in flight; opening a second one stacks duplicates and pollutes the review queue.
+
+```bash
+OPEN_PRIOR=$(gh pr list --repo "$REPO" --state open \
+  --search "head:chore/update-review-checklist-" \
+  --json number,url,headRefName \
+  --jq '.[]')
+```
+
+**If `OPEN_PRIOR` is non-empty:**
+
+Print one line to stdout naming the existing PR's URL and exit 0. Do **not** fire `PushNotification` — a single waiting PR is a normal between-cycles state, not an error:
+
+```text
+$REPO has an open checklist-update PR (<URL>). Merge or close it before re-running.
+```
+
+This rule applies in both attended and unattended modes. Dry-run is the one exception: continue through to Step 6 so the human can preview what *would* be proposed once the prior PR is resolved.
+
+## Step 2: Fetch Comments
+
+Run the helper script that lists merged PRs in window, fetches review-thread + review-body + issue-comment data per PR, applies the resolved-by-commit heuristic, and detects severity labels:
+
+```bash
+sh ../../scripts/fetch-merged-pr-comments.sh "$REPO" --lookback "$LOOKBACK"
+```
+
+Capture the JSON output into `PR_DATA`. Validate the response shape — abort with the error message if `.error` is present, or if `.prs` is missing.
+
+**If `.summary.truncated == true`:** Warn on stdout that the helper hit a per-PR pagination cap and some comments may be missing. Continue with the partial data.
+
+**If `.summary.list_limit_hit == true`:** Warn that the merged-PR list cap (200) was reached and recent PRs may be missing from analysis. Continue with what was returned.
+
+**Existing checklist read.** Also fetch the current checklist content for the dedup step in Step 5:
+
+```bash
+gh api "repos/$REPO/contents/docs/code-review-checklist.md" --jq '.content' | base64 -d > /tmp/current-checklist.md
+```
+
+## Step 3: Filter Comments
+
+Apply these filters in order; keep counters so the final summary can report what was dropped and why.
+
+1. **Drop bots** (`.is_bot == true`). Reviewer signal lives in human comments; bot comments are summaries, not new findings. *Council/codex findings posted via the GitHub CLI as a non-bot account are kept.*
+2. **Drop unresolved-by-commit** (`.resolved_by_commit == false`). A reviewer comment that did not provoke a code change from the PR author is either (a) a wishlist item ignored or deferred, or (b) something the reviewer themselves resolved as not-needed. Either way, it is not a pattern worth promoting to the checklist.
+3. **Drop hard-skip patterns** — read [`references/clustering-rubric.md`](references/clustering-rubric.md) now and apply its explicit blocklist (typos, formatting nits, "consider" wishlists with no specific action).
+
+Record the per-step drop counts. They surface in the Step 9 summary.
+
+## Step 4: Cluster Semantically
+
+Read [`references/clustering-rubric.md`](references/clustering-rubric.md) now and apply its semantic rules to group the surviving comments into clusters.
+
+A cluster's **PR-count** is the number of **distinct PR numbers** its member comments come from — not the total comment count. Two comments from the same PR count once.
+
+A cluster's **weight** is the sum of member severity weights from the rubric (`high=3`, `medium=2`, `low|null=1`).
+
+Drop any cluster with `pr_count < $THRESHOLD`. Sort the survivors by weight descending, then by PR-count descending.
+
+### Ambiguous-cluster gate
+
+After applying the rubric, mark a cluster as **ambiguous** when any of the following hold:
+
+- Members straddle the "same ask, different domain" line in the rubric (e.g. "add a test" for both an algorithm and a UI component) — could legitimately split into two clusters
+- The cluster's proposed title can be read as either too coarse ("Improve error handling") or genuinely useful, and you cannot decide from the member comments alone
+- Two existing clusters could merge into one broader cluster, or one cluster could split into two narrower ones, and the rubric's granularity guide doesn't break the tie
+
+For each ambiguous cluster:
+
+- **If `UNATTENDED == true`:** append `{theme, source_prs, reason: "ambiguous_clustering"}` to `PENDING_HUMAN` and **drop the cluster from the active set**. Pending-Human items are surfaced in Step 9, not in the PR.
+- **If `UNATTENDED == false`:** invoke `AskUserQuestion` once per ambiguous cluster with options shaped like:
+
+  ```
+  Cluster "<theme>" spans PRs #N, #M, #P. Members suggest <split/merge/keep>. Which?
+    (a) Keep as-is and propose
+    (b) Split into <theme-a> and <theme-b>
+    (c) Drop (too ambiguous to be useful)
+  ```
+
+  Apply the user's answer to the active set before continuing.
+
+Non-ambiguous clusters pass through unchanged. The active set after this gate is what Step 5 sees.
+
+## Step 5: Dedup Against Existing Checklist
+
+Read [`references/checklist-schema.md`](references/checklist-schema.md) now. For each surviving cluster, apply its semantic-dedup rubric against `/tmp/current-checklist.md`. The rubric's three diagnostic questions classify each cluster as **duplicate** (drop), **distinct** (keep), or **ambiguous** (needs a call).
+
+### Ambiguous-dedup gate
+
+A cluster is ambiguous against an existing entry when Q1/Q2/Q3 produce a mix of "maybe" answers — typically because the existing entry is generic and the cluster is specific (Q2 subsumption is unclear), or because the surface partially overlaps (Q3 partial-domain match).
+
+For each ambiguous dedup match:
+
+- **If `UNATTENDED == true`:** append `{theme, source_prs, reason: "ambiguous_dedup_vs_existing:<existing-entry-title>"}` to `PENDING_HUMAN` and drop the cluster from the active set.
+- **If `UNATTENDED == false`:** invoke `AskUserQuestion`:
+
+  ```
+  Cluster "<theme>" (PRs #N, #M) may overlap with existing entry "<E>". Propose anyway?
+    (a) Yes — distinct enough, add to PR
+    (b) No — covered by "<E>"
+    (c) Replace "<E>" with the new wording  [INFORMATIONAL — out of scope for v1; treat as (b) but record]
+  ```
+
+  Option (c) is out of scope per issue cc-skills#216 (no rewording of existing entries in v1) — record the suggestion in the PR body for the human reviewer's consideration, but treat behaviour as (b) and drop the cluster.
+
+> **Tie-breaker for genuine doubt that isn't ambiguous (attended mode without an AskUserQuestion prompt):** prefer keeping the candidate. Duplicate proposals get caught in human review; missed proposals do not. The ambiguous-dedup gate above only fires for the *specifically* ambiguous cases — most clusters will pass cleanly as either duplicate or distinct.
+
+## Step 6: Dry-Run Exit Point
+
+If `DRY_RUN=true`:
+
+Print each surviving cluster to stdout in this format:
+
+```text
+Cluster: <theme>
+  PRs:      #N, #M, #P  (n distinct, weight=W)
+  Members:  <reviewer1> on #N: "<comment excerpt 80c>"
+            <reviewer2> on #M: "<comment excerpt 80c>"
+  Proposed entry:
+    > <entry text per checklist-schema.md format>
+    > Source PRs: #N, #M, #P
+```
+
+Then print a summary block: total clusters proposed, filter drop counts from Step 3, dedup drop count from Step 5.
+
+Do **not** create a branch, edit any file, or open a PR. Exit 0.
+
+## Step 7: Author the PR
+
+If `DRY_RUN=false` and at least one cluster survives the dedup gate (i.e. the active set is non-empty after Step 5):
+
+### Always operate in a fresh clone
+
+Use a temporary work directory unconditionally — even when the target repo *is* the current working directory. This avoids two-path branching, prevents accidental edits in the user's working tree, and keeps the calling repo's git state clean for state-file writes in Step 8:
+
+```bash
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/update-review-checklist.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+BRANCH="chore/update-review-checklist-$(date -u +%Y-%m-%d-%H%M)"
+
+gh repo clone "$REPO" "$WORKDIR" -- --depth 50 --branch main >/dev/null
+cd "$WORKDIR"
+git checkout -b "$BRANCH"
+```
+
+The `trap ... EXIT` ensures the work dir is cleaned up whether the step succeeds, fails, or is interrupted.
+
+### Re-read the checklist from the clone
+
+The `/tmp/current-checklist.md` cache from Step 2 may be stale relative to the freshly cloned HEAD. Re-read in-place so Step 5's dedup is sound against the *actual* file you're about to edit:
+
+```bash
+CHECKLIST_PATH="$WORKDIR/docs/code-review-checklist.md"
+```
+
+If a meaningful diff exists between `/tmp/current-checklist.md` and `$CHECKLIST_PATH` (e.g. someone merged checklist changes between Step 2 and now), re-run the Step 5 dedup gate against the fresh content before continuing. For monthly-cadence runs this is almost never the case.
+
+### Edit the checklist
+
+Apply the active-set entries per [`references/checklist-schema.md`](references/checklist-schema.md) — match each cluster to its target section (or append to a "Recurring patterns" section if no existing match), and include the `> Source PRs: #N, #M` trailer on every entry. Use `Edit` operations rather than rewriting the file. Each successful edit increments `ENTRIES_ADDED`.
+
+### Commit, push, open PR
+
+GPG-signing must be bypassed — scheduled / unattended runs have no interactive pinentry available:
+
+```bash
+git add docs/code-review-checklist.md
+git -c commit.gpgsign=false commit -m "chore(dlc): update review checklist (lookback $LOOKBACK)"
+git push -u origin "$BRANCH"
+```
+
+Build the PR body per the template in [`references/checklist-schema.md`](references/checklist-schema.md). Include:
+
+- A one-line summary of `ENTRIES_ADDED`
+- A **"Derived from"** table listing each new entry and the PRs it was clustered from (acceptance criterion #4)
+- The lookback window and threshold used
+- If `PENDING_HUMAN` is non-empty, a separate **"Pending human review"** section listing the held-back themes with their `source_prs` and `reason` — informational, so reviewers know these clusters were observed but not promoted
+- A "How this was generated" footer pointing at this skill
+
+```bash
+gh pr create \
+  --repo "$REPO" \
+  --title "chore(dlc): update review checklist (lookback $LOOKBACK)" \
+  --body-file "$WORKDIR/.pr-body.md"
+```
+
+Capture the PR URL into `PR_URL`. Return to the original cwd before Step 8 so state-file writes target the calling repo, not the clone:
+
+```bash
+cd "$ORIG_CWD"
+```
+
+## Step 8: Persist State
+
+Write a small JSON state file in the **calling repo** (the place this skill was invoked from), not the cloned target. This file is informational; it does not gate future runs.
+
+```bash
+SLUG=$(printf '%s' "$REPO" | tr '/' '-')
+mkdir -p "$ORIG_CWD/.dev/dlc"
+cat > "$ORIG_CWD/.dev/dlc/update-review-checklist-$SLUG.state" <<EOF
+{
+  "last_run_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "last_pr_url": "$PR_URL",
+  "lookback": "$LOOKBACK",
+  "threshold": $THRESHOLD,
+  "entries_added": $ENTRIES_ADDED,
+  "pending_human": $(printf '%s' "$PENDING_HUMAN" | jq 'length // 0'),
+  "status": "pr_opened"
+}
+EOF
+```
+
+The state file lives alongside babysit's (`.dev/dlc/*.state`). Writing it to `$ORIG_CWD` matters because Step 7's clone is in a temp dir that gets `rm -rf`'d on exit — anything written there is lost.
+
+> **Why no self-cancel.** Unlike `dlc:babysit`, this skill is recurring by design — every month may yield new clusters. Do not call `CronDelete` to remove the schedule entry. Under `/loop` usage (ad-hoc, not the recommended cadence), the user manages stop via `/loop stop` themselves.
+
+## Step 9: Terminal Notification + Summary
+
+Emit a single summary block to stdout. The two key counters are deliberately separated so the user can see at a glance "how many entries actually landed in the PR" vs "how many clusters were observed but held back":
+
+```text
+update-review-checklist complete.
+  Repo:                 $REPO
+  Lookback:             $LOOKBACK (cutoff $CUTOFF_DATE)
+  Merged PRs inspected: $N  (skipped own PRs: $K)
+  Comments fetched:     $M
+  Filter drops:
+    - bots:                       $A
+    - unresolved-by-commit:       $B
+    - hard-skip patterns:         $C
+  Clusters above threshold:       $D
+  Dedup drops (already covered):  $E
+  Entries added to PR:            $ENTRIES_ADDED
+  Pending-Human (held back):      $PENDING_HUMAN_COUNT  [only printed when > 0]
+  PR opened:                      $PR_URL                [only printed when a PR was opened]
+```
+
+`ENTRIES_ADDED` counts clusters that landed in the PR. `PENDING_HUMAN_COUNT` counts ambiguous clusters held back via the Step 4 or Step 5 gates under `--unattended`. The two sets are disjoint by construction — Pending-Human items are dropped from the active set before Step 7 edits the file.
+
+### Notifications
+
+- **If a PR was opened** (`ENTRIES_ADDED > 0` and not dry-run): fire `PushNotification` with message `Review-checklist PR opened for $REPO: $ENTRIES_ADDED new entries (lookback $LOOKBACK). $PR_URL`
+- **If `--unattended` and `PENDING_HUMAN_COUNT > 0`**: fire `PushNotification` with message `Review checklist: $PENDING_HUMAN_COUNT clusters need a human call for $REPO. Re-run attended to triage.`
+- **If `ENTRIES_ADDED == 0` and not dry-run**: silent. No PR, no push. The summary above is enough — zero clusters worth promoting is a healthy result for a well-reviewed repo.
+- **Dry-run**: silent regardless of counts. The user invoked dry-run because they want stdout, not a push.
+
+## Step 10: Verify Against Acceptance Criteria
+
+Cross-reference the run against the VERIFY criteria in issue cc-skills#216:
+
+| AC | Verified by |
+|---|---|
+| #1 trigger phrases documented | This SKILL.md's `description` field contains all three triggers |
+| #2 runs standalone + under `/schedule` | "Standalone" + "Scheduled" usage shown at top of SKILL.md |
+| #3 missing-checklist exits cleanly | Step 1 prints guidance + exits 0 |
+| #4 PR cites source PRs per entry | Step 7 builds "Derived from" table; each entry has `> Source PRs:` trailer |
+| #5 threshold configurable | `--threshold` flag in Step 0; Step 4 enforces |
+| #6 semantic dedup | Step 5 invokes `references/checklist-schema.md` rubric |
+| #7 dry-run mode | Step 6 exits before any mutation |
+| #8 skips own prior PRs | helper script's `--skip-prefix chore/update-review-checklist-` |

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -29,7 +29,7 @@ The recurring nature is the entire signal. A one-off finding is noise; a finding
 
 ## Notification Rules
 
-Fire `PushNotification` only for **terminal states that benefit the user knowing about**:
+`PushNotification` fires only for **terminal states that benefit the user knowing about**:
 
 - `pr_opened` — a checklist update PR was opened (include the PR URL)
 - `pending_human` — under `--unattended`, clusters that need a human call were skipped

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -132,7 +132,20 @@ The helper uses `die_json` to write `{error, code}` JSON to **stderr** and exit 
 
 ```bash
 CURRENT_CHECKLIST="$(mktemp "${TMPDIR:-/tmp}/update-review-checklist-existing.XXXXXX")"
-gh api "repos/$REPO/contents/docs/code-review-checklist.md" --jq '.content' | base64 --decode > "$CURRENT_CHECKLIST"
+
+# Capture gh api output separately so a fetch failure (auth, rate limit, 404)
+# is not masked by a successful base64 exit status in a pipeline.
+ENCODED=$(gh api "repos/$REPO/contents/docs/code-review-checklist.md" --jq '.content') || {
+  echo "Failed to fetch docs/code-review-checklist.md from $REPO" >&2
+  exit 1
+}
+
+# Portable base64 decode: GNU/macOS Big Sur+ accept --decode; older BSD/macOS
+# use -D. Fall back across both so the skill works on every reviewer-supported
+# runtime without forcing a coreutils dependency.
+if ! printf '%s' "$ENCODED" | base64 --decode > "$CURRENT_CHECKLIST" 2>/dev/null; then
+  printf '%s' "$ENCODED" | base64 -D > "$CURRENT_CHECKLIST"
+fi
 ```
 
 ## Step 3: Filter Comments

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -83,8 +83,8 @@ The `--skip-prefix` filter in the helper script only excludes *merged* prior run
 ```bash
 OPEN_PRIOR=$(gh pr list --repo "$REPO" --state open \
   --search "head:chore/update-review-checklist-" \
-  --json number,url,headRefName \
-  --jq '.[]')
+  --json url \
+  --jq '.[0].url // empty')
 ```
 
 **If `OPEN_PRIOR` is non-empty:**
@@ -115,7 +115,7 @@ Capture the JSON output into `PR_DATA`. Validate the response shape — abort wi
 
 ```bash
 CURRENT_CHECKLIST="$(mktemp "${TMPDIR:-/tmp}/update-review-checklist-existing.XXXXXX")"
-gh api "repos/$REPO/contents/docs/code-review-checklist.md" --jq '.content' | base64 -d > "$CURRENT_CHECKLIST"
+gh api "repos/$REPO/contents/docs/code-review-checklist.md" --jq '.content' | base64 --decode > "$CURRENT_CHECKLIST"
 ```
 
 ## Step 3: Filter Comments
@@ -308,7 +308,6 @@ update-review-checklist complete.
   Merged PRs inspected: $N  (skipped own PRs: $K)
   Comments fetched:     $M
   Filter drops:
-    - bots:                       $A
     - unresolved-by-commit:       $B
     - hard-skip patterns:         $C
   Clusters above threshold:       $D

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -165,7 +165,7 @@ Non-ambiguous clusters pass through unchanged. The active set after this gate is
 
 ## Step 5: Dedup Against Existing Checklist
 
-Read [`references/checklist-schema.md`](references/checklist-schema.md) now. For each surviving cluster, apply its semantic-dedup rubric against `/tmp/current-checklist.md`. The rubric's three diagnostic questions classify each cluster as **duplicate** (drop), **distinct** (keep), or **ambiguous** (needs a call).
+Read [`references/checklist-schema.md`](references/checklist-schema.md) now. For each surviving cluster, apply its semantic-dedup rubric against the checklist content at `$CURRENT_CHECKLIST` (the per-run path from Step 2). The rubric's three diagnostic questions classify each cluster as **duplicate** (drop), **distinct** (keep), or **ambiguous** (needs a call).
 
 ### Ambiguous-dedup gate
 
@@ -236,7 +236,7 @@ The `$CURRENT_CHECKLIST` cache from Step 2 may be stale relative to the freshly 
 CHECKLIST_PATH="$WORKDIR/docs/code-review-checklist.md"
 ```
 
-If a meaningful diff exists between `/tmp/current-checklist.md` and `$CHECKLIST_PATH` (e.g. someone merged checklist changes between Step 2 and now), re-run the Step 5 dedup gate against the fresh content before continuing. For monthly-cadence runs this is almost never the case.
+If a meaningful diff exists between `$CURRENT_CHECKLIST` and `$CHECKLIST_PATH` (e.g. someone merged checklist changes between Step 2 and now), re-run the Step 5 dedup gate against the fresh content before continuing. For monthly-cadence runs this is almost never the case.
 
 ### Edit the checklist
 

--- a/plugins/dlc/skills/update-review-checklist/references/checklist-schema.md
+++ b/plugins/dlc/skills/update-review-checklist/references/checklist-schema.md
@@ -1,0 +1,99 @@
+# Checklist Schema
+
+Read this in Step 5 to dedup against existing entries, and in Step 7 to author new entries.
+
+## Canonical Entry Format
+
+Each new checklist entry is a single bullet under an H2 (`##`) section. Format:
+
+```markdown
+- **<title in imperative voice, ≤80 chars>** — <what to check, ≤200 chars>.
+  > Source PRs: #<N>, #<M>[, #<P>]
+```
+
+- **Title**: imperative voice (`"Disable submit buttons during async work"`, not `"submit buttons should be disabled…"`). Reads like a checkbox a reviewer can tick.
+- **Body**: one sentence describing what the reviewer looks for. Avoid restating the title.
+- **Source PRs trailer**: blockquote line with comma-separated `#N` references. Used for traceability — a reviewer can click through and read the actual reviewer comments that motivated the entry.
+
+Real example:
+
+```markdown
+- **Disable submit buttons during async work** — confirm that form submit buttons enter a disabled or loading state on click and stay non-interactive until the promise settles.
+  > Source PRs: #210, #214, #221
+```
+
+## Where to Insert (Step 7)
+
+The target file `docs/code-review-checklist.md` is owned by the target repo and may have any existing section structure. Decide insertion location with this rule:
+
+1. **If the cluster theme fits an existing H2 section** — append the entry as the last bullet of that section. Match by section title semantically: `"Accessibility"` accepts aria/keyboard/focus clusters; `"Security"` accepts injection/auth/secrets clusters; `"Async / error handling"` accepts promise/error/retry clusters; etc.
+2. **If no existing section is a clean match** — append the entry under a new H2 `## Recurring patterns` section at the end of the file. Create the section once on the first run; subsequent runs append into it. The section title is intentionally generic so it does not need ownership decisions from the human reviewer.
+
+Do **not** reorder, retire, or reword existing entries. Out of scope per issue cc-skills#216.
+
+## Semantic-Dedup Rubric (Step 5)
+
+For each proposed cluster, ask these three diagnostic questions against each existing checklist entry. Each question yields **yes**, **no**, or **maybe**. Aggregate into a verdict:
+
+- **Duplicate** (drop): at least one definitive **yes**.
+- **Distinct** (keep): all **no**.
+- **Ambiguous** (gate fires): mix of **maybe** answers, or one **maybe** plus surface partial-overlap evidence. The SKILL.md ambiguous-dedup gate triggers — under `--unattended` it becomes Pending-Human; in attended mode it asks the user.
+
+The questions:
+
+### Q1: Same ask?
+
+Does the existing entry ask the reviewer to check the same thing the cluster proposes?
+
+- "Forms have disabled state during submit" vs. cluster "Form submit buttons disable while pending" → **yes, same ask**, drop.
+- "Forms validate input client-side" vs. cluster "Form submit buttons disable while pending" → **no, different ask**, keep.
+
+### Q2: Subsumed scope?
+
+Is the existing entry a broader version of the cluster that already covers it?
+
+- Existing: "Disclosure components meet WAI-ARIA disclosure pattern requirements" vs. cluster "Disclosure buttons have aria-expanded" → **yes, subsumed** by the broader entry, drop.
+- Existing: "Use semantic HTML elements" vs. cluster "Disclosure buttons have aria-expanded" → **no, too generic to count as coverage**, keep.
+
+A subsumption claim must point to a *specific named pattern or standard* in the existing entry. Generic best-practice entries do not subsume specific ones.
+
+### Q3: Same domain + same surface?
+
+Does the existing entry address the same domain (e.g. async, a11y, validation) on the same code surface (component type, function shape, API contract)?
+
+- Existing on API responses: "Error responses include `code` and `message` fields" vs. cluster on API responses: "Errors have a machine-readable `code`" → **yes, same domain + surface**, drop.
+- Existing on API responses: "Error responses include `code` and `message` fields" vs. cluster on JS thrown errors: "Custom Error subclasses carry a `code` property" → **no, different surface** (API responses vs. in-process errors), keep.
+
+### Tie-breaker rule
+
+When in genuine doubt after all three questions, **keep** the candidate. The cost of a redundant proposal is one comment from a human reviewer ("we already have an entry for this"). The cost of a dropped proposal is the pattern continues drifting unfixed. The PR is the gate, and humans are good at noticing duplicates.
+
+## PR Body Structure (Step 7)
+
+The PR body the skill opens has this skeleton:
+
+```markdown
+## Summary
+
+This PR proposes **<N> new entries** to `docs/code-review-checklist.md`, derived from clustering review comments across **<merged_prs_inspected> merged PRs** over the last **<lookback>**.
+
+Each entry is sourced from at least <threshold> distinct PRs where reviewers asked for the same class of change.
+
+## Derived from
+
+| Entry | Source PRs | Weight |
+|---|---|---|
+| Disable submit buttons during async work | #210, #214, #221 | 6 |
+| API error responses include a `code` field | #198, #207, #220 | 5 |
+| …                                          | …                | … |
+
+## How this was generated
+
+This PR was opened automatically by the `dlc:update-review-checklist` skill (lookback `<lookback>`, threshold `<threshold>`). The skill clusters reviewer comments from merged PRs by theme, drops clusters already covered by existing entries, and proposes the survivors as new checklist items.
+
+Review the entries on their merits — duplicates, wrong-domain matches, or unclear wording are normal and worth flagging. The skill does not auto-merge.
+
+Re-run with `--dry-run` for clusters that surfaced but were dropped (filter drops, dedup matches).
+```
+
+Keep the body under ~600 chars of human-written prose. Most of the value is in the table.

--- a/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
+++ b/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
@@ -9,7 +9,7 @@ Drop a comment from clustering when its body matches any of the following. These
 | Pattern | Why dropped |
 |---|---|
 | Pure typo flags (`typo:`, `s/foo/bar`, `^typo in ` lead-in) | One-off lexical errors; not a checklist-worthy class |
-| Formatting nits matched by `^(nit|style|format):` *and* the comment proposes no semantic change | Style is handled by linters, not human checklist gates |
+| Formatting nits matched by `^(nit\|style\|format):` *and* the comment proposes no semantic change | Style is handled by linters, not human checklist gates |
 | "Consider …" / "What about …" wishlist comments with no specific action and no commit response | Already filtered by resolved-by-commit, but defensive — drop if `severity == null` and body starts with these |
 | Praise / acknowledgement (`LGTM`, `nice`, `👍`, etc., body < 40 chars) | No action proposed |
 | CodeRabbit no-findings summary: `^actionable comments posted:\s*0\b` | Header-only review summary, no member finding to cluster |

--- a/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
+++ b/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
@@ -9,7 +9,7 @@ Drop a comment from clustering when its body matches any of the following. These
 | Pattern | Why dropped |
 |---|---|
 | Pure typo flags (`typo:`, `s/foo/bar`, `^typo in ` lead-in) | One-off lexical errors; not a checklist-worthy class |
-| Formatting nits matched by `^(nit\|style\|format):` *and* the comment proposes no semantic change | Style is handled by linters, not human checklist gates |
+| Formatting nits matched by `^(nit&#124;style&#124;format):` *and* the comment proposes no semantic change | Style is handled by linters, not human checklist gates |
 | "Consider …" / "What about …" wishlist comments with no specific action and no commit response | Already filtered by resolved-by-commit, but defensive — drop if `severity == null` and body starts with these |
 | Praise / acknowledgement (`LGTM`, `nice`, `👍`, etc., body < 40 chars) | No action proposed |
 | CodeRabbit no-findings summary: `^actionable comments posted:\s*0\b` | Header-only review summary, no member finding to cluster |

--- a/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
+++ b/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
@@ -12,9 +12,13 @@ Drop a comment from clustering when its body matches any of the following. These
 | Formatting nits matched by `^(nit|style|format):` *and* the comment proposes no semantic change | Style is handled by linters, not human checklist gates |
 | "Consider …" / "What about …" wishlist comments with no specific action and no commit response | Already filtered by resolved-by-commit, but defensive — drop if `severity == null` and body starts with these |
 | Praise / acknowledgement (`LGTM`, `nice`, `👍`, etc., body < 40 chars) | No action proposed |
-| Bot CI summaries that slipped past `.is_bot` (e.g. human-posted "all checks green") | No reviewer signal |
+| CodeRabbit no-findings summary: `^actionable comments posted:\s*0\b` | Header-only review summary, no member finding to cluster |
+| Qodo no-findings summary: `^code review by qodo` followed by all-zero category counters (e.g. `🐞 Bugs (0)` AND `📘 Rule violations (0)` AND `📎 Requirement gaps (0)`) | All-zero counters = no findings; keep if any counter > 0 |
+| Empty or near-empty bodies (after stripping whitespace and markdown, < 20 chars) | No content to cluster on; usually a wrapper for inline thread comments which arrive separately |
 
 Match case-insensitively. If a comment matches a skip pattern AND carries a severity label (`high`/`medium`/`low`), **keep it** — severity-labelled findings are signal even when their leading word is "nit".
+
+The hard-skip rules above are content-defined, not author-defined. Bot accounts that post substantive reviews (Copilot, CodeRabbit non-zero summaries, Codex, Gemini, Qodo non-zero summaries) pass through; only their explicit no-findings summary formats are caught. This generalises across repos with any reviewer mix — human-led, bot-led, or hybrid.
 
 ## Severity Weights
 

--- a/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
+++ b/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
@@ -16,7 +16,7 @@ Matched case-insensitively against the comment body's leading non-whitespace tok
 
 | Pattern | Why dropped |
 |---|---|
-| Pure typo flags (`typo:`, `s/foo/bar`, `^typo in ` lead-in) | One-off lexical errors; not a checklist-worthy class |
+| Pure typo flags (`typo:`, `s/foo/bar`, `^typo in` lead-in) | One-off lexical errors; not a checklist-worthy class |
 | Formatting nits whose body starts with `nit:`, `style:`, or `format:` (case-insensitive) *and* the comment proposes no semantic change | Style is handled by linters, not human checklist gates |
 | "Consider …" / "What about …" wishlist comments with no specific action and no commit response | Already filtered by resolved-by-commit, but defensive — drop if `severity == null` and body starts with these |
 | Praise / acknowledgement (`LGTM`, `nice`, `👍`, etc., body < 40 chars) | No action proposed |

--- a/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
+++ b/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
@@ -1,0 +1,92 @@
+# Clustering Rubric
+
+Read this in Step 3 to apply the hard-skip filter and again in Step 4 to cluster surviving comments by theme.
+
+## Hard-Skip Patterns (Step 3)
+
+Drop a comment from clustering when its body matches any of the following. These patterns produce noise, not patterns worth promoting to a checklist.
+
+| Pattern | Why dropped |
+|---|---|
+| Pure typo flags (`typo:`, `s/foo/bar`, `^typo in ` lead-in) | One-off lexical errors; not a checklist-worthy class |
+| Formatting nits matched by `^(nit|style|format):` *and* the comment proposes no semantic change | Style is handled by linters, not human checklist gates |
+| "Consider …" / "What about …" wishlist comments with no specific action and no commit response | Already filtered by resolved-by-commit, but defensive — drop if `severity == null` and body starts with these |
+| Praise / acknowledgement (`LGTM`, `nice`, `👍`, etc., body < 40 chars) | No action proposed |
+| Bot CI summaries that slipped past `.is_bot` (e.g. human-posted "all checks green") | No reviewer signal |
+
+Match case-insensitively. If a comment matches a skip pattern AND carries a severity label (`high`/`medium`/`low`), **keep it** — severity-labelled findings are signal even when their leading word is "nit".
+
+## Severity Weights
+
+Each surviving comment carries a `severity` field set by the helper script (one of `high`, `medium`, `low`, `null`). Map to weights when computing cluster weight:
+
+| `severity` | Weight |
+|---|---|
+| `high` | 3 |
+| `medium` | 2 |
+| `low` or `null` | 1 |
+
+A cluster's weight is the sum of member weights. Use weight to sort clusters in Step 4 — heaviest first — so the most important patterns surface at the top of the PR.
+
+## Clustering Rules (Step 4)
+
+**The core rule:** cluster by *what the reviewer is asking the author to do*, not by the file, line, or surface text.
+
+Two comments belong in the same cluster when both of the following hold:
+
+1. **Same ask shape.** The action the reviewer requests is structurally the same (e.g. "add a null check before this access", "rename to match the verb-noun convention", "extract this duplicated block").
+2. **Same domain or scope.** The ask applies to the same kind of code (accessibility on disclosure components, error handling in async pipelines, validation at API boundaries, etc.).
+
+Two comments do **not** belong in the same cluster when:
+
+- Both touch the same file or function but ask for different things ("rename this var" vs. "add error handling" — different asks).
+- Both ask for the same generic improvement but in unrelated domains ("add a test" for an algorithm vs. "add a test" for UI accessibility — too broad to be one checklist entry).
+- One is a question and the other is a directive — a question may end up as a clarification entry, not the same item as a directive.
+
+### Granularity calibration
+
+- **Too coarse:** clusters titled "code quality" or "tests" — these are not actionable as checklist entries.
+- **Right size:** clusters titled like a reviewable check — "API error responses include a `code` field", "form submit buttons have a loading state", "queries with user input use parameterised statements".
+- **Too fine:** clusters of 2 PRs about the same specific function name. If the pattern is "this function specifically", it is not a pattern.
+
+If a cluster's title can be re-used verbatim as a future PR-review checkbox, it is the right granularity.
+
+### When a cluster is "ambiguous"
+
+Some clusters cannot be confidently labelled distinct or duplicate from the rules above. Flag a cluster as **ambiguous** (which triggers the SKILL.md ambiguous-cluster gate) when any of these hold:
+
+- Members satisfy the same-ask test but the **domain** is borderline (e.g. "needs a test" applies to both pure-logic and UI a11y — could legitimately be one cluster or two)
+- The proposed title sits on the granularity line: stripping one word makes it too coarse, adding one word makes it too narrow
+- A meaningful subset of members suggests a *different* sibling cluster — splitting is reasonable but not obviously correct
+
+Ambiguous clusters are not failures of the rubric — they are real cases where reviewer signal genuinely overlaps. Under `--unattended` the SKILL.md drops them into the Pending-Human bucket; in attended mode it asks the user to choose.
+
+### Examples
+
+**Good cluster** (3 PRs, weight 6):
+- Theme: "Form submissions disable the submit button while pending"
+- Members:
+  - PR #210, reviewer @ana, "this button stays active during submit — should be disabled"
+  - PR #214, reviewer @ben, severity:medium, "missing pending state on the submit button, double-submit possible"
+  - PR #221, reviewer @ana, "same issue as #210 — disable while loading"
+
+**Bad cluster** (overcoarse):
+- Theme: "Improve error handling"
+- Members: span 4 PRs but the asks are: catch a specific exception, return a typed error, add a fallback path, log to telemetry. These are 4 distinct asks. Split into 4 clusters; any below threshold gets dropped.
+
+**Bad cluster** (overfine):
+- Theme: "Rename `getUser()` to `fetchUser()`"
+- Members: 2 PRs about the exact same function. This is a one-off rename, not a checklist pattern.
+
+## Severity-Label Detection (reference for the helper script)
+
+The helper script regex-matches comment bodies against these two formats:
+
+- **Council / deep-review prose** (most common):
+  - `Severity: High` / `Severity: Medium` / `Severity: Low`
+  - `Confidence: High` / `Confidence: Medium`
+- **Inline label-style** (sometimes used in bot or council output):
+  - `severity/high`, `severity/critical`, `severity/medium`, `severity/low`
+  - `deep-review/critical`
+
+When a comment carries both formats, the helper records the highest. `critical` maps to the `high` bucket.

--- a/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
+++ b/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
@@ -9,10 +9,10 @@ Drop a comment from clustering when its body matches any of the following. These
 The formatting-nits row in the table below describes the pattern in prose to avoid GFM table escape ambiguity. The literal regex an implementation should use is:
 
 ```regex
-^(nit|style|format):
+^\s*(nit|style|format):
 ```
 
-Matched case-insensitively against the comment body's leading non-whitespace token.
+Matched case-insensitively. The leading `\s*` permits common preamble whitespace (markdown blockquote indentation, list markers, accidental leading spaces) so a comment body like `"  nit: trailing whitespace"` still matches.
 
 | Pattern | Why dropped |
 |---|---|

--- a/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
+++ b/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
@@ -12,7 +12,7 @@ The formatting-nits row in the table below describes the pattern in prose to avo
 ^\s*(nit|style|format):
 ```
 
-Matched case-insensitively. The leading `\s*` permits common preamble whitespace (markdown blockquote indentation, list markers, accidental leading spaces) so a comment body like `"  nit: trailing whitespace"` still matches.
+Matched case-insensitively. The leading `\s*` permits accidental leading whitespace (spaces or tabs) so a comment body like `"  nit: trailing whitespace"` still matches. Markdown preamble characters like `>`, `-`, or `*` are not whitespace and so are *not* matched — in practice review-tool comment bodies are delivered without those prefixes, so widening the regex to cover them would add noise without adding signal.
 
 | Pattern | Why dropped |
 |---|---|

--- a/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
+++ b/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
@@ -6,10 +6,18 @@ Read this in Step 3 to apply the hard-skip filter and again in Step 4 to cluster
 
 Drop a comment from clustering when its body matches any of the following. These patterns produce noise, not patterns worth promoting to a checklist.
 
+The formatting-nits row in the table below describes the pattern in prose to avoid GFM table escape ambiguity. The literal regex an implementation should use is:
+
+```regex
+^(nit|style|format):
+```
+
+Matched case-insensitively against the comment body's leading non-whitespace token.
+
 | Pattern | Why dropped |
 |---|---|
 | Pure typo flags (`typo:`, `s/foo/bar`, `^typo in ` lead-in) | One-off lexical errors; not a checklist-worthy class |
-| Formatting nits matched by `^(nit&#124;style&#124;format):` *and* the comment proposes no semantic change | Style is handled by linters, not human checklist gates |
+| Formatting nits whose body starts with `nit:`, `style:`, or `format:` (case-insensitive) *and* the comment proposes no semantic change | Style is handled by linters, not human checklist gates |
 | "Consider …" / "What about …" wishlist comments with no specific action and no commit response | Already filtered by resolved-by-commit, but defensive — drop if `severity == null` and body starts with these |
 | Praise / acknowledgement (`LGTM`, `nice`, `👍`, etc., body < 40 chars) | No action proposed |
 | CodeRabbit no-findings summary: `^actionable comments posted:\s*0\b` | Header-only review summary, no member finding to cluster |
@@ -88,7 +96,7 @@ The helper script regex-matches comment bodies against these two formats:
 
 - **Council / deep-review prose** (most common):
   - `Severity: High` / `Severity: Medium` / `Severity: Low`
-  - `Confidence: High` / `Confidence: Medium`
+  - `Confidence: High` / `Confidence: Medium` / `Confidence: Low`
 - **Inline label-style** (sometimes used in bot or council output):
   - `severity/high`, `severity/critical`, `severity/medium`, `severity/low`
   - `deep-review/critical`


### PR DESCRIPTION
## Summary

New `dlc:update-review-checklist` skill — clusters recurring reviewer comments across merged PRs in a window, dedups against the target repo's `docs/code-review-checklist.md`, and opens a PR proposing new entries with PR traceability. Designed for `/schedule monthly` cadence; never auto-merges.

Closes #216.

## Architecture

- **Deterministic data plane** lives in `plugins/dlc/scripts/fetch-merged-pr-comments.sh` (GraphQL) — lists merged PRs in window, fetches threads + review bodies + issue comments per PR, applies the `resolved_by_commit` heuristic (was the comment followed by a PR-author commit?), detects council/deep-review severity labels, emits structured JSON.
- **Semantic plane** lives in `plugins/dlc/skills/update-review-checklist/SKILL.md` — bot filtering, hard-skip patterns, LLM-driven clustering by reviewer ask, semantic dedup against the existing checklist, and PR authoring against a fresh clone.
- **Reference rubrics** (`clustering-rubric.md`, `checklist-schema.md`) carry the granularity calibration, severity-weight map, three-question dedup rubric, and PR-body template — loaded only at the steps that need them.

## Design notes

- **Both v1 heuristics included** (per issue Design Notes): comment-resolved-by-commit *and* severity weighting. Settled in plan review.
- **Always-temp-dir Step 7** — clones target into `mktemp -d`, branches there, pushes, then cleans up via `trap … EXIT`. Keeps caller's working tree untouched and avoids two-path branching for same-repo vs cross-repo invocations.
- **GPG bypass** — `git -c commit.gpgsign=false commit`, so `/schedule` runs can commit without pinentry.
- **Pending-Human pipeline under `--unattended`** — ambiguous clusters and ambiguous dedup matches flow into a held-back bucket that surfaces in the Step 9 summary using the same shape `dlc:babysit` parses.
- **Skip-own-PRs at two layers** — helper script `--skip-prefix` filters merged prior runs; Step 1.5 guards against open prior PRs.

## Acceptance criteria (#216 VERIFY items)

| # | AC | Where |
|---|---|---|
| 1 | trigger phrases documented | SKILL.md `description` lists all three |
| 2 | runs standalone + under `/schedule` | usage shown at top of SKILL.md |
| 3 | missing-checklist exits cleanly | Step 1, exit 0 with guidance |
| 4 | PR cites source PRs per entry | Step 7 builds "Derived from" table; entries have `> Source PRs:` trailer |
| 5 | threshold configurable | `--threshold N` flag (default 2) |
| 6 | semantic dedup | Step 5 invokes the three-question rubric in `checklist-schema.md` |
| 7 | dry-run mode | Step 6 exits before any mutation |
| 8 | skips own prior PRs | helper script `--skip-prefix`; Step 1.5 guards against open ones too |

## Files

- `plugins/dlc/skills/update-review-checklist/SKILL.md` (+341)
- `plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md` (+92)
- `plugins/dlc/skills/update-review-checklist/references/checklist-schema.md` (+99)
- `plugins/dlc/scripts/fetch-merged-pr-comments.sh` (+444)
- `docs/learnings.md` (+64) — jq filter-parameter semantics and JSONL+`--slurpfile` discoveries from this work

## Test plan

- [x] `bun scripts/validate-plugins.mjs` — passes (schema, source paths, no orphans, frontmatter)
- [x] Helper script smoke-tested against this repo with `--lookback 1d` and `--lookback 7d` — returns valid JSON; bot filtering, resolved-by-commit, and severity detection all working
- [x] Helper script edge cases — invalid `--lookback`, unknown flags both reject with structured error JSON
- [ ] Reviewer to verify SKILL.md reads cleanly end-to-end (it is the LLM's runtime spec)
- [ ] Reviewer to spot-check the clustering rubric examples against real reviewer comments in their repo
- [ ] End-to-end dry-run against a repo with `docs/code-review-checklist.md` and human reviewer comments — the cc-skills repo currently has bot-only review data so a real-PR dry-run can't be exercised here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Shell/JQ best practices for safer parameter handling and robust JSON-array construction.
  * Added an end-to-end checklist-update workflow (dry-run/unattended modes, dedup/cluster rules, PR generation, state recording).
  * Added clustering/deduplication rubrics and canonical checklist-entry format, with severity mapping and examples.

* **Chores**
  * Added a POSIX script to aggregate merged-PR reviews/comments and emit normalized JSON used by the checklist workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rube-de/cc-skills/pull/230)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->