### PR TITLE
fix(dlc): detect bot reviewers by API type field in babysit re-request

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -1328,3 +1328,26 @@ The first pass of `--unattended` only split the classifier for Discussion items.
 **Good pattern:** audit every call site before merging the first mode-split. If `AskUserQuestion` fires anywhere under `UNATTENDED=true`, the feature is incomplete.
 
 > Source: follow-up to #212 (#213); surfaced by copilot-pull-request-reviewer on PR #213; files: `plugins/dlc/skills/pr-check/references/fixable-workflow.md`
+
+### Detect bot reviewers by the API's `type` field, never by the `[bot]` login suffix
+
+`dlc:babysit` Step 3 re-requests review from prior reviewers after a push, filtering out bots so only humans get pinged. The filter was `[.reviews[].author.login | select(endswith("[bot]") | not)]` over `gh pr view --json reviews`. It misfired two ways at once: it failed to exclude App-based review bots (`coderabbitai`, `gemini-code-assist`, `copilot-pull-request-reviewer`, `chatgpt-codex-connector`) **and** it left the PR author in the list — so `gh pr edit --add-reviewer` would error on the author and redundantly re-ping bots that already auto-trigger on every push.
+
+**Root pattern:** the `[bot]` login suffix is present on some GitHub API surfaces and absent on others for the *same* account. REST `GET /pulls/{pr}/reviews` returns `user.login = "coderabbitai[bot]"` **with** the suffix and `user.type = "Bot"`; GraphQL and `gh pr view --json reviews` return `author.login = "coderabbitai"` **without** it. The `endswith("[bot]")` heuristic was written for REST-shaped logins but applied to the suffix-stripped `gh pr view` output, so it silently matched nothing. The bug failed *open* (bots passed through) rather than erroring, so it survived casual testing.
+
+**Rule:** Distinguish bots from humans by the explicit type field the API hands you — REST `user.type` (`Bot`/`User`) or GraphQL `author.__typename` (`Bot`/`User`) — never by pattern-matching the login string. Type fields are format-independent; login-suffix presence is coupled to which endpoint produced the string. Separately, always exclude the PR author from any re-request-reviewers list — GitHub rejects requesting review from a PR's own author.
+
+**Bad pattern (login-suffix heuristic, endpoint-coupled, fails open):**
+```bash
+gh pr view $PR --json reviews \
+  --jq '[.reviews[].author.login | select(endswith("[bot]") | not)] | unique | join(",")'
+# gh pr view strips the [bot] suffix → endswith never matches → bots AND author included
+```
+
+**Good pattern (explicit type field, endpoint-independent, author excluded):**
+```bash
+gh api repos/{owner}/{repo}/pulls/$PR/reviews \
+  --jq "[.[].user | select(.type == \"User\") | .login] | map(select(. != \"$PR_AUTHOR\")) | unique | join(\",\")"
+```
+
+> Source: PR #233 babysit run; file: `plugins/dlc/skills/babysit/SKILL.md` (Step 0 extraction adds `PR_AUTHOR`; Step 3 re-request switches to REST `user.type`)

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -1335,7 +1335,7 @@ The first pass of `--unattended` only split the classifier for Discussion items.
 
 **Root pattern:** the `[bot]` login suffix is present on some GitHub API surfaces and absent on others for the *same* account. REST `GET /pulls/{pr}/reviews` returns `user.login = "coderabbitai[bot]"` **with** the suffix and `user.type = "Bot"`; GraphQL and `gh pr view --json reviews` return `author.login = "coderabbitai"` **without** it. The `endswith("[bot]")` heuristic was written for REST-shaped logins but applied to the suffix-stripped `gh pr view` output, so it silently matched nothing. The bug failed *open* (bots passed through) rather than erroring, so it survived casual testing.
 
