### PR TITLE
feat(council): migrate gemini consultant to omp CLI with Gemini 3.5 Flash

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "council",
-      "description": "AI Council - Orchestrate multiple AI consultants (Gemini, Codex, Qwen, GLM-5.2, Kimi K2.5) for consensus-driven code reviews, plan validation, and architectural decisions",
+      "description": "AI Council - Orchestrate multiple AI consultants (Gemini 3.5 Flash, Codex, Qwen, GLM-5.2, Kimi K2.5) for consensus-driven code reviews, plan validation, and architectural decisions",
       "version": "2.4.0",
       "source": "./plugins/council",
       "category": "code-review",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A monorepo of [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plug
 
 | Plugin | Category | Install | Description |
 |--------|----------|---------|-------------|
-| [council](./plugins/council/) | Code Review | Plugin or Skill | Orchestrate Gemini, Codex, Qwen, GLM-5.2, and Kimi K2.5 for consensus-driven reviews |
+| [council](./plugins/council/) | Code Review | Plugin or Skill | Orchestrate Gemini 3.5 Flash, Codex, Qwen, GLM-5.2, and Kimi K2.5 for consensus-driven reviews |
 | [cdt](./plugins/cdt/) | Development | Plugin only | Multi-agent dev team with four modes: plan, dev, full, and auto via Agent Teams |
 | [pm](./plugins/pm/) | Productivity | Plugin or Skill | GitHub issue lifecycle: create, triage, and audit issues for LLM agent teams |
 | [plugin-dev](./plugins/plugin-dev/) | Development | Plugin or Skill | Scaffold plugins, validate SKILL.md frontmatter, audit hooks |

--- a/plugins/council/README.md
+++ b/plugins/council/README.md
@@ -7,7 +7,7 @@
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
 [![Install](https://img.shields.io/badge/Install-Plugin%20%7C%20Skill-informational.svg)]()
 
-Orchestrate multiple AI consultants (Gemini, Codex, Qwen, GLM-5.2, Kimi K2.5) and specialized Claude subagents for consensus-driven code reviews, plan validation, and architectural decisions.
+Orchestrate multiple AI consultants (Gemini 3.5 Flash, Codex, Qwen, GLM-5.2, Kimi K2.5) and specialized Claude subagents for consensus-driven code reviews, plan validation, and architectural decisions.
 
 > [!NOTE]
 > **Dual-Layer Architecture**: External consultants provide model diversity across 5 different AI providers, while internal Claude subagents provide deep, tool-assisted analysis — one for security/bugs/performance, one for quality/compliance/history/docs.
@@ -19,7 +19,7 @@ Orchestrate multiple AI consultants (Gemini, Codex, Qwen, GLM-5.2, Kimi K2.5) an
 **Layer 1 — External Consultants** (model diversity, same prompt):
 | Consultant | CLI | Strength |
 |------------|-----|----------|
-| Gemini | `gemini` | Architecture, security, fast analysis |
+| Gemini 3.5 Flash | `omp -p --no-tools --model google-antigravity/gemini-3.5-flash` | Architecture, security, fast analysis |
 | Codex | `codex` | PR review, bug detection, security |
 | Qwen | `qwen` | Code quality, brainstorming, explanations |
 | GLM-5.2 | `omp -p --no-tools --model zai/glm-5.2` | Alternative perspectives, algorithms |
@@ -90,7 +90,7 @@ Built-in taxonomy auto-rejects:
 │  1. Pre-flight — verify CLI availability                 │
 │                                                          │
 │  2. Layer 1: External Consultants (parallel, 120s)       │
-│     ├── gemini -p "review ..." -f changed_files          │
+│     ├── omp -p --no-tools --model .../gemini-3.5-flash   │
 │     ├── codex "review ..."                               │
 │     ├── qwen "review ..."                                │
 │     ├── omp -p --no-tools --model zai/glm-5.2 "..."      │
@@ -153,15 +153,14 @@ At least one external CLI must be installed:
 
 ```bash
 # Check availability (prints ✓/✗ per CLI — any one is enough)
-for cli in gemini codex qwen omp opencode; do
+for cli in codex qwen omp opencode; do
   command -v "$cli" >/dev/null 2>&1 && echo "✓ $cli" || echo "✗ $cli"
 done
 
 # Install as needed
-# gemini  — https://github.com/google-gemini/gemini-cli
 # codex   — https://github.com/openai/codex
 # qwen    — https://github.com/QwenLM/qwen-cli
-# omp     — https://github.com/can1357/oh-my-pi (GLM-5.2)
+# omp     — https://github.com/can1357/oh-my-pi (Gemini 3.5 Flash via antigravity, GLM-5.2)
 # opencode — https://github.com/opencode-ai/opencode (Kimi)
 ```
 
@@ -172,22 +171,21 @@ The plugin operates in partial-success mode — it proceeds with whichever consu
 | Component | Required | Purpose |
 |-----------|----------|---------|
 | Claude Code | Yes | Plugin host |
-| gemini CLI | Recommended | Gemini consultant |
 | codex CLI | Recommended | Codex consultant |
 | qwen CLI | Recommended | Qwen consultant |
-| omp CLI | Recommended | GLM-5.2 consultant |
+| omp CLI | Recommended | Gemini and GLM-5.2 consultants |
 | opencode CLI | Recommended | Kimi consultant |
 
 ## Troubleshooting
 
 | Issue | Cause | Solution |
 |-------|-------|----------|
-| "No consultants available" | No external CLIs installed | Install at least one: gemini, codex, qwen, omp, or opencode |
+| "No consultants available" | No external CLIs installed | Install at least one: codex, qwen, omp, or opencode |
 | Consultant returns empty output | Rate limiting or timeout | Automatic retry with exponential backoff; check API quotas |
 | Low confidence scores | Vague review scope | Use concern-specific mode: `/council review security` |
 | Too many false positives | Broad review on large diff | Use `/council quick` for parallel triage (2-agent lightweight review) |
 | JSON validation warnings | Consultant output malformed | PostToolUse hook retries; check CLI version |
-| Pre-flight warning on start | CLI not in PATH | Verify installation: `which gemini codex qwen omp opencode` |
+| Pre-flight warning on start | CLI not in PATH | Verify installation: `which codex qwen omp opencode` |
 
 ## References
 

--- a/plugins/council/agents/gemini-consultant.md
+++ b/plugins/council/agents/gemini-consultant.md
@@ -14,39 +14,71 @@ hooks:
           command: "${CLAUDE_PLUGIN_ROOT}/scripts/validate-json-output.sh"
 ---
 
-You are an expert technical consultant specializing in obtaining and synthesizing external feedback for software development decisions. Your role is to leverage the **Gemini CLI** directly via Bash to get second opinions on plans, code reviews, and technical debates.
+You are an expert technical consultant specializing in obtaining and synthesizing external feedback for software development decisions. Your role is to leverage **Google's Gemini 3.5 Flash** via the **omp CLI** to get second opinions on plans, code reviews, and technical debates. Gemini 3.5 Flash offers fast, broad analysis with particular strength in architecture and security.
 
-## Gemini CLI Usage
+## omp CLI Usage
 
-The Gemini CLI (`gemini`) is invoked directly from the command line. Key patterns:
+The omp CLI (`omp`) reaches Gemini 3.5 Flash through the `google-antigravity` provider. This requires an **antigravity login** to be configured (verify with `omp -p --model google-antigravity/gemini-3.5-flash "ping"`). Key patterns:
 
-### Basic Query
+- `-p` runs non-interactively (print result and exit).
+- `--model google-antigravity/gemini-3.5-flash` selects the model.
+- `--no-tools` disables omp's built-in `read`/`bash`/`edit`/`write` tools, so the model cannot inspect or modify the workspace through them. **It does not make the session report-only on its own:** `--no-tools` does *not* disable custom-tool discovery. omp still scans its working directory's `.omp/tools/` and `.claude/tools/` and `import()`s those modules at startup, executing their code regardless of `--no-tools`. A reviewed branch that ships a `.omp/tools/*.ts` file would run during the review.
+- **Run omp from an isolated sandbox directory** (see "Report-Only Sandbox" below) whenever the reviewed content is untrusted. *Project-level* custom-tool discovery (`<cwd>/.claude/tools`, `<cwd>/.omp/tools`) is keyed to omp's cwd, so a throwaway cwd outside the repo starves the untrusted repo's own tools — that closes the main vector (a reviewed branch shipping its own `.omp/tools/*.ts`, which would run at `import()` time with no model involvement). Attach the real files by absolute `@path`. **Caveat:** *user-level* tools (`~/.claude/tools`, `~/.omp/plugins/*`) resolve from `$HOME`, not cwd, so the sandbox does **not** starve them — see "What the sandbox does and doesn't cover" below.
+- Attach files by writing `@path` inside the prompt; each referenced file's contents are read into the message context. Multiple `@path` tokens (and multi-line prompts) work. Use **absolute** paths so attachment still works from the sandbox cwd. **Quote any mention that interpolates a path** — `@\"$repo/file\"` — because omp's unquoted-mention parser stops at the first space (`[^\s@]+`), so an absolute path containing a space (e.g. a repo under `/Users/me/My App`) is truncated and the file is silently skipped.
+- `omp` does **not** read piped stdin — `git diff | omp …` silently drops the diff and the model answers from nothing. To review a diff or any command output, write it to a file first and attach it with `@`.
+
+### Report-Only Sandbox (required for untrusted code)
+
+Because `--no-tools` does not stop custom-tool discovery, run omp from a throwaway directory so the reviewed repo's `.omp/tools/` and `.claude/tools/` are never on omp's cwd. `mktemp -d` lands outside the repo; capture repo content (file paths, diffs) **before** `cd`, then attach by absolute path:
+
 ```bash
-gemini -p "Your prompt here"
+(
+  repo="$PWD"
+  sandbox=$(mktemp -d)
+  trap 'rm -rf "$sandbox"' EXIT        # remove the sandbox even on error/interrupt
+  cd "$sandbox"                        # isolate cwd: omp won't discover the repo's custom tools
+  omp -p --no-tools --model google-antigravity/gemini-3.5-flash "Review this code for security issues @\"$repo/src/auth/middleware.ts\""
+)
 ```
 
-### Query with File Context
+**What the sandbox does and doesn't cover.** It starves *project-level* discovery (`<cwd>/.claude/tools`, `<cwd>/.omp/tools`) — the vector that matters most, since those files run at `import()` time with no model involvement. It does **not** disable *user-level* tools (`~/.claude/tools`, `~/.omp/plugins/*`): omp resolves these from `$HOME` regardless of cwd, and neither `--no-tools` (empties built-in `toolNames` only) nor `--no-extensions` (gates custom *commands*, not *tools*) drops them from the model-callable set. So with user-level tools installed, a prompt injection in an untrusted diff could still get the model to invoke one mid-review.
+
+For untrusted code, the robust isolation is OS-level: a container or a dedicated account whose `~/.claude/tools` and `~/.omp/plugins` are empty. Relocating `$HOME` into the sandbox would also starve user-level discovery, but omp keeps its auth/model config under `~/.omp/agent/`, so a bare `HOME=$sandbox` breaks the run — don't rely on it without provisioning that config. On your normal account, keep `~/.claude/tools` and `~/.omp/plugins` to trusted tools only.
+
+### Multiple Files
 ```bash
-gemini -p "Review this code for bugs and security issues" -f path/to/file1.ts path/to/file2.ts
+(
+  repo="$PWD"; sandbox=$(mktemp -d); trap 'rm -rf "$sandbox"' EXIT; cd "$sandbox"
+  omp -p --no-tools --model google-antigravity/gemini-3.5-flash "Review these files for bugs, security issues, performance problems, and design concerns. Be specific and actionable. @\"$repo/src/middleware/auth.ts\" @\"$repo/src/services/user.ts\" @\"$repo/src/routes/api.ts\""
+)
 ```
 
-### Query with Directory Context
+### Reviewing Diffs & Command Output
+`omp` does not read piped stdin — write the diff **into the sandbox dir** (capture it before `cd`, since `git` needs the repo cwd), then attach it by absolute path:
 ```bash
-gemini -p "Analyze the architecture of this module" -f src/auth/
+# PR review (sandbox dir isolates cwd; trap removes it even on error/interrupt)
+(
+  sandbox=$(mktemp -d)
+  trap 'rm -rf "$sandbox"' EXIT
+  git diff main...HEAD > "$sandbox/changes.diff"   # capture before cd
+  cd "$sandbox"
+  omp -p --no-tools --model google-antigravity/gemini-3.5-flash "Review these PR changes for issues @\"$sandbox/changes.diff\""
+)
+
+# Specific commit range
+(
+  sandbox=$(mktemp -d)
+  trap 'rm -rf "$sandbox"' EXIT
+  git diff HEAD~5 > "$sandbox/changes.diff"
+  cd "$sandbox"
+  omp -p --no-tools --model google-antigravity/gemini-3.5-flash "Review recent changes @\"$sandbox/changes.diff\""
+)
 ```
 
-### Sandbox Mode (for code execution/testing)
+### Interactive Mode
+You drive an interactive session against your **trusted** working tree, so the sandbox is optional — but never start it inside an untrusted checkout, since custom-tool discovery still applies to omp's cwd:
 ```bash
-gemini -s -p "Test this function and verify it works correctly" -f utils.ts
-```
-
-### Model Selection
-```bash
-# Use flash (faster, cheaper)
-gemini -m flash -p "Quick review of this approach"
-
-# Use pro (more capable, default)
-gemini -m pro -p "Deep architectural analysis"
+omp --no-tools --model google-antigravity/gemini-3.5-flash  # Start interactive session (omit -p)
 ```
 
 ## Core Responsibilities
@@ -61,7 +93,9 @@ gemini -m pro -p "Deep architectural analysis"
 
 ### Plan Review
 ```bash
-gemini -p "Review this implementation plan for a caching layer using Redis.
+(
+  sandbox=$(mktemp -d); trap 'rm -rf "$sandbox"' EXIT; cd "$sandbox"
+  omp -p --no-tools --model google-antigravity/gemini-3.5-flash "Review this implementation plan for a caching layer using Redis.
 
 Plan:
 1. Add Redis client dependency
@@ -73,17 +107,22 @@ Tech stack: Node.js, Express, PostgreSQL
 Requirements: Low latency, cache invalidation on writes
 
 What are the weaknesses, edge cases, or risks I'm missing?"
+)
 ```
 
 ### Code Review with Files
 ```bash
-gemini -p "Review these files for bugs, security issues, performance problems, and design concerns. Be specific and actionable." \
-  -f src/middleware/auth.ts src/services/user.ts src/routes/api.ts
+(
+  repo="$PWD"; sandbox=$(mktemp -d); trap 'rm -rf "$sandbox"' EXIT; cd "$sandbox"
+  omp -p --no-tools --model google-antigravity/gemini-3.5-flash "Review these files for bugs, security issues, performance problems, and design concerns. Be specific and actionable. @\"$repo/src/middleware/auth.ts\" @\"$repo/src/services/user.ts\" @\"$repo/src/routes/api.ts\""
+)
 ```
 
 ### Solution Debate
 ```bash
-gemini -p "Compare Redis vs Memcached for session storage.
+(
+  sandbox=$(mktemp -d); trap 'rm -rf "$sandbox"' EXIT; cd "$sandbox"
+  omp -p --no-tools --model google-antigravity/gemini-3.5-flash "Compare Redis vs Memcached for session storage.
 
 Context:
 - 100K daily active users
@@ -92,43 +131,46 @@ Context:
 - Already using PostgreSQL for primary data
 
 Provide objective tradeoff analysis and a recommendation with justification."
+)
 ```
 
 ### Architecture Analysis
 ```bash
-gemini -m pro -p "Analyze this module's architecture. Identify:
+(
+  repo="$PWD"; sandbox=$(mktemp -d); trap 'rm -rf "$sandbox"' EXIT; cd "$sandbox"
+  omp -p --no-tools --model google-antigravity/gemini-3.5-flash "Analyze this module's architecture. Identify:
 1. Coupling issues
 2. Potential circular dependencies
 3. Violation of SOLID principles
-4. Suggestions for improvement" \
-  -f src/events/
+4. Suggestions for improvement
+@\"$repo/src/events/dispatcher.ts\" @\"$repo/src/events/handlers.ts\""
+)
 ```
 
 ### PR Review
 ```bash
-# Review PR changes
-git diff main...HEAD | gemini -p "Review this PR for:
+(
+  sandbox=$(mktemp -d)
+  trap 'rm -rf "$sandbox"' EXIT
+  git diff main...HEAD > "$sandbox/changes.diff"   # capture before cd
+  cd "$sandbox"
+  omp -p --no-tools --model google-antigravity/gemini-3.5-flash "Review this PR for:
 1. Breaking changes
 2. Security vulnerabilities
 3. Performance regressions
 4. Missing error handling
 5. Test coverage gaps
 
-Be specific with file:line references."
-
-# Or with file context
-gemini -p "Review these changed files for issues" \
-  -f $(git diff --name-only main...HEAD)
+Be specific with file:line references. @\"$sandbox/changes.diff\""
+)
 ```
 
 ## Query Formulation Guidelines
 
 - Be specific and focused—vague queries get vague responses
-- Include relevant context (Gemini is stateless, each call is independent)
-- Use `-m pro` for complex architectural decisions
-- Use `-m flash` for quick syntax/style checks
+- Include relevant context (each omp `-p` call is independent—Gemini is stateless across invocations)
 - Structure queries to elicit actionable feedback, not generic advice
-- For file-heavy reviews, group related files together
+- For file-heavy reviews, group related files together with multiple `@path` tokens
 
 ## Output Format
 
@@ -150,7 +192,7 @@ After receiving Gemini's feedback:
 
 - If Gemini times out or fails, retry with a simpler query
 - If response is too generic, add more specific context and retry
-- If Gemini CLI is unavailable, clearly report the limitation and suggest alternatives (e.g., manual review checklist)
+- If the omp CLI is unavailable, clearly report the limitation and suggest alternatives (e.g., manual review checklist)
 
 ## When to Use Gemini vs Others
 
@@ -160,7 +202,7 @@ After receiving Gemini's feedback:
 | Plan validation | Quick feedback loops |
 | PR review | Security-focused, file-aware |
 | Solution debates | Balanced tradeoff analysis |
-| Quick checks | `-m flash` for speed |
+| Quick checks | Fast flash model, broad coverage |
 
 ## Important: Report Only
 

--- a/plugins/council/agents/gemini-consultant.md
+++ b/plugins/council/agents/gemini-consultant.md
@@ -18,7 +18,7 @@ You are an expert technical consultant specializing in obtaining and synthesizin
 
 ## omp CLI Usage
 
-The omp CLI (`omp`) reaches Gemini 3.5 Flash through the `google-antigravity` provider. This requires an **antigravity login** to be configured (verify with `omp -p --model google-antigravity/gemini-3.5-flash "ping"`). Key patterns:
+The omp CLI (`omp`) reaches Gemini 3.5 Flash through the `google-antigravity` provider. This requires an **antigravity login** to be configured — verify it once from a trusted directory (never inside an untrusted checkout) with `omp -p --no-tools --model google-antigravity/gemini-3.5-flash "ping"`, since omp's cwd-local tool discovery (described below) runs even for this check. Key patterns:
 
 - `-p` runs non-interactively (print result and exit).
 - `--model google-antigravity/gemini-3.5-flash` selects the model.

--- a/plugins/council/scripts/preflight.sh
+++ b/plugins/council/scripts/preflight.sh
@@ -3,7 +3,7 @@
 # Verifies external CLI tools are available for council consultants
 
 missing=()
-for cli in gemini codex qwen omp opencode; do
+for cli in codex qwen omp opencode; do
   command -v "$cli" >/dev/null 2>&1 || missing+=("$cli")
 done
 

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -49,7 +49,7 @@ Layer 1: External Consultants                    Layer 2: Claude Subagents
 
 ```bash
 # Run before ANY council invocation
-for cli in gemini codex qwen omp opencode; do
+for cli in codex qwen omp opencode; do
   command -v "$cli" >/dev/null 2>&1 && echo "✓ $cli" || echo "✗ $cli"
 done
 ```
@@ -105,7 +105,7 @@ Quick mode (`/council quick`) runs **exactly 2 agents** — no more, no fewer:
 
 | Agent | Model | Role |
 |-------|-------|------|
-| `council:gemini-consultant` | Gemini Flash | Fast external perspective |
+| `council:gemini-consultant` | Gemini 3.5 Flash | Fast external perspective |
 | `council:claude-codebase-context` | Sonnet | Codebase-aware depth (native tool access) |
 
 **Skipped in quick mode** (only run if escalating to full council):
@@ -296,10 +296,9 @@ Weighted → CRITICAL (Gemini's expertise dominates)
 ## CLI Commands
 
 ```bash
-# Gemini
-gemini -p "prompt" -f files
-gemini -m flash -p "quick check"  # Fast mode
-gemini -m pro -p "deep analysis"  # Thorough mode
+# Gemini (antigravity login; run from an isolated cwd for untrusted code — --no-tools does NOT block .omp/tools execution; see gemini-consultant.md "Report-Only Sandbox")
+omp -p --no-tools --model google-antigravity/gemini-3.5-flash "prompt"
+omp -p --no-tools --model google-antigravity/gemini-3.5-flash "prompt @file"
 
 # Codex
 cat file | codex "prompt"

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: council
-description: Consult external AI council (Gemini, Codex, Qwen, GLM-5.2, Kimi) for thorough reviews and consensus-driven decisions. Use ONLY when explicitly invoked with "/council" or when user says "consult the council", "invoke council", or "council review". Do NOT auto-trigger on generic phrases like "thorough review".
+description: Consult external AI council (Gemini 3.5 Flash, Codex, Qwen, GLM-5.2, Kimi) for thorough reviews and consensus-driven decisions. Use ONLY when explicitly invoked with "/council" or when user says "consult the council", "invoke council", or "council review". Do NOT auto-trigger on generic phrases like "thorough review".
 argument-hint: "[review|plan|adversarial|consensus|quick] [security|architecture|bugs|quality] [--blind]"
 allowed-tools: Task, Read, Grep, Glob, Bash, TodoWrite
 user-invocable: true
@@ -18,10 +18,9 @@ Before invoking any consultant, verify:
 
 ```bash
 # Check CLI availability (any subset works — a missing CLI just disables that consultant)
-command -v gemini >/dev/null 2>&1 || echo "WARN: gemini CLI not found"
 command -v codex >/dev/null 2>&1 || echo "WARN: codex CLI not found"
 command -v qwen >/dev/null 2>&1 || echo "WARN: qwen CLI not found"
-command -v omp >/dev/null 2>&1 || echo "WARN: omp CLI not found (needed for GLM)"
+command -v omp >/dev/null 2>&1 || echo "WARN: omp CLI not found (needed for Gemini and GLM)"
 command -v opencode >/dev/null 2>&1 || echo "WARN: opencode CLI not found (needed for Kimi)"
 ```
 
@@ -73,7 +72,7 @@ Invoked via CLI. Each brings a different AI model's perspective. All receive the
 
 | Agent | CLI | Strength | Expertise Weight |
 |-------|-----|----------|------------------|
-| `council:gemini-consultant` | `gemini` | Architecture, security | Security: 0.9, Architecture: 0.85 |
+| `council:gemini-consultant` | `omp -p --no-tools --model google-antigravity/gemini-3.5-flash` | Architecture, security | Security: 0.9, Architecture: 0.85 |
 | `council:codex-consultant` | `codex` | PR review, bugs | Debugging: 0.9, Security: 0.8 |
 | `council:qwen-consultant` | `qwen` | Quality, brainstorming | Quality: 0.9, Refactoring: 0.85 |
 | `council:glm-consultant` | `omp -p --no-tools --model zai/glm-5.2` | Alternative views, algorithms | Algorithms: 0.85, Architecture: 0.80 |
@@ -412,7 +411,7 @@ Quick mode runs **exactly these 2 agents**:
 
 | Agent | Model | Role | Why included |
 |-------|-------|------|--------------|
-| `council:gemini-consultant` | Gemini Flash (`-m flash`) | Fast external perspective | Fastest external model, broad coverage |
+| `council:gemini-consultant` | Gemini 3.5 Flash (`google-antigravity/gemini-3.5-flash`) | Fast external perspective | Fastest external model, broad coverage |
 | `council:claude-codebase-context` | Sonnet | Codebase-aware depth | Native tool access, CLAUDE.md compliance, git history |
 
 Quick mode **does NOT run** these agents:
@@ -432,7 +431,7 @@ Quick mode **does NOT run** these agents:
     Skipping 6 agents (codex, qwen, glm, kimi, claude-deep-review, review-scorer)."
 
 2. Launch BOTH in parallel:
-   - council:gemini-consultant (gemini -m flash) — fastest external model
+   - council:gemini-consultant (omp google-antigravity/gemini-3.5-flash) — fastest external model
    - council:claude-codebase-context (sonnet) — native codebase access
 
 3. Validate both responses (see Response Validation above)

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -10,7 +10,7 @@ Before ANY workflow, execute:
 AVAILABLE=()
 MISSING=()
 
-for cli in gemini codex qwen omp opencode; do
+for cli in codex qwen omp opencode; do
   if command -v "$cli" >/dev/null 2>&1; then
     AVAILABLE+=("$cli")
   else
@@ -364,7 +364,7 @@ fi
 
    | Agent | Model | Role |
    |-------|-------|------|
-   | `council:gemini-consultant` | Gemini Flash (`-m flash`) | Fast external perspective |
+   | `council:gemini-consultant` | Gemini 3.5 Flash (`google-antigravity/gemini-3.5-flash`) | Fast external perspective |
    | `council:claude-codebase-context` | Sonnet | Codebase-aware depth (native tool access) |
 
    **Skipped** (reserved for full council escalation):
@@ -375,7 +375,7 @@ fi
    Launch simultaneously:
 
    ```text
-   Task(council:gemini-consultant, flags="-m flash"):
+   Task(council:gemini-consultant):
    "Quick review of [artifact]. Return JSON with:
    - consultant: your name (e.g. 'gemini')
    - success: true


### PR DESCRIPTION
## Summary

Migrates the council **gemini-consultant** from the standalone `gemini` CLI to the `omp` CLI, calling Google's **Gemini 3.5 Flash** via the `google-antigravity` provider:

```bash
omp -p --no-tools --model google-antigravity/gemini-3.5-flash "...prompt with @path..."
```

This mirrors the GLM consultant's omp migration (#231) — both consultants now share the `omp` binary, so the same proven `omp` safety guidance applies (Report-Only Sandbox, `@path` attachment, no piped stdin).

## What changed

- **`agents/gemini-consultant.md`** — full rewrite to omp's interface: `-p` non-interactive, `--no-tools`, `@path` file attachment (omp ignores piped stdin, so diffs are captured to a file and attached with `@`), and the `mktemp -d` **Report-Only Sandbox** so an untrusted branch's `.omp/tools/` never execute on omp's cwd. Documents the antigravity-login prerequisite.
- **Removed the now-unused `gemini` CLI** from every availability check and dependency list (`preflight.sh`, SKILL, QUICK-REFERENCE, WORKFLOWS, README). No consultant uses it post-migration; `omp` now powers both Gemini and GLM-5.2.
- **`Gemini` → `Gemini 3.5 Flash`** labels across the council docs, root README, and `marketplace.json`.

The agent name `council:gemini-consultant` is unchanged, so all callers (e.g. `plugin-dev`) keep working — this is an implementation swap behind a stable interface.

## Verification

- ✅ `omp -p --model google-antigravity/gemini-3.5-flash` returns content (antigravity auth live)
- ✅ `bun scripts/validate-plugins.mjs` — all checks pass
- ✅ `preflight.sh` exits 0; all 4 preflight CLI loops identical (`codex qwen omp opencode`)
- ✅ Zero stale `gemini -p` / `-m flash` references in tracked files
- ✅ 4-lens adversarial review (prompt pitfalls vs `docs/learnings.md`, omp correctness, completeness, cross-file consistency) → **0 confirmed issues**

## Out of scope

A pre-existing 1-char ASCII misalignment on `plugins/council/README.md` line 87 (the `/council review` title line) predates this branch and is left untouched to keep the diff scoped.

https://claude.ai/code/session_01JuGuGMYuuJqFUkWedniQr9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated council plugin descriptions with specific included models: Gemini 3.5 Flash, Codex, Qwen, GLM-5.2, and Kimi K2.5
  * Enhanced council plugin guides with clarified workflow examples and updated troubleshooting documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->