-**Rule:** Distinguish bots from humans by the explicit type field the API hands you — REST `user.type` (`Bot`/`User`) or GraphQL `author.__typename` (`Bot`/`User`) — never by pattern-matching the login string. Type fields are format-independent; login-suffix presence is coupled to which endpoint produced the string. Separately, always exclude the PR author from any re-request-reviewers list — GitHub rejects requesting review from a PR's own author.
+**Rule:** Distinguish bots from humans by the explicit type field the API hands you — REST `user.type` (`Bot`/`User`) or GraphQL `author.__typename` (`Bot`/`User`) — never by pattern-matching the login string. Type fields are format-independent; login-suffix presence is coupled to which endpoint produced the string. Separately, always exclude the PR author from any re-request-reviewers list — GitHub rejects requesting review from a PR's own author. And paginate the fetch (`gh api --paginate` + `jq -s '(add // [])'`): the reviews endpoint returns 30 per page, so a single-page read silently drops human reviewers sitting behind many bot reviews — the same *fail-open under-inclusion* the type-field fix was meant to close.
 
 **Bad pattern (login-suffix heuristic, endpoint-coupled, fails open):**
 ```bash
@@ -1346,8 +1346,8 @@ gh pr view $PR --json reviews \
 
 **Good pattern (explicit type field, endpoint-independent, author excluded):**
 ```bash
-gh api repos/{owner}/{repo}/pulls/$PR/reviews \
-  --jq "[.[].user | select(.type == \"User\") | .login] | map(select(. != \"$PR_AUTHOR\")) | unique | join(\",\")"
+gh api --paginate repos/{owner}/{repo}/pulls/$PR/reviews \
+  | jq -rs "(add // []) | [.[].user | select(.type == \"User\" and .login != \"$PR_AUTHOR\") | .login] | unique | join(\",\")"
 ```
 
-> Source: PR #233 babysit run; file: `plugins/dlc/skills/babysit/SKILL.md` (Step 0 extraction adds `PR_AUTHOR`; Step 3 re-request switches to REST `user.type`)
+> Source: PR #233 babysit run; file: `plugins/dlc/skills/babysit/SKILL.md` (Step 0 extraction adds `PR_AUTHOR`; Step 3 re-request switches to REST `user.type`). Pagination (`--paginate` + `jq -s '(add // [])'`) and the folded-`select` simplification added in PR #234 after five reviewers flagged the first-page-only fetch.

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -1350,4 +1350,4 @@ gh api --paginate repos/{owner}/{repo}/pulls/$PR/reviews \
   | jq -rs "(add // []) | [.[].user | select(.type == \"User\" and .login != \"$PR_AUTHOR\") | .login] | unique | join(\",\")"
 ```
 
-> Source: PR #233 babysit run; file: `plugins/dlc/skills/babysit/SKILL.md` (Step 0 extraction adds `PR_AUTHOR`; Step 3 re-request switches to REST `user.type`). Pagination (`--paginate` + `jq -s '(add // [])'`) and the folded-`select` simplification added in PR #234 after five reviewers flagged the first-page-only fetch.
+> Source: PR #233 babysit run; file: `plugins/dlc/skills/babysit/SKILL.md` (Step 0 extraction adds `PR_AUTHOR`; Step 3 re-request switches to REST `user.type`, paginates with `--paginate` + `jq -s '(add // [])'`, and folds the author exclusion into the `select`).

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -49,18 +49,18 @@ Create `.dev/dlc/` if it does not exist. Read the state file if it exists.
 If `$ARGUMENTS` contains a number, use it as PR_NUMBER and fetch that PR explicitly:
 
 ```bash
-gh pr view $PR_NUMBER --json number,title,headRefName,baseRefName,state,url,reviewDecision,mergeable
+gh pr view $PR_NUMBER --json number,title,headRefName,baseRefName,state,url,reviewDecision,mergeable,author
 ```
 
 If no number is provided, auto-detect from the current branch:
 
 ```bash
-gh pr view --json number,title,headRefName,baseRefName,state,url,reviewDecision,mergeable
+gh pr view --json number,title,headRefName,baseRefName,state,url,reviewDecision,mergeable,author
 ```
 
 If no PR exists for the current branch, stop silently.
 
-Extract and store: PR_NUMBER, PR_TITLE, PR_BRANCH, BASE_BRANCH, PR_STATE, PR_URL, REVIEW_DECISION, MERGEABLE.
+Extract and store: PR_NUMBER, PR_TITLE, PR_BRANCH, BASE_BRANCH, PR_STATE, PR_URL, REVIEW_DECISION, MERGEABLE, PR_AUTHOR (`.author.login`).
 
 **State gate:** If PR_STATE is not `OPEN`:
 - Write state key `closed:<state>`.
@@ -259,10 +259,13 @@ After pr-check completes, parse its output summary to extract these values:
 - **Pending-Human count and items**: parse the `Pending-Human: <n> — <item1_short>; <item2_short>; ...` line from the Step 6 summary. The `<n>` is the count; split the tail on `;` (trimming whitespace) to get the per-item short descriptions. If the line is absent, the count is 0. This line is emitted only under `--unattended`. Worked example: `Pending-Human: 2 — rename foo to bar; clarify async semantics of handler()` → `count=2`, `items=["rename foo to bar", "clarify async semantics of handler()"]`.
 - Whether pr-check pushed any commits (look for "Pushed" in the summary or a non-empty git diff from before)
 
-If pr-check pushed commits, re-request review from all prior reviewers. Filter out bot accounts (logins ending in `[bot]`):
+If pr-check pushed commits, re-request review from all prior **human** reviewers. Bots re-trigger automatically on every push, so only humans need an explicit nudge. Use the REST reviews endpoint's `user.type` field (`Bot` vs `User`) as the discriminator, and drop the PR author — you cannot request review from a PR's own author.
+
+> **Why not filter on the `[bot]` login suffix:** `gh pr view --json reviews` returns author logins *without* the `[bot]` suffix (e.g. `coderabbitai`, `gemini-code-assist`), so an `endswith("[bot]")` filter silently fails to exclude App-based review bots **and** leaves the PR author in the list. The REST `user.type` field is format-independent and reliably reports `Bot` vs `User`. (`gh api` substitutes `{owner}`/`{repo}` from the current repo automatically.)
 
 ```bash
-REVIEWERS=$(gh pr view $PR_NUMBER --json reviews --jq '[.reviews[].author.login | select(endswith("[bot]") | not)] | unique | join(",")')
+REVIEWERS=$(gh api repos/{owner}/{repo}/pulls/$PR_NUMBER/reviews \
+  --jq "[.[].user | select(.type == \"User\") | .login] | map(select(. != \"$PR_AUTHOR\")) | unique | join(\",\")")
 if [ -n "$REVIEWERS" ]; then
   gh pr edit $PR_NUMBER --add-reviewer "$REVIEWERS"
 fi

--- a/plugins/dlc/skills/babysit/SKILL.md
+++ b/plugins/dlc/skills/babysit/SKILL.md
@@ -261,11 +261,11 @@ After pr-check completes, parse its output summary to extract these values:
 
 If pr-check pushed commits, re-request review from all prior **human** reviewers. Bots re-trigger automatically on every push, so only humans need an explicit nudge. Use the REST reviews endpoint's `user.type` field (`Bot` vs `User`) as the discriminator, and drop the PR author — you cannot request review from a PR's own author.
 
-> **Why not filter on the `[bot]` login suffix:** `gh pr view --json reviews` returns author logins *without* the `[bot]` suffix (e.g. `coderabbitai`, `gemini-code-assist`), so an `endswith("[bot]")` filter silently fails to exclude App-based review bots **and** leaves the PR author in the list. The REST `user.type` field is format-independent and reliably reports `Bot` vs `User`. (`gh api` substitutes `{owner}`/`{repo}` from the current repo automatically.)
+> **Why not filter on the `[bot]` login suffix:** `gh pr view --json reviews` returns author logins *without* the `[bot]` suffix (e.g. `coderabbitai`, `gemini-code-assist`), so an `endswith("[bot]")` filter silently fails to exclude App-based review bots **and** leaves the PR author in the list. The REST `user.type` field is format-independent and reliably reports `Bot` vs `User`. `--paginate` fetches every page — the reviews endpoint returns 30 per page by default, so on a PR with many bot reviews a human reviewer on a later page isn't missed — and `jq -s '(add // [])'` merges the per-page arrays before filtering. (`gh api` substitutes `{owner}`/`{repo}` from the current repo automatically.)
 
 ```bash
-REVIEWERS=$(gh api repos/{owner}/{repo}/pulls/$PR_NUMBER/reviews \
-  --jq "[.[].user | select(.type == \"User\") | .login] | map(select(. != \"$PR_AUTHOR\")) | unique | join(\",\")")
+REVIEWERS=$(gh api --paginate repos/{owner}/{repo}/pulls/$PR_NUMBER/reviews \
+  | jq -rs "(add // []) | [.[].user | select(.type == \"User\" and .login != \"$PR_AUTHOR\") | .login] | unique | join(\",\")")
 if [ -n "$REVIEWERS" ]; then
   gh pr edit $PR_NUMBER --add-reviewer "$REVIEWERS"
 fi


### PR DESCRIPTION
## Problem

`dlc:babysit` Step 3 re-requests review from prior reviewers after a push, filtering out bots so only humans get pinged. The filter was:

\`\`\`bash
gh pr view \$PR_NUMBER --json reviews --jq '[.reviews[].author.login | select(endswith(\"[bot]\") | not)] | unique | join(\",\")'
\`\`\`

This misfired **two ways at once**:

1. **Bots not excluded.** `gh pr view --json reviews` returns author logins *without* the `[bot]` suffix (`coderabbitai`, `gemini-code-assist`, `copilot-pull-request-reviewer`, `chatgpt-codex-connector`), so `endswith("[bot]")` never matched and every App-based review bot passed through.
2. **PR author included.** The filter never excluded the PR author, so `gh pr edit --add-reviewer` would error (GitHub rejects requesting review from a PR's own author).

Net effect: the re-request either errored on the author or redundantly re-pinged bots that already auto-trigger on every push.

### Root cause

The `[bot]` login suffix is present on some GitHub API surfaces and absent on others for the *same* account: REST `GET /pulls/{pr}/reviews` returns `user.login = "coderabbitai[bot]"` **with** the suffix (and `user.type = "Bot"`), while `gh pr view --json reviews` returns it **without**. The heuristic was written for REST-shaped logins but applied to suffix-stripped output — and it failed *open* (bots passed through) rather than erroring, so it survived casual testing.

## Fix

- **Discriminator:** switch to the REST reviews endpoint's `user.type` field (`Bot`/`User`) — format-independent, unlike the login-suffix heuristic. Uses `gh api`'s `{owner}/{repo}` auto-placeholders, so no new owner/repo variables are needed.
- **Author exclusion:** Step 0 now extracts `PR_AUTHOR`; the re-request drops it from the list.
- **Learning:** documented the generalizable pattern (detect bots by API `type`/`__typename`, never by `[bot]` login suffix) in `docs/learnings.md`.

## Verification

On an all-bot PR (#233), the fixed filter correctly returns an empty reviewer list (nothing to re-request), instead of erroring on the author. `bun scripts/validate-plugins.mjs` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “re-request reviews” behavior by excluding the PR author and targeting only prior human reviewers.
  * Switched bot filtering to a more reliable account-type approach and ensured pagination is handled so reviewer lists are complete.

* **Documentation**
  * Updated babysit step instructions to reflect the safer review re-request workflow, including pagination and bot/user filtering guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->