### PR TITLE
feat(feature-discovery): add multi-agent roadmap discovery plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -208,6 +208,26 @@
         "git-ops",
         "github-issues"
       ]
+    },
+    {
+      "name": "feature-discovery",
+      "description": "Discover what to build next: map the current product from its repo, research competitors, ideate across value lenses, dedup and shortlist, then spec and adversarially validate a ranked roadmap via a deterministic multi-agent Workflow pipeline",
+      "version": "2.6.2",
+      "source": "./plugins/feature-discovery",
+      "category": "productivity",
+      "author": {
+        "name": "rube-de",
+        "url": "https://github.com/rube-de"
+      },
+      "keywords": [
+        "feature-discovery",
+        "roadmap",
+        "product-strategy",
+        "competitor-analysis",
+        "gap-analysis",
+        "ideation",
+        "feature-spec"
+      ]
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@
 | ci-review | Code Review | `/ci-review` |
 | jules-review | Code Review | `/jules-review` |
 | dlc | Quality | `/dlc`, `/dlc:security`, `/dlc:quality`, `/dlc:perf`, `/dlc:test`, `/dlc:pr-check`, `/dlc:pr-validity`, `/dlc:git-ops`, `/dlc:babysit` |
+| feature-discovery | Productivity | `/feature-discovery` |
 
 ## Navigation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A monorepo of [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins and [agent skills](https://agentskills.io).
 
-[![Plugins](https://img.shields.io/badge/plugins-10-green.svg)](#plugins)
+[![Plugins](https://img.shields.io/badge/plugins-11-green.svg)](#plugins)
 [![License](https://img.shields.io/badge/license-MIT-yellow.svg)](./LICENSE)
 
 ## Plugins
@@ -19,6 +19,7 @@ A monorepo of [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plug
 | [ci-review](./plugins/ci-review/) | Code Review | Plugin or Skill | CI-optimized multi-agent code review with confidence scoring and atomic GitHub PR review posting |
 | [jules-review](./plugins/jules-review/) | Code Review | Plugin or Skill | Review Jules AI agent PRs using council with smart quick/full mode |
 | [dlc](./plugins/dlc/) | Quality | Plugin or Skill | Dev Life Cycle quality gates: security scans, code quality, performance analysis, test coverage, and PR review compliance |
+| [feature-discovery](./plugins/feature-discovery/) | Productivity | Plugin only | Multi-agent roadmap discovery: map the product, research competitors, ideate across value lenses, then rank and spec a validated roadmap (requires the Workflow tool) |
 
 > **Plugin vs Skill**: Plugins use the full Claude Code plugin system (hooks, agents, commands, scripts). Skills install only SKILL.md definitions via [skills.sh](https://skills.sh). Plugins that rely on hooks, commands, or agent definitions need plugin install. See each plugin's README for details.
 
@@ -63,9 +64,10 @@ claude plugin install oasis-dev@rube-cc-skills
 claude plugin install jules-review@rube-cc-skills
 claude plugin install ci-review@rube-cc-skills
 claude plugin install dlc@rube-cc-skills
+claude plugin install feature-discovery@rube-cc-skills
 
 # Or install all at once
-for p in council cdt pm plugin-dev temporal doppler oasis-dev ci-review jules-review dlc; do claude plugin install "$p@rube-cc-skills"; done
+for p in council cdt pm plugin-dev temporal doppler oasis-dev ci-review jules-review dlc feature-discovery; do claude plugin install "$p@rube-cc-skills"; done
 
 # Restart Claude Code to activate
 claude
@@ -143,7 +145,7 @@ To make plugins available to Claude cloud agents, CI runners, or teammates witho
 claude plugin marketplace add rube-de/cc-skills
 
 # 2. Install plugins at project scope
-for p in council cdt pm plugin-dev temporal doppler oasis-dev ci-review jules-review dlc; do
+for p in council cdt pm plugin-dev temporal doppler oasis-dev ci-review jules-review dlc feature-discovery; do
   claude plugin install "$p@rube-cc-skills" --scope project
 done
 
@@ -193,9 +195,11 @@ cc-skills/
 │   │   └── skills/          # ci-review + references
 │   ├── jules-review/        # Jules PR review via council
 │   │   └── skills/          # jules-review + references
-│   └── dlc/                 # Dev lifecycle quality gates
-│       ├── scripts/         # Quality gate scripts
-│       └── skills/          # dlc, security, quality, perf, test, pr-check, pr-validity, git-ops
+│   ├── dlc/                 # Dev lifecycle quality gates
+│   │   ├── scripts/         # Quality gate scripts
+│   │   └── skills/          # dlc, security, quality, perf, test, pr-check, pr-validity, git-ops
+│   └── feature-discovery/   # Multi-agent roadmap discovery
+│       └── skills/          # feature-discovery + workflow script
 ├── scripts/
 │   └── validate-plugins.mjs # Plugin validation
 ├── CLAUDE.md                # Claude Code context
@@ -218,7 +222,7 @@ cd ~/.claude/plugins/marketplaces/rube-cc-skills && git pull
 claude plugin install council@rube-cc-skills
 
 # Or reinstall all plugins
-for p in council cdt pm plugin-dev temporal doppler oasis-dev ci-review jules-review dlc; do
+for p in council cdt pm plugin-dev temporal doppler oasis-dev ci-review jules-review dlc feature-discovery; do
   claude plugin install "$p@rube-cc-skills"
 done
 
@@ -231,7 +235,7 @@ For **project-scoped** plugins, add `--scope project` and re-commit:
 ```bash
 cd ~/.claude/plugins/marketplaces/rube-cc-skills && git pull
 
-for p in council cdt pm plugin-dev temporal doppler oasis-dev ci-review jules-review dlc; do
+for p in council cdt pm plugin-dev temporal doppler oasis-dev ci-review jules-review dlc feature-discovery; do
   claude plugin install "$p@rube-cc-skills" --scope project
 done
 

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -1385,3 +1385,36 @@ Workflow({ scriptPath: "${CLAUDE_SKILL_DIR}/scripts/feature-discovery.workflow.j
 Corollary: `allowed-tools` is additive pre-approval, never a block — a misspelled tool name there triggers a permission prompt rather than silently failing, so it won't manifest as a "dead skill." The dead-skill failure mode comes from the path variable, not the tool list.
 
 > Source: `feature-discovery` plugin port (SKILL.md `scripts/feature-discovery.workflow.js` invocation); verified against Claude Code skills reference (`code.claude.com/docs/en/skills.md`, `plugins-reference.md`).
+
+### Guard every fan-out result before the next phase consumes it - a happy-path return isn't proof the data is real
+
+`feature-discovery.workflow.js`'s 5-phase pipeline fans out N agents per phase (7 ideators, up to 12 spec+validate pairs) and feeds each phase's output into the next. Across three rounds of PR review, five distinct instances of the same root bug surfaced: a phase's output could be empty, falsy, or silently truncated, and the next phase would still run on it and still return a success-shaped `{ report, meta, counts }` object - no `error` key, just a degraded or invented result.
+
+- Empty ideation (`allIdeas.length === 0`) still invoked the curator, which could invent a shortlist from the inventory rather than report the failure.
+- A validator's `.then((v) => ({ feature: f, spec, verdict: v }))` wrapped even a falsy `v` in a truthy object, so `specced.filter(Boolean)` never dropped a failed validation - the `empty-validated-results` guard added to catch "every validator failed" couldn't fire, because the array was never actually empty.
+- A `scope: 'competitor'` run whose segment planner failed silently fell back to a mixed/internal-shaped run while still telling ideators to "focus on competitor capabilities" and the synthesizer to "report gaps versus competitors" - producing a report that either omits the requested analysis or invents unsupported competitor evidence.
+- A malformed-JSON `args` string was caught and coerced to `{}`, so both `scope` and `depth` silently took their valid defaults and bypassed the `invalid-args` contract built specifically to catch bad input.
+- A later fix that bounded large JSON payloads at a fixed character budget (to stop token cost compounding across the fan-out) was applied uniformly, including to the two collections whose *individual items* are the thing being ranked or selected (`allIdeas` for the curator, `clean` for the synthesizer). Since items are concatenated in deterministic order, truncating the JSON string silently dropped every candidate after the cut - while the reported count (`rawIdeas`, `shortlisted`) still reflected the untruncated total. An "exhaustive" ranking then depended on array order.
+
+**Root pattern:** in a multi-phase agent pipeline, any point where one phase's output feeds the next is a place where "the call returned" and "the call returned something real and complete" are different claims. A filter like `.filter(Boolean)` or a bounding helper like `boundedJson()` can be correctness-positive for one axis (dropping a null result, capping token cost) and correctness-negative for another (silently keeping a falsy wrapper as truthy; silently keeping only the first items of a ranked collection) if applied without checking how it interacts with what downstream code assumes about completeness.
+
+**Rule:** After every fan-out or pipeline stage, verify the *substance* of the result, not just its shape - `!!result` is not "this result is usable." When adding a bounding/truncation helper to control cost, apply it only to reference/grounding context, never to a collection whose individual items are enumerated, ranked, or selected downstream; those need per-item compaction or an explicit size-aware batching strategy instead, so item *count* stays truthful even when content shrinks. When a value coming out of user input, a parse, or an agent call could be genuinely absent, present-but-empty, or present-but-wrong-shape, branch on each case explicitly and return a distinct, honestly-named `error` code for it - resist the pull to catch-and-default, which trades a loud failure for a silent, more expensive one.
+
+**Bad pattern (fan-out result trusted by shape, not substance):**
+```js
+const specced = await pipeline(features, specStage, (spec, f) =>
+  validateAgent(...).then((v) => ({ feature: f, spec, verdict: v })) // truthy wrapper even if v is falsy
+)
+const clean = specced.filter(Boolean) // never drops a failed validation
+```
+
+**Good pattern (only construct the wrapper when the inner result is real):**
+```js
+const specced = await pipeline(features, specStage, (spec, f) =>
+  validateAgent(...).then((v) => (v ? { feature: f, spec, verdict: v } : null))
+)
+const clean = specced.filter(Boolean) // now actually drops failed validations
+if (!clean.length) return { error: 'empty-validated-results', shortlisted: features.length }
+```
+
+> Source: PR #236 (https://github.com/rube-de/cc-skills/pull/236), review rounds 2-4; file: `plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js` (empty-ideation guard, empty-validated-results guard + validator null-fix, competitor-research-failed guard, invalid-args-on-malformed-JSON fix, and reverting `boundedJson()` on `allIdeas`/`clean`).

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -1449,3 +1449,40 @@ node /tmp/repro.js           # SyntaxError: Illegal return statement - the real 
 ```
 
 > Source: PR #236 (https://github.com/rube-de/cc-skills/pull/236), review rounds 1, 4, and 6 (chatgpt-codex-connector, copilot-pull-request-reviewer, and qodo-code-review each raised a variant of the underlying "illegal top-level return" claim; coderabbitai independently re-ran the repro with an explicit `"type": "module"` package.json via its own sandbox and caught the version/config-dependence this entry now documents); file: `plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js` (top-of-file comment documents the harness's static-extraction execution model).
+
+### A per-item compaction fix must bound every dimension that can grow, not just the one the current bug report names
+
+`boundedCompetitorJson`'s per-record compaction (added to stop a single oversized competitor from being dropped wholesale by the per-segment character budget) went through three separate review-cycle fixes in direct succession, each one closing a different dimension of the same underlying problem:
+
+1. First fix: split the character budget evenly across segments instead of one whole-array slice, so no segment was entirely excluded once an earlier one consumed the budget.
+2. Second fix: within a segment, stop char-slicing the serialized JSON (which could cut a competitor record mid-string) and instead drop whole trailing records - but a single record whose own JSON exceeded the *entire* per-segment budget still got dropped on the first loop iteration, leaving `competitors: []`.
+3. Third fix: compact an oversized record instead of dropping it, by capping `notableFeatures`/`lessonsForUs` to 3 entries each - but capping array *length* doesn't bound array *content*; a single long string entry (or a long `whatItIs`) could still push the compacted record over budget.
+4. Fourth fix (the one that actually closed the class): cap every string field individually to a fixed character length, not just array length. This gives a calculable worst-case size per compacted record independent of the input, which is the only way to guarantee termination - every prior fix bounded one growth dimension while leaving another unbounded.
+
+Each of the three intermediate fixes was individually correct and reviewer-verified against real code, but each was also incomplete in a way a reviewer caught on the very next cycle. In hindsight, the question "what are ALL the ways this data structure's serialized size can grow?" (item count AND per-item string length AND nesting) should have been asked once, up front, rather than being discovered one dimension at a time across three review rounds.
+
+**Rule:** When writing a compaction/truncation helper for arbitrary agent-generated data, enumerate every axis the structure can grow along (array length, individual string length, nested object depth) before implementing, and bound all of them in the same pass. A fix that closes only the axis the current bug report names is a strong signal there's a sibling axis still open - don't wait for the next review cycle to find it; ask "is this now a *provable*, input-independent bound, or does it just handle the specific shape the reviewer described?"
+
+**Bad pattern (bounds one axis, leaves size unbounded on another):**
+```js
+const compactCompetitor = (c) => {
+  const cap = (arr) => (arr && arr.length > 3 ? arr.slice(0, 3) : arr) // bounds count...
+  return { ...c, notableFeatures: cap(c.notableFeatures), lessonsForUs: cap(c.lessonsForUs) }
+  // ...but a single very long string in a kept entry, or in `whatItIs`/`name`/`url`,
+  // is completely unbounded - the record can still blow the budget.
+}
+```
+
+**Good pattern (every axis that can grow gets a fixed cap, giving a provable worst case):**
+```js
+const MAX_FIELD_CHARS = 200
+const truncateField = (s) => (typeof s === 'string' && s.length > MAX_FIELD_CHARS ? `${s.slice(0, MAX_FIELD_CHARS)}...` : s)
+const compactCompetitor = (c) => {
+  const cap = (arr) => ((arr && arr.length > 3 ? arr.slice(0, 3) : arr) || []).map(truncateField)
+  return { ...c, name: truncateField(c.name), url: truncateField(c.url), whatItIs: truncateField(c.whatItIs), notableFeatures: cap(c.notableFeatures), lessonsForUs: cap(c.lessonsForUs) }
+  // worst case is now ~5 fields x 200 chars + JSON overhead - fixed and calculable,
+  // independent of how verbose the original agent output was.
+}
+```
+
+> Source: PR #236 (https://github.com/rube-de/cc-skills/pull/236), review rounds 12-15 (chatgpt-codex-connector, three consecutive rounds each finding a deeper layer of the same `boundedCompetitorJson`/`compactCompetitor` bug); file: `plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js`.

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -1363,3 +1363,25 @@ The council `codex-consultant` documented `codex "prompt"` and `codex --quiet "p
 **A second, sharper distinction surfaced by PR review on the same file: "don't force a choice" only applies to preference axes (model, effort). Safety contracts are not a preference axis.** `codex-consultant.md` promises "NEVER auto-fix or modify files," but the bare `codex exec` invocations didn't pass `--sandbox read-only` — so a caller whose global config defaults to `workspace-write` or `danger-full-access` would silently let Codex write to disk during a review the agent explicitly advertises as read-only. Leaving *model* unset respects the user's preference; leaving *sandbox* unset outsources a promise the agent file itself makes to the caller's unrelated config. Enforce contracts your own prompt states in prose at the CLI level too — prose-only enforcement is not enforcement.
 
 > Source: PR #235 (https://github.com/rube-de/cc-skills/pull/235); file: `plugins/council/agents/codex-consultant.md` (all invocations → `codex exec --sandbox read-only`, `--quiet` block removed, no model/effort pinned); cheat-sheet `plugins/council/skills/council/QUICK-REFERENCE.md`.
+
+### Reference bundled scripts from a SKILL.md body with `${CLAUDE_SKILL_DIR}`, not `${CLAUDE_PLUGIN_ROOT}`
+
+The `feature-discovery` skill instructs the model to invoke the `Workflow` tool with the bundled engine's path: `Workflow({ scriptPath: "…/scripts/feature-discovery.workflow.js" })`. The first draft used `${CLAUDE_PLUGIN_ROOT}/skills/feature-discovery/scripts/…`, copying the pattern seen in `hooks.json` and agent frontmatter across the repo. That path never resolves from a skill body: `${CLAUDE_PLUGIN_ROOT}` is a **harness-config-only** substitution (documented for `hooks.json`/`.mcp.json` command values), and it is **absent** from the skill-body substitution set. The model would have emitted the literal unexpanded `${CLAUDE_PLUGIN_ROOT}/…` string as the tool argument, the file wouldn't be found, and the skill would be dead on first use for every installed user. Static gates miss this entirely — `validate-plugins.mjs` only checks frontmatter + marketplace structure, and `node --check` only validates the engine's own syntax.
+
+**Root pattern:** the two variables live in different substitution tables. `${CLAUDE_PLUGIN_ROOT}` is expanded by the harness inside config files it processes itself; a SKILL.md body is rendered with a *different* set — `$ARGUMENTS`, `${CLAUDE_SESSION_ID}`, `${CLAUDE_EFFORT}`, `${CLAUDE_SKILL_DIR}`, `${CLAUDE_PROJECT_DIR}`. Render-time substitution happens *before* the SKILL.md text enters the conversation, so a variable from the skill-body table reaches even non-shell contexts (tool-call argument values, `allowed-tools` frontmatter) already resolved. A variable outside that table does not.
+
+**Rule:** To hand a bundled file's path to a tool (or a shell command) from a SKILL.md body, use `${CLAUDE_SKILL_DIR}` — the directory containing that `SKILL.md` (for plugin skills, the skill's subdirectory *within* the plugin, not the plugin root). Reserve `${CLAUDE_PLUGIN_ROOT}` for `hooks.json` and agent/MCP config. Because `${CLAUDE_SKILL_DIR}` already points at the skill dir, do not re-append the `skills/<name>/` segment.
+
+**Bad pattern (harness-config variable in a skill body — emitted literally, file not found):**
+```
+Workflow({ scriptPath: "${CLAUDE_PLUGIN_ROOT}/skills/feature-discovery/scripts/feature-discovery.workflow.js", … })
+```
+
+**Good pattern (skill-body variable, resolves at render time before the model emits the arg):**
+```
+Workflow({ scriptPath: "${CLAUDE_SKILL_DIR}/scripts/feature-discovery.workflow.js", … })
+```
+
+Corollary: `allowed-tools` is additive pre-approval, never a block — a misspelled tool name there triggers a permission prompt rather than silently failing, so it won't manifest as a "dead skill." The dead-skill failure mode comes from the path variable, not the tool list.
+
+> Source: `feature-discovery` plugin port (SKILL.md `scripts/feature-discovery.workflow.js` invocation); verified against Claude Code skills reference (`code.claude.com/docs/en/skills.md`, `plugins-reference.md`).

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -1423,26 +1423,29 @@ if (!clean.length) return { error: 'empty-validated-results', shortlisted: featu
 
 `feature-discovery.workflow.js` combines `export const meta = {...}` with several top-level early-return guards (`return { error: '...' }` outside any function). Three separate reviewers, across two review rounds, flagged this as an "illegal top-level return" bug, each time citing `node --check <file>` passing as the counter-evidence that the file was fine.
 
-`node --check` passing is not that evidence. An isolated repro combining `export const x = 1` with a later top-level `return` passes `node --check` silently, but running the *same file* with plain `node <file>.js` throws `SyntaxError: Illegal return statement` - the `export` keyword triggers Node's unflagged ESM auto-detection, and top-level `return` is illegal under ESM. `node --check` does not perform (or does not act on) that same auto-detection, so it misses a syntax error that real execution would hit.
+`node --check` passing is not that evidence - **but only in the specific config this repo actually has**: a plain `.js` file with no `"type": "module"` anywhere in its package.json chain, relying on Node's *auto-detection* of ESM syntax rather than an explicit declaration. In that config (verified on Node v22.23.1 and, per a reviewer's independent check, v24.15.0), an isolated repro combining `export const x = 1` with a later top-level `return` passes `node --check` silently, but running the *same file* with plain `node <file>.js` throws `SyntaxError: Illegal return statement`. Add an explicit `"type": "module"` to package.json, though, and the gap closes - `node --check` then throws the same `SyntaxError` that real execution does, because there's no auto-detection left to do. This repo's root `package.json` has no `type` field (defaults to CommonJS) and `feature-discovery.workflow.js` has no package.json of its own, so the auto-detection gap is real for this file - but the claim is config-dependent, not a general property of `node --check`.
 
 The actual reason `feature-discovery.workflow.js` is safe has nothing to do with `node --check`: the Workflow tool statically extracts the `meta` object from source text and executes the rest of the file's body inside its own async wrapper - it never loads the file as a real Node module, so Node's ESM top-level-return restriction never applies. That claim is corroborated by the file's own history of repeated successful live Workflow-tool runs, not by any static check.
 
-**Rule:** When a harness executes a script under different rules than plain `node <file>.js` (injected globals, top-level `await`/`return`, non-standard module semantics), do not cite `node --check` passing as proof the script is valid for that harness. Build an isolated repro of the specific syntax in question and run it with real `node` execution, not just `--check`, before trusting either the code or a reviewer's "invalid syntax" claim - then document *why* the harness accepts syntax plain Node would reject, so the next reviewer with the same instinct has a real answer instead of another round of the same false positive.
+**Rule:** When a harness executes a script under different rules than plain `node <file>.js` (injected globals, top-level `await`/`return`, non-standard module semantics), do not cite `node --check` passing as proof the script is valid for that harness - and when documenting a `node --check` gap, name the Node version and the module-type config it was observed under, since `--check`'s ESM auto-detection has changed across Node versions and a `"type": "module"` declaration changes the result entirely. Build an isolated repro of the specific syntax in question and run it with real `node` execution, not just `--check`, before trusting either the code or a reviewer's "invalid syntax" claim - then document *why* the harness accepts syntax plain Node would reject, so the next reviewer with the same instinct has a real answer instead of another round of the same false positive.
 
-**Bad pattern (treating a weaker check as proof):**
+**Bad pattern (treating a weaker check as proof, no config named):**
 ```bash
 node --check feature-discovery.workflow.js   # passes
 # ...therefore the top-level `return` statements must be fine.
 ```
 
-**Good pattern (verify against the thing that actually matters):**
+**Good pattern (verify against the thing that actually matters, config stated):**
 ```bash
-# Isolated repro of the exact construct in question:
+# Isolated repro of the exact construct, in this repo's actual config
+# (plain .js, no "type": "module" anywhere in the package.json chain):
 printf 'export const x = 1\nreturn 1\n' > /tmp/repro.js
-node --check /tmp/repro.js   # passes silently - proves nothing
+node --check /tmp/repro.js   # passes silently under auto-detection - proves nothing
 node /tmp/repro.js           # SyntaxError: Illegal return statement - the real signal
+# Note: with an explicit "type": "module" in package.json, `node --check`
+# throws the same error - the gap is auto-detection-specific, not general.
 # Then explain the harness's actual execution model (static meta-extraction,
 # no real Node module load) rather than leaning on the weaker check.
 ```
 
-> Source: PR #236 (https://github.com/rube-de/cc-skills/pull/236), review rounds 1 and 4 (chatgpt-codex-connector, copilot-pull-request-reviewer, qodo-code-review each raised a variant of this claim); file: `plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js` (top-of-file comment documents the harness's static-extraction execution model).
+> Source: PR #236 (https://github.com/rube-de/cc-skills/pull/236), review rounds 1, 4, and 6 (chatgpt-codex-connector, copilot-pull-request-reviewer, and qodo-code-review each raised a variant of the underlying "illegal top-level return" claim; coderabbitai independently re-ran the repro with an explicit `"type": "module"` package.json via its own sandbox and caught the version/config-dependence this entry now documents); file: `plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js` (top-of-file comment documents the harness's static-extraction execution model).

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -1366,7 +1366,7 @@ The council `codex-consultant` documented `codex "prompt"` and `codex --quiet "p
 
 ### Reference bundled scripts from a SKILL.md body with `${CLAUDE_SKILL_DIR}`, not `${CLAUDE_PLUGIN_ROOT}`
 
-The `feature-discovery` skill instructs the model to invoke the `Workflow` tool with the bundled engine's path: `Workflow({ scriptPath: "…/scripts/feature-discovery.workflow.js" })`. The first draft used `${CLAUDE_PLUGIN_ROOT}/skills/feature-discovery/scripts/…`, copying the pattern seen in `hooks.json` and agent frontmatter across the repo. That path never resolves from a skill body: `${CLAUDE_PLUGIN_ROOT}` is a **harness-config-only** substitution (documented for `hooks.json`/`.mcp.json` command values), and it is **absent** from the skill-body substitution set. The model would have emitted the literal unexpanded `${CLAUDE_PLUGIN_ROOT}/…` string as the tool argument, the file wouldn't be found, and the skill would be dead on first use for every installed user. Static gates miss this entirely — `validate-plugins.mjs` only checks frontmatter + marketplace structure, and `node --check` only validates the engine's own syntax.
+The `feature-discovery` skill instructs the model to invoke the `Workflow` tool with the bundled engine's path: `Workflow({ scriptPath: "…/scripts/feature-discovery.workflow.js" })`. The first draft used `${CLAUDE_PLUGIN_ROOT}/skills/feature-discovery/scripts/…`, copying the pattern seen in `hooks.json` and agent frontmatter across the repo. That path never resolves from a skill body: `${CLAUDE_PLUGIN_ROOT}` is a **harness-config-only** substitution (documented for `hooks.json`/`.mcp.json` command values), and it is **absent** from the skill-body substitution set. The model would have emitted the literal unexpanded `${CLAUDE_PLUGIN_ROOT}/…` string as the tool argument, the file wouldn't be found, and the skill would be dead on first use for every installed user. Static gates miss this entirely — `validate-plugins.mjs` only checks frontmatter + marketplace structure, and `node --check` only performs a parse-level syntax check (and, per the harness-execution-model entry below, not even a fully reliable one for this specific engine).
 
 **Root pattern:** the two variables live in different substitution tables. `${CLAUDE_PLUGIN_ROOT}` is expanded by the harness inside config files it processes itself; a SKILL.md body is rendered with a *different* set — `$ARGUMENTS`, `${CLAUDE_SESSION_ID}`, `${CLAUDE_EFFORT}`, `${CLAUDE_SKILL_DIR}`, `${CLAUDE_PROJECT_DIR}`. Render-time substitution happens *before* the SKILL.md text enters the conversation, so a variable from the skill-body table reaches even non-shell contexts (tool-call argument values, `allowed-tools` frontmatter) already resolved. A variable outside that table does not.
 
@@ -1418,3 +1418,31 @@ if (!clean.length) return { error: 'empty-validated-results', shortlisted: featu
 ```
 
 > Source: PR #236 (https://github.com/rube-de/cc-skills/pull/236), review rounds 2-4; file: `plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js` (empty-ideation guard, empty-validated-results guard + validator null-fix, competitor-research-failed guard, invalid-args-on-malformed-JSON fix, and reverting `boundedJson()` on `allIdeas`/`clean`).
+
+### `node --check` passing is not proof a harness-executed script is safe - verify against real `node` execution
+
+`feature-discovery.workflow.js` combines `export const meta = {...}` with several top-level early-return guards (`return { error: '...' }` outside any function). Three separate reviewers, across two review rounds, flagged this as an "illegal top-level return" bug, each time citing `node --check <file>` passing as the counter-evidence that the file was fine.
+
+`node --check` passing is not that evidence. An isolated repro combining `export const x = 1` with a later top-level `return` passes `node --check` silently, but running the *same file* with plain `node <file>.js` throws `SyntaxError: Illegal return statement` - the `export` keyword triggers Node's unflagged ESM auto-detection, and top-level `return` is illegal under ESM. `node --check` does not perform (or does not act on) that same auto-detection, so it misses a syntax error that real execution would hit.
+
+The actual reason `feature-discovery.workflow.js` is safe has nothing to do with `node --check`: the Workflow tool statically extracts the `meta` object from source text and executes the rest of the file's body inside its own async wrapper - it never loads the file as a real Node module, so Node's ESM top-level-return restriction never applies. That claim is corroborated by the file's own history of repeated successful live Workflow-tool runs, not by any static check.
+
+**Rule:** When a harness executes a script under different rules than plain `node <file>.js` (injected globals, top-level `await`/`return`, non-standard module semantics), do not cite `node --check` passing as proof the script is valid for that harness. Build an isolated repro of the specific syntax in question and run it with real `node` execution, not just `--check`, before trusting either the code or a reviewer's "invalid syntax" claim - then document *why* the harness accepts syntax plain Node would reject, so the next reviewer with the same instinct has a real answer instead of another round of the same false positive.
+
+**Bad pattern (treating a weaker check as proof):**
+```bash
+node --check feature-discovery.workflow.js   # passes
+# ...therefore the top-level `return` statements must be fine.
+```
+
+**Good pattern (verify against the thing that actually matters):**
+```bash
+# Isolated repro of the exact construct in question:
+printf 'export const x = 1\nreturn 1\n' > /tmp/repro.js
+node --check /tmp/repro.js   # passes silently - proves nothing
+node /tmp/repro.js           # SyntaxError: Illegal return statement - the real signal
+# Then explain the harness's actual execution model (static meta-extraction,
+# no real Node module load) rather than leaning on the weaker check.
+```
+
+> Source: PR #236 (https://github.com/rube-de/cc-skills/pull/236), review rounds 1 and 4 (chatgpt-codex-connector, copilot-pull-request-reviewer, qodo-code-review each raised a variant of this claim); file: `plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js` (top-of-file comment documents the harness's static-extraction execution model).

--- a/plugins/feature-discovery/LICENSE
+++ b/plugins/feature-discovery/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 fabianhug
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/feature-discovery/README.md
+++ b/plugins/feature-discovery/README.md
@@ -19,8 +19,11 @@ your opt-in to a heavyweight fan-out of roughly 35-40 sub-agents at exhaustive
 depth. If the Workflow tool is unavailable in your environment, the skill cannot
 run. For `scope: competitor` or `mixed` runs, your session also needs `WebSearch`
 and `WebFetch` available - Workflow sub-agents run in the background and can't
-prompt for tool approval, so competitor research fails loudly (`competitor-research-failed`)
-rather than silently if those tools aren't pre-approved.
+prompt for tool approval. A `competitor`-scoped run fails loudly
+(`competitor-research-failed`) if those tools aren't pre-approved, since it has
+no fallback without competitor data. A `mixed`-scoped run degrades gracefully
+instead, falling back to an internal-only framing rather than asking for
+competitor precedent that isn't there.
 
 ## Installation
 

--- a/plugins/feature-discovery/README.md
+++ b/plugins/feature-discovery/README.md
@@ -17,7 +17,10 @@ idea traces to a concrete product gap or a named competitor feature.
 Requires the **Workflow** tool (multi-agent orchestration). Invoking the skill is
 your opt-in to a heavyweight fan-out of roughly 35-40 sub-agents at exhaustive
 depth. If the Workflow tool is unavailable in your environment, the skill cannot
-run.
+run. For `scope: competitor` or `mixed` runs, your session also needs `WebSearch`
+and `WebFetch` available - Workflow sub-agents run in the background and can't
+prompt for tool approval, so competitor research fails loudly (`competitor-research-failed`)
+rather than silently if those tools aren't pre-approved.
 
 ## Installation
 

--- a/plugins/feature-discovery/README.md
+++ b/plugins/feature-discovery/README.md
@@ -69,11 +69,16 @@ work, not a ten-times-a-day tool. For three quick ideas, ask an agent directly. 
 
 ## Credit
 
-Ported from the open-source
+Adapted from the open-source
 [feature-discovery-skill](https://github.com/fabianhug/feature-discovery-skill) by
-Fabian Hug ([0xfabs](https://x.com/0xfabs)), MIT licensed. The Workflow engine is
-kept verbatim; the packaging, frontmatter, script path, and result handling were
-adapted for this marketplace.
+Fabian Hug ([0xfabs](https://x.com/0xfabs)), MIT licensed, as a fork rather than a
+verbatim port. Beyond packaging, frontmatter, script path, and result handling, the
+bundled engine also adds: argument validation, schema bounds (min/max item counts,
+required fields) on the segment/shortlist/spec/verdict schemas, hard-fail guards for
+empty ground/ideation/shortlist/validation/synthesis results, character-budgeted
+(and per-record-compacted) competitor research, and partial-fan-out coverage
+reporting (competitor tracks, ideation lenses, spec/validate pairs) so silent data
+loss surfaces in the report instead of being hidden.
 
 ## License
 

--- a/plugins/feature-discovery/README.md
+++ b/plugins/feature-discovery/README.md
@@ -1,7 +1,7 @@
 # feature-discovery
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)](https://docs.anthropic.com/en/docs/claude-code)
 
 Turns "what should we build next?" into a researched, ranked roadmap instead of one
 agent guessing. Fans out a deterministic multi-agent Workflow that maps the current

--- a/plugins/feature-discovery/README.md
+++ b/plugins/feature-discovery/README.md
@@ -1,0 +1,74 @@
+# feature-discovery
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
+
+Turns "what should we build next?" into a researched, ranked roadmap instead of one
+agent guessing. Fans out a deterministic multi-agent Workflow that maps the current
+product from its repo, researches competitors, ideates across seven value lenses,
+dedups and shortlists, then specs and adversarially validates the winners. Every
+idea traces to a concrete product gap or a named competitor feature.
+
+> **Distinct from `pm:brainstorm`.** Brainstorm goes deep on one feature; this goes
+> wide across the whole product and returns a ranked roadmap of many candidates.
+
+## Prerequisite
+
+Requires the **Workflow** tool (multi-agent orchestration). Invoking the skill is
+your opt-in to a heavyweight fan-out of roughly 35-40 sub-agents at exhaustive
+depth. If the Workflow tool is unavailable in your environment, the skill cannot
+run.
+
+## Installation
+
+```bash
+claude plugin install feature-discovery@rube-cc-skills
+```
+
+## Usage
+
+Run it with `/feature-discovery`, or just ask what to build next. The skill maps
+the repo in the current working directory, so run it from the product's codebase.
+
+### Example Triggers
+
+- "What should we build next?"
+- "Do a gap analysis and competitor analysis for this product"
+- "What are we missing / where can we add value?"
+- "Ideate features across the whole product and spec the best ones"
+
+### Pipeline
+
+| Phase | What happens |
+|-------|--------------|
+| Ground | Map the current product from the repo; plan competitor segments and research each via web search |
+| Ideate | One agent per value lens, forbidden from proposing anything that already exists |
+| Shortlist | A curator dedups, drops the trivial and already-built, ranks by value-to-effort |
+| Spec & Validate | Spec each finalist, then an adversarial skeptic returns build / maybe / drop with a confidence score |
+| Synthesize | A single ranked-roadmap Markdown report: exec summary, gaps, roadmap table, full specs, dropped ideas |
+
+### Args
+
+| key | values | default | effect |
+|-----|--------|---------|--------|
+| `product` | free text one-liner | mapped from the repo | Description of the product; inferred from code/README/docs if omitted |
+| `scope` | `mixed` \| `internal` \| `competitor` | `mixed` | `internal` skips competitor research; `competitor` hunts for capabilities rivals have |
+| `depth` | `exhaustive` \| `quick` | `exhaustive` | `exhaustive` = 4 competitor tracks, 7 lenses, top 8-12. `quick` = 2 tracks, 4 lenses, top 5-6 |
+
+## Caveat
+
+35-40 agents at full depth. It is for when you sit down to plan the next chunk of
+work, not a ten-times-a-day tool. For three quick ideas, ask an agent directly. Use
+`depth: quick` for a faster, cheaper first pass.
+
+## Credit
+
+Ported from the open-source
+[feature-discovery-skill](https://github.com/fabianhug/feature-discovery-skill) by
+Fabian Hug ([0xfabs](https://x.com/0xfabs)), MIT licensed. The Workflow engine is
+kept verbatim; the packaging, frontmatter, script path, and result handling were
+adapted for this marketplace.
+
+## License
+
+MIT

--- a/plugins/feature-discovery/skills/feature-discovery/SKILL.md
+++ b/plugins/feature-discovery/skills/feature-discovery/SKILL.md
@@ -88,8 +88,9 @@ does (see
    It runs in the background and returns `{ report, meta, counts }`, where `report`
    is finished Markdown.
 3. If the result has an `error` key - currently `invalid-args`, `product-mapping-failed`,
-   `empty-ideation`, `empty-shortlist`, `empty-validated-results`, or `synthesis-failed`,
-   though the script may add others later - treat it as a failed run: say so plainly
+   `competitor-research-failed`, `empty-ideation`, `empty-shortlist`,
+   `empty-validated-results`, or `synthesis-failed`, though the script may add others
+   later - treat it as a failed run: say so plainly
    with the error code and offer to rerun. Any `error` key short-circuits processing;
    never extract `report` or `counts` from an error result, including codes not listed
    here.

--- a/plugins/feature-discovery/skills/feature-discovery/SKILL.md
+++ b/plugins/feature-discovery/skills/feature-discovery/SKILL.md
@@ -22,7 +22,7 @@ allowed-tools:
   - AskUserQuestion
 metadata:
   author: rube-de
-  version: "1.0"
+  version: "1.0.0"
 ---
 
 # Feature discovery

--- a/plugins/feature-discovery/skills/feature-discovery/SKILL.md
+++ b/plugins/feature-discovery/skills/feature-discovery/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   answer directly instead of invoking this.
 user-invocable: true
 argument-hint: "[product one-liner] [scope: internal|competitor|mixed] [depth: quick|exhaustive]"
-compatibility: "Requires the Workflow tool (multi-agent orchestration). Invoking this skill opts into a heavyweight fan-out of up to ~40 sub-agents at exhaustive depth."
+compatibility: "Requires the Workflow tool (multi-agent orchestration). Invoking this skill opts into a heavyweight fan-out of up to ~40 sub-agents at exhaustive depth. For scope: competitor or mixed runs, the session also needs WebSearch and WebFetch pre-approved - Workflow sub-agents run in the background and can't prompt for tool approval."
 allowed-tools:
   - Workflow
   - Artifact

--- a/plugins/feature-discovery/skills/feature-discovery/SKILL.md
+++ b/plugins/feature-discovery/skills/feature-discovery/SKILL.md
@@ -120,8 +120,13 @@ to change.
 
 ## Credit
 
-Ported from the open-source
+Adapted from the open-source
 [feature-discovery-skill](https://github.com/fabianhug/feature-discovery-skill) by
-Fabian Hug (0xfabs), MIT licensed. The Workflow engine
-(`scripts/feature-discovery.workflow.js`) is kept verbatim; only the packaging,
-frontmatter, script path, and result handling were adapted for this marketplace.
+Fabian Hug (0xfabs), MIT licensed, as a fork rather than a verbatim port. Beyond
+packaging, frontmatter, script path, and result handling, the bundled engine
+(`scripts/feature-discovery.workflow.js`) also adds: argument validation, schema
+bounds (min/max item counts, required fields) on the segment/shortlist/spec/verdict
+schemas, hard-fail guards for empty ground/ideation/shortlist/validation/synthesis
+results, character-budgeted (and per-record-compacted) competitor research, and
+partial-fan-out coverage reporting (competitor tracks, ideation lenses, spec/validate
+pairs) so silent data loss surfaces in the report instead of being hidden.

--- a/plugins/feature-discovery/skills/feature-discovery/SKILL.md
+++ b/plugins/feature-discovery/skills/feature-discovery/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: feature-discovery
+description: >-
+  Discover what to build next across a whole product: fan out parallel agents to
+  map the current repo into a feature inventory, research competitors, ideate
+  across seven value lenses, dedup and shortlist, spec and adversarially validate
+  the winners, then synthesize a ranked roadmap. Distinct from brainstorm, which
+  goes deep on one feature - this goes wide and returns a ranked roadmap of many
+  candidates. Heavyweight: runs a deterministic multi-agent Workflow of roughly
+  35-40 sub-agents at exhaustive depth. Use when the user asks what to build next,
+  wants feature ideas, a roadmap or gap analysis, a competitor analysis, "what are
+  we missing", or "where can we add value". For a casual "give me three ideas",
+  answer directly instead of invoking this.
+user-invocable: true
+argument-hint: "[product one-liner] [scope: internal|competitor|mixed] [depth: quick|exhaustive]"
+compatibility: "Requires the Workflow tool (multi-agent orchestration). Invoking this skill opts into a heavyweight fan-out of up to ~40 sub-agents at exhaustive depth."
+allowed-tools:
+  - Workflow
+  - Artifact
+  - Write
+  - Read
+  - AskUserQuestion
+metadata:
+  author: rube-de
+  version: "1.0"
+---
+
+# Feature discovery
+
+Turns "what should we build next?" into a grounded, ranked roadmap by fanning out
+many agents instead of one agent guessing. The whole run is a deterministic
+Workflow script, so every invocation follows the same pipeline rather than being
+re-improvised.
+
+**Distinct from `brainstorm`.** `pm:brainstorm` goes deep on one known-ish feature
+(interactive Q&A, a single spec doc). This goes wide across the whole product and
+returns a ranked roadmap of many candidate features. Reach for brainstorm to design
+*how* to build a chosen feature; reach for this to discover *what* to build.
+
+## When this fits
+
+Use it when the user wants ideas that are researched, deduped, specced, and
+pressure-tested, not a quick off-the-cuff list. It is deliberately heavyweight
+(roughly 35-40 agents at exhaustive depth), so for a casual "give me three ideas"
+just answer directly.
+
+## The pipeline (what the script runs)
+
+The Workflow engine runs five phases - you do not run these yourself, the engine
+does (see
+[scripts/feature-discovery.workflow.js](scripts/feature-discovery.workflow.js)):
+
+- **Ground** - one agent maps the current product from the repo (entry points,
+  routes, data models, content, services, config, docs); in parallel a planner
+  proposes competitor segments and one analyst researches each via web search. The
+  product is always mapped, even in `internal` scope, so ideation never re-proposes
+  what exists.
+- **Ideate** - one agent per value lens (discoverability, core value, UX,
+  monetization, engagement, trust, information architecture), each grounded in the
+  inventory and competitor findings, each forbidden from proposing anything that
+  already exists.
+- **Shortlist** - a single curator merges duplicates, drops the trivial and the
+  already-built, ranks by value-to-effort, and picks the top 8-12.
+- **Spec & Validate** - a pipeline per feature: spec it, then an adversarial
+  skeptic scores novelty, real value, feasibility in the current architecture,
+  competitor precedent, and maintenance burden, returning build / maybe / drop with
+  a confidence score.
+- **Synthesize** - one agent writes the final Markdown report: exec summary, gaps
+  (internal and versus competitors), a ranked roadmap table, full specs for the
+  build/maybe features, dropped ideas with reasons, and a quick-wins-vs-bigger-bets
+  split.
+
+## Steps
+
+1. Determine `product`, `scope` (default `mixed`), and `depth` (default
+   `exhaustive`) from the user's request. If the user gave none and the intent is
+   clearly the full run, default to a repo-mapped product with `mixed` +
+   `exhaustive`; otherwise ask for the three values before launching.
+2. Invoke the **Workflow** tool pointed at the bundled script by its plugin path.
+   Do not paste the script inline - use its path so the persisted version stays the
+   source of truth:
+   ```
+   Workflow({
+     scriptPath: "${CLAUDE_SKILL_DIR}/scripts/feature-discovery.workflow.js",
+     args: { product: "one-line description of your product", scope: "mixed", depth: "exhaustive" }
+   })
+   ```
+   It runs in the background and returns `{ report, meta, counts }`, where `report`
+   is finished Markdown.
+3. If an `error` is returned (`product-mapping-failed` or `empty-shortlist`), say so
+   plainly and offer to rerun - do not present a half-report.
+4. Lead in chat with the executive summary and the ranked roadmap table from
+   `report`, then report the `counts` funnel (raw ideas / shortlisted / specced) so
+   the user can see how the funnel narrowed.
+5. Offer to render the full `report` as an **Artifact** for readability.
+6. Offer to save the full `report` to `.dev/feature-discovery/<date>-roadmap.md`
+   with `Write` (create the directory if needed; never write under `.claude/`).
+   Treat the report as a working artifact - do not write it unless the user asks.
+
+### Parameters (`args`)
+
+| key       | values                                | default            | effect |
+|-----------|---------------------------------------|--------------------|--------|
+| `product` | free text                             | (mapped from repo) | One-line description of the product. If omitted, the mapper infers it from the code, README, and docs. |
+| `scope`   | `mixed` \| `internal` \| `competitor` | `mixed`            | Where ideas come from. `internal` skips competitor research; `competitor` still maps the product but tells ideators to hunt for capabilities rivals have that it lacks. |
+| `depth`   | `exhaustive` \| `quick`               | `exhaustive`       | `exhaustive` = 4 competitor tracks, 7 lenses, top 8-12. `quick` = 2 tracks, 4 lenses, top 5-6, for a faster first pass. |
+
+## Extending
+
+The lens list (`ALL_LENSES`) lives at the top of the script; add or reword entries
+to change ideation coverage. Competitor segments are planned dynamically from the
+product, so no market list is hardcoded. The phase wiring and schemas do not need
+to change.
+
+## Credit
+
+Ported from the open-source
+[feature-discovery-skill](https://github.com/fabianhug/feature-discovery-skill) by
+Fabian Hug (0xfabs), MIT licensed. The Workflow engine
+(`scripts/feature-discovery.workflow.js`) is kept verbatim; only the packaging,
+frontmatter, script path, and result handling were adapted for this marketplace.

--- a/plugins/feature-discovery/skills/feature-discovery/SKILL.md
+++ b/plugins/feature-discovery/skills/feature-discovery/SKILL.md
@@ -87,8 +87,12 @@ does (see
    ```
    It runs in the background and returns `{ report, meta, counts }`, where `report`
    is finished Markdown.
-3. If an `error` is returned (`product-mapping-failed` or `empty-shortlist`), say so
-   plainly and offer to rerun - do not present a half-report.
+3. If the result has an `error` key - currently `invalid-args`, `product-mapping-failed`,
+   `empty-ideation`, `empty-shortlist`, `empty-validated-results`, or `synthesis-failed`,
+   though the script may add others later - treat it as a failed run: say so plainly
+   with the error code and offer to rerun. Any `error` key short-circuits processing;
+   never extract `report` or `counts` from an error result, including codes not listed
+   here.
 4. Lead in chat with the executive summary and the ranked roadmap table from
    `report`, then report the `counts` funnel (raw ideas / shortlisted / specced) so
    the user can see how the funnel narrowed.

--- a/plugins/feature-discovery/skills/feature-discovery/SKILL.md
+++ b/plugins/feature-discovery/skills/feature-discovery/SKILL.md
@@ -60,7 +60,8 @@ does (see
   inventory and competitor findings, each forbidden from proposing anything that
   already exists.
 - **Shortlist** - a single curator merges duplicates, drops the trivial and the
-  already-built, ranks by value-to-effort, and picks the top 8-12.
+  already-built, ranks by value-to-effort, and picks the top 8-12 (5-6 at
+  `depth: quick`).
 - **Spec & Validate** - a pipeline per feature: spec it, then an adversarial
   skeptic scores novelty, real value, feasibility in the current architecture,
   competitor precedent, and maintenance burden, returning build / maybe / drop with

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -28,8 +28,21 @@ const ARGS = typeof args === 'string'
   ? (() => { try { return JSON.parse(args) || {} } catch { return {} } })()
   : (args || {})
 const product = ARGS.product || ''
-const scope = ARGS.scope || 'mixed'
-const depth = ARGS.depth || 'exhaustive'
+
+const VALID_SCOPES = ['mixed', 'internal', 'competitor']
+const VALID_DEPTHS = ['exhaustive', 'quick']
+const rawScope = String(ARGS.scope || 'mixed').trim().toLowerCase()
+const rawDepth = String(ARGS.depth || 'exhaustive').trim().toLowerCase()
+if (!VALID_SCOPES.includes(rawScope) || !VALID_DEPTHS.includes(rawDepth)) {
+  return {
+    error: 'invalid-args',
+    allowed: { scope: VALID_SCOPES, depth: VALID_DEPTHS },
+    received: { scope: ARGS.scope, depth: ARGS.depth },
+  }
+}
+const scope = rawScope
+const depth = rawDepth
+
 const includeCompetitors = scope !== 'internal'
 const emphasis =
   scope === 'internal'
@@ -131,7 +144,7 @@ const VERDICT_SCHEMA = {
   type: 'object',
   properties: {
     verdict: { type: 'string', enum: ['build', 'maybe', 'drop'] },
-    confidence: { type: 'number' },
+    confidence: { type: 'number', minimum: 1, maximum: 10 },
     objections: { type: 'array', items: { type: 'string' } },
     refinements: { type: 'array', items: { type: 'string' } },
   },
@@ -214,6 +227,10 @@ const specced = await pipeline(
 )
 
 const clean = specced.filter(Boolean)
+if (!clean.length) {
+  log('No features survived spec + validation. Aborting before synthesis.')
+  return { error: 'empty-validated-results', shortlisted: features.length }
+}
 
 // ---- Phase 5: Synthesize --------------------------------------------------
 phase('Synthesize')
@@ -221,6 +238,11 @@ const report = await agent(
   `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${JSON.stringify(competitorResults)}\nSpecced & validated features: ${JSON.stringify(clean)}\n\nStructure the report as: (1) a short executive summary; (2) key gaps found, split into internal gaps and gaps versus competitors; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
   { label: 'synthesize:report', phase: 'Synthesize' },
 )
+
+if (!report) {
+  log('Synthesizer failed to produce a report. Aborting.')
+  return { error: 'synthesis-failed', counts: { rawIdeas: allIdeas.length, shortlisted: features.length, specced: clean.length } }
+}
 
 return {
   report,

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -60,7 +60,7 @@ const PRODUCT = product
   ? `The product is: ${product}.`
   : 'The product is the one built in the current repository; infer what it is from the code, README, and docs.'
 
-const CONTEXT = `${PRODUCT} Its source code is the current working directory. Map what it does from the repo: entry points and routes, data models, content, services, config, and docs. If a connected MCP server or CLI exposes live product data, you may call it to inspect real usage.`
+const CONTEXT = `${PRODUCT} Its source code is the current working directory. Map what it does from the repo: entry points and routes, data models, content, services, config, and docs. If a connected MCP server or CLI exposes live product data, you may make read-only calls to inspect real usage - never call anything that creates, modifies, deletes, or sends.`
 
 const ALL_LENSES = [
   { key: 'discoverability', name: 'Discoverability & acquisition', brief: 'how people and AI agents find the product and its content: search, SEO, structured data, machine-readable surfaces, integrations, shareable and programmatic access.' },
@@ -75,6 +75,18 @@ const ALL_LENSES = [
 const LENSES = depth === 'quick' ? ALL_LENSES.slice(0, 4) : ALL_LENSES
 const SEGMENT_COUNT = depth === 'quick' ? 2 : 4
 const SHORTLIST_TARGET = depth === 'quick' ? '5-6' : '8-12'
+
+// Large collection payloads (inventory, competitor research, raw ideas, specced
+// results) get re-embedded into many downstream prompts - every ideator lens,
+// every spec/validate pipeline stage - so an unbounded JSON.stringify compounds
+// token cost across the fan-out. Cap each at a fixed character budget instead.
+const MAX_CONTEXT_CHARS = 12000
+const boundedJson = (value) => {
+  const json = JSON.stringify(value)
+  return json.length > MAX_CONTEXT_CHARS
+    ? `${json.slice(0, MAX_CONTEXT_CHARS)}\n...(truncated, ${json.length} chars total)`
+    : json
+}
 
 // ---- Schemas --------------------------------------------------------------
 const INVENTORY_SCHEMA = {
@@ -192,7 +204,7 @@ const competitorResults = segments.length
 
 // ---- Phase 2: Ideate ------------------------------------------------------
 phase('Ideate')
-const groundContext = JSON.stringify({ inventory, competitors: competitorResults })
+const groundContext = boundedJson({ inventory, competitors: competitorResults })
 
 const ideaResults = await parallel(LENSES.map((lens) => () => agent(
   `${CONTEXT}\n\nGround truth (current-product inventory + competitor research):\n${groundContext}\n\nYou are a PRODUCT IDEATOR working the "${lens.name}" lens: ${lens.brief}\n\n${emphasis}\n\nPropose new, value-adding features or improvements through this lens. Rules: never propose anything the inventory shows already exists; ground every idea in either a concrete product gap or a named competitor precedent; prefer depth and specificity over a long list of shallow ideas. For each idea give: title, description, the lens, the user-value hypothesis, the evidence (the gap or competitor it comes from), and a rough effort estimate (S, M, or L).`,
@@ -209,7 +221,7 @@ if (!allIdeas.length) {
 // ---- Phase 3: Shortlist (barrier: needs every idea at once to dedup) ------
 phase('Shortlist')
 const shortlist = await agent(
-  `${CONTEXT}\n\nHere are ${allIdeas.length} candidate ideas from parallel ideators across different lenses:\n${JSON.stringify(allIdeas)}\n\nCurrent-product inventory:\n${JSON.stringify(inventory)}\n\nYou are the CURATOR. Merge duplicate and near-duplicate ideas into single consolidated items. Remove anything that already exists or is trivial. Rank the survivors by value-to-effort and select the TOP ${SHORTLIST_TARGET} for full speccing. For each selected item return: a clear title, a merged description, why it matters (value), rough effort, and the supporting evidence (gaps and/or competitors).`,
+  `${CONTEXT}\n\nHere are ${allIdeas.length} candidate ideas from parallel ideators across different lenses:\n${boundedJson(allIdeas)}\n\nCurrent-product inventory:\n${boundedJson(inventory)}\n\nYou are the CURATOR. Merge duplicate and near-duplicate ideas into single consolidated items. Remove anything that already exists or is trivial. Rank the survivors by value-to-effort and select the TOP ${SHORTLIST_TARGET} for full speccing. For each selected item return: a clear title, a merged description, why it matters (value), rough effort, and the supporting evidence (gaps and/or competitors).`,
   { label: 'curate:shortlist', phase: 'Shortlist', schema: SHORTLIST_SCHEMA },
 )
 
@@ -222,7 +234,7 @@ log(`${features.length} features shortlisted for spec + validation`)
 
 // ---- Phase 4: Spec + adversarial validate (pipeline, per feature) --------
 phase('Spec & Validate')
-const invJson = JSON.stringify(inventory)
+const invJson = boundedJson(inventory)
 const specced = await pipeline(
   features,
   (f) => agent(
@@ -244,7 +256,7 @@ if (!clean.length) {
 // ---- Phase 5: Synthesize --------------------------------------------------
 phase('Synthesize')
 const report = await agent(
-  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${JSON.stringify(competitorResults)}\nSpecced & validated features: ${JSON.stringify(clean)}\n\nStructure the report as: (1) a short executive summary; (2) key gaps found, split into internal gaps and gaps versus competitors; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
+  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedJson(competitorResults)}\nSpecced & validated features: ${boundedJson(clean)}\n\nStructure the report as: (1) a short executive summary; (2) key gaps found, split into internal gaps and gaps versus competitors; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
   { label: 'synthesize:report', phase: 'Synthesize' },
 )
 

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -218,9 +218,14 @@ const MAX_IDEAS_PER_LENS = 10
 const IDEAS_SCHEMA = {
   type: 'object',
   properties: {
+    // maxItems bounds count; maxLength bounds each field so a handful of
+    // verbose ideators can't blow up the curator prompt even while staying
+    // under the item cap - source-side generation bounding, same as
+    // maxItems, so every candidate still survives (nothing is post-hoc
+    // truncated out of the curator's input).
     ideas: { type: 'array', maxItems: MAX_IDEAS_PER_LENS, items: { type: 'object', properties: {
-      title: { type: 'string' }, description: { type: 'string' }, lens: { type: 'string' },
-      valueHypothesis: { type: 'string' }, evidence: { type: 'string' }, effort: { type: 'string', enum: ['S', 'M', 'L'] },
+      title: { type: 'string', maxLength: 100 }, description: { type: 'string', maxLength: 400 }, lens: { type: 'string', maxLength: 50 },
+      valueHypothesis: { type: 'string', maxLength: 400 }, evidence: { type: 'string', maxLength: 400 }, effort: { type: 'string', enum: ['S', 'M', 'L'] },
     }, required: ['title', 'description', 'lens', 'valueHypothesis', 'evidence', 'effort'] } },
   },
   required: ['ideas'],
@@ -240,8 +245,8 @@ const SHORTLIST_SCHEMA = {
 const SPEC_SCHEMA = {
   type: 'object',
   properties: {
-    title: { type: 'string' }, problem: { type: 'string' }, solution: { type: 'string' },
-    userValue: { type: 'string' }, architectureFit: { type: 'string' },
+    title: { type: 'string' }, problem: { type: 'string', pattern: '\\S' }, solution: { type: 'string', pattern: '\\S' },
+    userValue: { type: 'string', pattern: '\\S' }, architectureFit: { type: 'string', pattern: '\\S' },
     scope: { type: 'array', minItems: 1, items: { type: 'string', pattern: '\\S' } },
     successMetrics: { type: 'array', minItems: 1, items: { type: 'string', pattern: '\\S' } },
     openQuestions: { type: 'array', items: { type: 'string' } },

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -151,7 +151,7 @@ const SHORTLIST_SCHEMA = {
     features: { type: 'array', items: { type: 'object', properties: {
       title: { type: 'string' }, description: { type: 'string' }, value: { type: 'string' },
       effort: { type: 'string' }, evidence: { type: 'string' },
-    }, required: ['title', 'description'] } },
+    }, required: ['title', 'description', 'value', 'effort', 'evidence'] } },
   },
   required: ['features'],
 }
@@ -165,7 +165,7 @@ const SPEC_SCHEMA = {
     successMetrics: { type: 'array', items: { type: 'string' } },
     openQuestions: { type: 'array', items: { type: 'string' } },
   },
-  required: ['title', 'problem', 'solution'],
+  required: ['title', 'problem', 'solution', 'userValue', 'architectureFit', 'scope', 'successMetrics', 'openQuestions'],
 }
 
 const VERDICT_SCHEMA = {
@@ -292,7 +292,7 @@ const specced = await pipeline(
   ),
   (spec, f) => spec
     ? agent(
-        `${CONTEXT}\n\nAdversarially validate this feature spec. Be a skeptic: your job is to find why it might NOT be worth building.\n\nFeature: ${JSON.stringify(f)}\nSpec: ${JSON.stringify(spec)}\nCurrent-product inventory: ${invJson}\n\nAssess: (1) is it genuinely NEW versus what already exists? (2) real, sizable user value or just nice-to-have? (3) feasible in the current architecture and stack? (4) real competitor precedent or user demand, or speculative? (5) maintenance burden. Return a verdict (build / maybe / drop), a 1-10 confidence score, the strongest objections, and concrete refinements that would make it stronger.`,
+        `${CONTEXT}\n\nAdversarially validate this feature spec. Be a skeptic: your job is to find why it might NOT be worth building.\n\nFeature: ${JSON.stringify(f)}\nSpec: ${JSON.stringify(spec)}\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedJson(competitorResults)}\n\nAssess: (1) is it genuinely NEW versus what already exists? (2) real, sizable user value or just nice-to-have? (3) feasible in the current architecture and stack? (4) real competitor precedent or user demand, or speculative - check this against the competitor research above, not just the feature's own evidence claim? (5) maintenance burden. Return a verdict (build / maybe / drop), a 1-10 confidence score, the strongest objections, and concrete refinements that would make it stronger.`,
         { label: `validate:${f.title}`, phase: 'Spec & Validate', schema: VERDICT_SCHEMA },
       ).then((v) => (v ? { feature: f, spec, verdict: v } : null))
     : null,

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -174,15 +174,21 @@ const boundedCompetitorJson = (results) => {
 }
 
 // ---- Schemas --------------------------------------------------------------
+// No maxItems on any array here - features/dataTypes/interfaces/gaps entries
+// must never be dropped, or ideators would silently lose novelty-check
+// grounding (see the groundContext comment below). maxLength on individual
+// string fields is safe though: it bounds per-entry verbosity without
+// hiding any entry's existence, capping the cost this inventory adds across
+// the ~30 downstream agent calls it gets embedded into.
 const INVENTORY_SCHEMA = {
   type: 'object',
   properties: {
-    features: { type: 'array', items: { type: 'object', properties: { name: { type: 'string' }, description: { type: 'string' }, files: { type: 'array', items: { type: 'string' } } }, required: ['name', 'description'] } },
-    dataTypes: { type: 'array', items: { type: 'object', properties: { name: { type: 'string' }, fields: { type: 'array', items: { type: 'string' } }, notes: { type: 'string' } }, required: ['name'] } },
-    interfaces: { type: 'array', items: { type: 'string' } },
-    gaps: { type: 'array', items: { type: 'string' } },
+    features: { type: 'array', items: { type: 'object', properties: { name: { type: 'string', maxLength: 100 }, description: { type: 'string', maxLength: 300 }, files: { type: 'array', items: { type: 'string', maxLength: 200 } } }, required: ['name', 'description'] } },
+    dataTypes: { type: 'array', items: { type: 'object', properties: { name: { type: 'string', maxLength: 100 }, fields: { type: 'array', items: { type: 'string', maxLength: 100 } }, notes: { type: 'string', maxLength: 300 } }, required: ['name'] } },
+    interfaces: { type: 'array', items: { type: 'string', maxLength: 200 } },
+    gaps: { type: 'array', items: { type: 'string', maxLength: 300 } },
   },
-  required: ['features', 'gaps'],
+  required: ['features', 'dataTypes', 'interfaces', 'gaps'],
 }
 
 const SEGMENTS_SCHEMA = {
@@ -235,8 +241,8 @@ const SHORTLIST_SCHEMA = {
   type: 'object',
   properties: {
     features: { type: 'array', maxItems: SHORTLIST_MAX, items: { type: 'object', properties: {
-      title: { type: 'string' }, description: { type: 'string' }, value: { type: 'string' },
-      effort: { type: 'string' }, evidence: { type: 'string' },
+      title: { type: 'string', pattern: '\\S' }, description: { type: 'string', pattern: '\\S' }, value: { type: 'string', pattern: '\\S' },
+      effort: { type: 'string', pattern: '\\S' }, evidence: { type: 'string', pattern: '\\S' },
     }, required: ['title', 'description', 'value', 'effort', 'evidence'] } },
   },
   required: ['features'],
@@ -348,10 +354,13 @@ const emphasis = !hasCompetitorData
 // ---- Phase 2: Ideate ------------------------------------------------------
 phase('Ideate')
 // Inventory is a single mapped object, reused as-is everywhere below - unlike
-// competitor/idea/feature collections it doesn't grow with fan-out, so it is
-// never bounded: truncating it would silently hide already-built features
-// from novelty checks in every downstream phase. Only competitor research
-// (which grows with segment count) gets a character budget here.
+// competitor/idea/feature collections it doesn't grow with fan-out, so its
+// entry count is never bounded post-hoc here: truncating the serialized
+// object would silently hide already-built features from novelty checks in
+// every downstream phase. Per-field verbosity IS bounded, at the source, via
+// INVENTORY_SCHEMA's maxLength constraints - that caps cost without dropping
+// any entry. Competitor research additionally gets a character budget here
+// since it also grows with fan-out (segment count), unlike inventory.
 const groundContext = `Inventory: ${JSON.stringify(inventory)}\nCompetitor research: ${boundedCompetitorJson(competitorResults)}`
 
 const ideaResults = await parallel(LENSES.map((lens) => () => agent(

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -119,9 +119,14 @@ const MAX_CONTEXT_CHARS = 12000
 // realistic perSegmentBudget) instead of another size-dependent edge case.
 const MAX_FIELD_CHARS = 200
 const truncateField = (s) => (typeof s === 'string' && s.length > MAX_FIELD_CHARS ? `${s.slice(0, MAX_FIELD_CHARS)}...` : s)
+// Reconstructed explicitly from only the known COMPETITOR_SCHEMA item fields
+// (same reasoning as the segment wrapper below) - COMPETITOR_SCHEMA doesn't
+// forbid additional properties on a competitor, so spreading `...c` back in
+// would leave any oversized extra field completely uncapped regardless of
+// how well the known fields are truncated.
 const compactCompetitor = (c) => {
   const cap = (arr) => ((arr && arr.length > 3 ? arr.slice(0, 3) : arr) || []).map(truncateField)
-  return { ...c, name: truncateField(c.name), url: truncateField(c.url), whatItIs: truncateField(c.whatItIs), notableFeatures: cap(c.notableFeatures), lessonsForUs: cap(c.lessonsForUs) }
+  return { name: truncateField(c.name), url: truncateField(c.url), whatItIs: truncateField(c.whatItIs), notableFeatures: cap(c.notableFeatures), lessonsForUs: cap(c.lessonsForUs) }
 }
 const boundedCompetitorJson = (results) => {
   if (!results.length) return '[]'

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -108,7 +108,16 @@ const MAX_CONTEXT_CHARS = 12000
 // least a proportional share of representation. Within a segment that still
 // exceeds its share, drop whole competitor records from the tail rather than
 // slicing the JSON string, so every record that reaches the prompt is
-// complete and parseable instead of cut off mid-record.
+// complete and parseable instead of cut off mid-record. A single competitor
+// with long notableFeatures/lessonsForUs arrays can still exceed the entire
+// per-segment budget on its own - compact it (cap those arrays) rather than
+// dropping it wholesale, so a genuinely substantive competitor doesn't vanish
+// from every downstream prompt while hasCompetitorData/coverage (computed
+// from the unbounded results) keep reporting the track as usable.
+const compactCompetitor = (c) => {
+  const cap = (arr) => (arr && arr.length > 3 ? arr.slice(0, 3) : arr)
+  return { ...c, notableFeatures: cap(c.notableFeatures), lessonsForUs: cap(c.lessonsForUs) }
+}
 const boundedCompetitorJson = (results) => {
   if (!results.length) return '[]'
   const perSegmentBudget = Math.max(1, Math.floor(MAX_CONTEXT_CHARS / results.length))
@@ -119,9 +128,10 @@ const boundedCompetitorJson = (results) => {
     const kept = []
     let used = 0
     for (const c of competitors) {
-      const size = JSON.stringify(c).length + 1
+      const candidate = JSON.stringify(c).length > perSegmentBudget ? compactCompetitor(c) : c
+      const size = JSON.stringify(candidate).length + 1
       if (used + size > perSegmentBudget) break
-      kept.push(c)
+      kept.push(candidate)
       used += size
     }
     return JSON.stringify({ ...r, competitors: kept })

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -147,7 +147,13 @@ const boundedCompetitorJson = (results) => {
       kept.push(candidate)
       used += size
     }
-    return JSON.stringify({ ...r, competitors: kept })
+    // Spreading `...r` back in preserves competitors' bound but leaves every
+    // OTHER field on the wrapper (e.g. `segment`, or any additional
+    // schema-allowed property) completely unbounded - a single oversized
+    // `segment` string alone can blow the budget regardless of how well
+    // `competitors` is capped. Rebuild explicitly from only the known,
+    // capped fields instead of spreading whatever the agent returned.
+    return JSON.stringify({ segment: truncateField(r && r.segment), competitors: kept })
   }).join(', ')}]`
 }
 
@@ -213,8 +219,8 @@ const SPEC_SCHEMA = {
   properties: {
     title: { type: 'string' }, problem: { type: 'string' }, solution: { type: 'string' },
     userValue: { type: 'string' }, architectureFit: { type: 'string' },
-    scope: { type: 'array', minItems: 1, items: { type: 'string' } },
-    successMetrics: { type: 'array', minItems: 1, items: { type: 'string' } },
+    scope: { type: 'array', minItems: 1, items: { type: 'string', pattern: '\\S' } },
+    successMetrics: { type: 'array', minItems: 1, items: { type: 'string', pattern: '\\S' } },
     openQuestions: { type: 'array', items: { type: 'string' } },
   },
   required: ['title', 'problem', 'solution', 'userValue', 'architectureFit', 'scope', 'successMetrics', 'openQuestions'],

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -29,14 +29,17 @@ export const meta = {
 // `args` can cross the Workflow tool boundary as an already-parsed object or as
 // a JSON string (harness-dependent). Normalize to an object so scope/depth are
 // honored rather than silently falling back to the expensive exhaustive default.
+const isPlainArgsObject = (v) => typeof v === 'object' && v !== null && !Array.isArray(v)
+
 const parsedArgs =
   typeof args === 'string'
     ? (() => { try { return { ok: true, value: JSON.parse(args) } } catch { return { ok: false } } })()
-    : { ok: true, value: typeof args === 'undefined' ? {} : (args || {}) }
-if (!parsedArgs.ok) {
+    : { ok: true, value: typeof args === 'undefined' ? {} : args }
+
+if (!parsedArgs.ok || !isPlainArgsObject(parsedArgs.value)) {
   return { error: 'invalid-args', reason: 'malformed-json-args' }
 }
-const ARGS = parsedArgs.value || {}
+const ARGS = parsedArgs.value
 const product = ARGS.product || ''
 
 const VALID_SCOPES = ['mixed', 'internal', 'competitor']
@@ -56,12 +59,6 @@ const scope = rawScope
 const depth = rawDepth
 
 const includeCompetitors = scope !== 'internal'
-const emphasis =
-  scope === 'internal'
-    ? 'Focus ideas on gaps in the existing product.'
-    : scope === 'competitor'
-      ? 'Focus ideas on capabilities competitors have that this product lacks.'
-      : 'Draw ideas from a balanced mix of internal gaps and competitor precedent.'
 
 const PRODUCT = product
   ? `The product is: ${product}.`
@@ -215,14 +212,32 @@ const competitorResults = segments.length
     )))).filter(Boolean)
   : []
 
-// Segments planned but every analyst still failed (e.g. WebSearch/WebFetch not
-// pre-approved in the session - Workflow sub-agents run in the background and
-// can't prompt for tool approval). Same failure mode as the segment-planning
-// guard above, just one step later in the pipeline.
-if (scope === 'competitor' && includeCompetitors && segments.length && !competitorResults.length) {
-  log('Competitor research produced no results for a competitor-focused run - aborting rather than reporting on missing data.')
+// A truthy per-segment result can still carry zero competitors (the schema
+// allows `{ competitors: [] }`), so count the flattened total rather than just
+// how many analyst calls returned something.
+const competitorCount = competitorResults.reduce((sum, r) => sum + ((r && r.competitors) || []).length, 0)
+const hasCompetitorData = competitorCount > 0
+
+// Segments planned but every analyst still failed or returned nothing usable
+// (e.g. WebSearch/WebFetch not pre-approved in the session - Workflow
+// sub-agents run in the background and can't prompt for tool approval). Same
+// failure mode as the segment-planning guard above, just one step later. Only
+// `competitor` scope hard-fails here - it has no fallback framing without
+// competitor data. `mixed` degrades gracefully via `emphasis` below instead.
+if (scope === 'competitor' && includeCompetitors && segments.length && !hasCompetitorData) {
+  log('Competitor research produced no usable results for a competitor-focused run - aborting rather than reporting on missing data.')
   return { error: 'competitor-research-failed' }
 }
+
+// Emphasis depends on whether competitor research actually produced data, not
+// just on the requested scope - a mixed run with no competitor data falls back
+// to internal-only framing instead of asking ideators for competitor precedent
+// that doesn't exist.
+const emphasis = !hasCompetitorData
+  ? 'Focus ideas on gaps in the existing product.'
+  : scope === 'competitor'
+    ? 'Focus ideas on capabilities competitors have that this product lacks.'
+    : 'Draw ideas from a balanced mix of internal gaps and competitor precedent.'
 
 // ---- Phase 2: Ideate ------------------------------------------------------
 phase('Ideate')
@@ -277,8 +292,11 @@ if (!clean.length) {
 
 // ---- Phase 5: Synthesize --------------------------------------------------
 phase('Synthesize')
+const gapsInstruction = hasCompetitorData
+  ? 'key gaps found, split into internal gaps and gaps versus competitors'
+  : 'key gaps found in the existing product (no competitor research was available for this run)'
 const report = await agent(
-  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedJson(competitorResults)}\nSpecced & validated features: ${JSON.stringify(clean)}\n\nStructure the report as: (1) a short executive summary; (2) key gaps found, split into internal gaps and gaps versus competitors; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
+  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedJson(competitorResults)}\nSpecced & validated features: ${JSON.stringify(clean)}\n\nStructure the report as: (1) a short executive summary; (2) ${gapsInstruction}; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
   { label: 'synthesize:report', phase: 'Synthesize' },
 )
 

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -191,8 +191,8 @@ if (includeCompetitors) {
 
 const ground = await parallel(groundThunks)
 const inventory = ground[0]
-if (!inventory) {
-  log('Product mapping failed - cannot ground ideation. Aborting.')
+if (!inventory || !inventory.features || !inventory.features.length) {
+  log('Product mapping failed or returned no features - cannot ground ideation. Aborting.')
   return { error: 'product-mapping-failed' }
 }
 
@@ -241,7 +241,11 @@ const emphasis = !hasCompetitorData
 
 // ---- Phase 2: Ideate ------------------------------------------------------
 phase('Ideate')
-const groundContext = boundedJson({ inventory, competitors: competitorResults })
+// Bound inventory and competitor data independently, not as one combined
+// blob - a large inventory alone can exceed MAX_CONTEXT_CHARS and truncate
+// before the competitors key is ever serialized, silently zeroing out
+// competitor evidence even when hasCompetitorData is true.
+const groundContext = `Inventory: ${boundedJson(inventory)}\nCompetitor research: ${boundedJson(competitorResults)}`
 
 const ideaResults = await parallel(LENSES.map((lens) => () => agent(
   `${CONTEXT}\n\nGround truth (current-product inventory + competitor research):\n${groundContext}\n\nYou are a PRODUCT IDEATOR working the "${lens.name}" lens: ${lens.brief}\n\n${emphasis}\n\nPropose new, value-adding features or improvements through this lens. Rules: never propose anything the inventory shows already exists; ground every idea in either a concrete product gap or a named competitor precedent; prefer depth and specificity over a long list of shallow ideas. For each idea give: title, description, the lens, the user-value hypothesis, the evidence (the gap or competitor it comes from), and a rough effort estimate (S, M, or L).`,

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -86,6 +86,7 @@ const ALL_LENSES = [
 const LENSES = depth === 'quick' ? ALL_LENSES.slice(0, 4) : ALL_LENSES
 const SEGMENT_COUNT = depth === 'quick' ? 2 : 4
 const SHORTLIST_TARGET = depth === 'quick' ? '5-6' : '8-12'
+const SHORTLIST_MAX = depth === 'quick' ? 6 : 12
 
 // Large collection payloads (inventory, competitor research, raw ideas, specced
 // results) get re-embedded into many downstream prompts - every ideator lens,
@@ -148,7 +149,7 @@ const IDEAS_SCHEMA = {
 const SHORTLIST_SCHEMA = {
   type: 'object',
   properties: {
-    features: { type: 'array', items: { type: 'object', properties: {
+    features: { type: 'array', maxItems: SHORTLIST_MAX, items: { type: 'object', properties: {
       title: { type: 'string' }, description: { type: 'string' }, value: { type: 'string' },
       effort: { type: 'string' }, evidence: { type: 'string' },
     }, required: ['title', 'description', 'value', 'effort', 'evidence'] } },
@@ -173,7 +174,7 @@ const VERDICT_SCHEMA = {
   properties: {
     verdict: { type: 'string', enum: ['build', 'maybe', 'drop'] },
     confidence: { type: 'number', minimum: 1, maximum: 10 },
-    objections: { type: 'array', items: { type: 'string' } },
+    objections: { type: 'array', minItems: 1, items: { type: 'string' } },
     refinements: { type: 'array', items: { type: 'string' } },
   },
   required: ['verdict', 'confidence', 'objections', 'refinements'],

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -109,14 +109,19 @@ const MAX_CONTEXT_CHARS = 12000
 // exceeds its share, drop whole competitor records from the tail rather than
 // slicing the JSON string, so every record that reaches the prompt is
 // complete and parseable instead of cut off mid-record. A single competitor
-// with long notableFeatures/lessonsForUs arrays can still exceed the entire
-// per-segment budget on its own - compact it (cap those arrays) rather than
-// dropping it wholesale, so a genuinely substantive competitor doesn't vanish
-// from every downstream prompt while hasCompetitorData/coverage (computed
-// from the unbounded results) keep reporting the track as usable.
+// can still exceed the entire per-segment budget on its own - compact it
+// rather than dropping it wholesale, so a genuinely substantive competitor
+// doesn't vanish from every downstream prompt while hasCompetitorData/coverage
+// (computed from the unbounded results) keep reporting the track as usable.
+// Capping array length alone doesn't bound total size if individual strings
+// are long, so every string field is also capped - this gives a fixed,
+// calculable worst-case size per compacted competitor (well under any
+// realistic perSegmentBudget) instead of another size-dependent edge case.
+const MAX_FIELD_CHARS = 200
+const truncateField = (s) => (typeof s === 'string' && s.length > MAX_FIELD_CHARS ? `${s.slice(0, MAX_FIELD_CHARS)}...` : s)
 const compactCompetitor = (c) => {
-  const cap = (arr) => (arr && arr.length > 3 ? arr.slice(0, 3) : arr)
-  return { ...c, notableFeatures: cap(c.notableFeatures), lessonsForUs: cap(c.lessonsForUs) }
+  const cap = (arr) => ((arr && arr.length > 3 ? arr.slice(0, 3) : arr) || []).map(truncateField)
+  return { ...c, name: truncateField(c.name), url: truncateField(c.url), whatItIs: truncateField(c.whatItIs), notableFeatures: cap(c.notableFeatures), lessonsForUs: cap(c.lessonsForUs) }
 }
 const boundedCompetitorJson = (results) => {
   if (!results.length) return '[]'
@@ -263,8 +268,12 @@ const competitorResults = segments.length
 // how many analyst calls returned something. Only `name`+`whatItIs` are
 // schema-required, so a competitor entry can be little more than a label
 // ("Rival: a tool") - count only entries with actual substance (notable
-// features or lessons), not just array presence.
-const hasSubstance = (c) => c && (((c.notableFeatures && c.notableFeatures.length) || 0) + ((c.lessonsForUs && c.lessonsForUs.length) || 0)) > 0
+// features or lessons), not just array presence. The schema doesn't enforce
+// nonblank strings, so a blank entry ("" in notableFeatures) would otherwise
+// pass this check with zero real information - require at least one entry
+// with actual (trimmed, nonempty) content.
+const hasContent = (arr) => (arr || []).some((s) => typeof s === 'string' && s.trim().length > 0)
+const hasSubstance = (c) => c && (hasContent(c.notableFeatures) || hasContent(c.lessonsForUs))
 const competitorCount = competitorResults.reduce((sum, r) => sum + ((r && r.competitors) || []).filter(hasSubstance).length, 0)
 const hasCompetitorData = competitorCount > 0
 

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -130,9 +130,17 @@ const boundedCompetitorJson = (results) => {
     const full = JSON.stringify(r)
     if (full.length <= perSegmentBudget) return full
     const competitors = (r && r.competitors) || []
+    // Greedily filling in original order lets an early name-only record
+    // (hasSubstance below is defined later, but resolved at call time - safe
+    // since boundedCompetitorJson is only ever called after Ground) consume
+    // the budget before a later substantive one is reached, even though the
+    // track has real evidence. Pack substantive competitors first (stable
+    // sort preserves original order within each group) so a track that has
+    // any substance at all is more likely to actually surface some.
+    const ordered = [...competitors].sort((a, b) => (hasSubstance(b) ? 1 : 0) - (hasSubstance(a) ? 1 : 0))
     const kept = []
     let used = 0
-    for (const c of competitors) {
+    for (const c of ordered) {
       const candidate = JSON.stringify(c).length > perSegmentBudget ? compactCompetitor(c) : c
       const size = JSON.stringify(candidate).length + 1
       if (used + size > perSegmentBudget) break
@@ -217,7 +225,7 @@ const VERDICT_SCHEMA = {
   properties: {
     verdict: { type: 'string', enum: ['build', 'maybe', 'drop'] },
     confidence: { type: 'number', minimum: 1, maximum: 10 },
-    objections: { type: 'array', minItems: 1, items: { type: 'string' } },
+    objections: { type: 'array', minItems: 1, items: { type: 'string', pattern: '\\S' } },
     refinements: { type: 'array', items: { type: 'string' } },
   },
   required: ['verdict', 'confidence', 'objections', 'refinements'],

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -88,17 +88,15 @@ const SEGMENT_COUNT = depth === 'quick' ? 2 : 4
 const SHORTLIST_TARGET = depth === 'quick' ? '5-6' : '8-12'
 const SHORTLIST_MAX = depth === 'quick' ? 6 : 12
 
-// Large collection payloads (inventory, competitor research, raw ideas, specced
-// results) get re-embedded into many downstream prompts - every ideator lens,
-// every spec/validate pipeline stage - so an unbounded JSON.stringify compounds
-// token cost across the fan-out. Cap each at a fixed character budget instead.
+// Of the large collection payloads re-embedded into downstream prompts
+// (inventory, competitor research, raw ideas, specced results), only
+// competitor research is bounded. Inventory is a single reused object that
+// doesn't grow with fan-out (see below), and ideas/specced-features are
+// ranked/selected collections where character-slicing would silently drop
+// candidates - see docs/learnings.md. Competitor research is the one
+// collection that both grows with fan-out (segment count) and isn't itself a
+// ranked/selected output, so it's the one that needs a budget.
 const MAX_CONTEXT_CHARS = 12000
-const boundedJson = (value) => {
-  const json = JSON.stringify(value)
-  return json.length > MAX_CONTEXT_CHARS
-    ? `${json.slice(0, MAX_CONTEXT_CHARS)}\n...(truncated, ${json.length} chars total)`
-    : json
-}
 
 // competitorResults is one entry per researched segment - unlike inventory
 // (a single object), it genuinely grows with segment count, so it still needs
@@ -327,14 +325,28 @@ if (!clean.length) {
   log('No features survived spec + validation. Aborting before synthesis.')
   return { error: 'empty-validated-results', shortlisted: features.length }
 }
+// A feature whose spec or validator call failed partway is indistinguishable
+// from one the validator deliberately rejected - both are just absent from
+// `clean`. Note the count so the synthesizer doesn't conflate "evaluated and
+// passed" with "never got evaluated."
+const specCoverageNote = clean.length < features.length
+  ? ` ${features.length - clean.length} of ${features.length} shortlisted feature(s) could not be spec'd or validated due to an agent failure and are missing below - this is different from a deliberate "drop" verdict; mention it in the executive summary rather than silently omitting it.`
+  : ''
 
 // ---- Phase 5: Synthesize --------------------------------------------------
 phase('Synthesize')
+// A competitor-scoped run only hard-fails when every planned track comes back
+// empty - partial completion (e.g. 1 of 4 analysts succeeding) is treated as
+// a normal success today, with nothing telling the reader how much research
+// actually landed. Surface the gap in the report instead of hiding it.
+const competitorCoverageNote = segments.length && competitorResults.length < segments.length
+  ? ` (${competitorResults.length} of ${segments.length} planned competitor tracks completed - some analyst calls failed or returned nothing)`
+  : ''
 const gapsInstruction = hasCompetitorData
-  ? 'key gaps found, split into internal gaps and gaps versus competitors'
+  ? `key gaps found, split into internal gaps and gaps versus competitors${competitorCoverageNote}`
   : 'key gaps found in the existing product (no competitor research was available for this run)'
 const report = await agent(
-  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedCompetitorJson(competitorResults)}\nSpecced & validated features: ${JSON.stringify(clean)}\n\nStructure the report as: (1) a short executive summary; (2) ${gapsInstruction}; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
+  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedCompetitorJson(competitorResults)}\nSpecced & validated features: ${JSON.stringify(clean)}\n\nStructure the report as: (1) a short executive summary${specCoverageNote}; (2) ${gapsInstruction}; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
   { label: 'synthesize:report', phase: 'Synthesize' },
 )
 

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -105,15 +105,26 @@ const MAX_CONTEXT_CHARS = 12000
 // while hasCompetitorData/competitorCount are computed from the full,
 // untruncated data - silently reporting success while omitting whole tracks.
 // Split the budget evenly per segment instead, so every segment keeps at
-// least a proportional share of representation.
+// least a proportional share of representation. Within a segment that still
+// exceeds its share, drop whole competitor records from the tail rather than
+// slicing the JSON string, so every record that reaches the prompt is
+// complete and parseable instead of cut off mid-record.
 const boundedCompetitorJson = (results) => {
   if (!results.length) return '[]'
   const perSegmentBudget = Math.max(1, Math.floor(MAX_CONTEXT_CHARS / results.length))
   return `[${results.map((r) => {
-    const json = JSON.stringify(r)
-    return json.length > perSegmentBudget
-      ? `${json.slice(0, perSegmentBudget)}...(truncated)`
-      : json
+    const full = JSON.stringify(r)
+    if (full.length <= perSegmentBudget) return full
+    const competitors = (r && r.competitors) || []
+    const kept = []
+    let used = 0
+    for (const c of competitors) {
+      const size = JSON.stringify(c).length + 1
+      if (used + size > perSegmentBudget) break
+      kept.push(c)
+      used += size
+    }
+    return JSON.stringify({ ...r, competitors: kept })
   }).join(', ')}]`
 }
 
@@ -282,12 +293,20 @@ const ideaResults = await parallel(LENSES.map((lens) => () => agent(
   { label: `ideate:${lens.key}`, phase: 'Ideate', schema: IDEAS_SCHEMA },
 )))
 
-const allIdeas = ideaResults.filter(Boolean).flatMap((r) => (r && r.ideas) || [])
-log(`${allIdeas.length} raw ideas from ${LENSES.length} lenses`)
+const successfulLenses = ideaResults.filter(Boolean)
+const allIdeas = successfulLenses.flatMap((r) => (r && r.ideas) || [])
+log(`${allIdeas.length} raw ideas from ${successfulLenses.length}/${LENSES.length} lenses`)
 if (!allIdeas.length) {
   log('No ideas survived ideation - cannot curate a shortlist. Aborting.')
   return { error: 'empty-ideation' }
 }
+// A lens whose ideator call failed is indistinguishable downstream from a
+// lens that legitimately had nothing to add - both just contribute zero
+// ideas. Note the count so the synthesizer doesn't report full lens coverage
+// it didn't actually get.
+const lensCoverageNote = successfulLenses.length < LENSES.length
+  ? ` ${LENSES.length - successfulLenses.length} of ${LENSES.length} ideation lens(es) failed to return results and were skipped - mention this gap in the executive summary rather than silently omitting it.`
+  : ''
 
 // ---- Phase 3: Shortlist (barrier: needs every idea at once to dedup) ------
 phase('Shortlist')
@@ -338,15 +357,20 @@ phase('Synthesize')
 // A competitor-scoped run only hard-fails when every planned track comes back
 // empty - partial completion (e.g. 1 of 4 analysts succeeding) is treated as
 // a normal success today, with nothing telling the reader how much research
-// actually landed. Surface the gap in the report instead of hiding it.
-const competitorCoverageNote = segments.length && competitorResults.length < segments.length
-  ? ` (${competitorResults.length} of ${segments.length} planned competitor tracks completed - some analyst calls failed or returned nothing)`
+// actually landed. Surface the gap in the report instead of hiding it. A
+// track only counts as completed if it produced at least one competitor with
+// real substance (the same hasSubstance check used for competitorCount above)
+// - a track that came back truthy but empty, or name-only, is not "completed"
+// research even though the analyst call itself didn't fail.
+const usableTrackCount = competitorResults.filter((r) => ((r && r.competitors) || []).some(hasSubstance)).length
+const competitorCoverageNote = segments.length && usableTrackCount < segments.length
+  ? ` (${usableTrackCount} of ${segments.length} planned competitor tracks completed - some analyst calls failed, returned nothing, or returned no substantive competitors)`
   : ''
 const gapsInstruction = hasCompetitorData
   ? `key gaps found, split into internal gaps and gaps versus competitors${competitorCoverageNote}`
   : 'key gaps found in the existing product (no competitor research was available for this run)'
 const report = await agent(
-  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedCompetitorJson(competitorResults)}\nSpecced & validated features: ${JSON.stringify(clean)}\n\nStructure the report as: (1) a short executive summary${specCoverageNote}; (2) ${gapsInstruction}; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
+  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedCompetitorJson(competitorResults)}\nSpecced & validated features: ${JSON.stringify(clean)}\n\nStructure the report as: (1) a short executive summary${specCoverageNote}${lensCoverageNote}; (2) ${gapsInstruction}; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
   { label: 'synthesize:report', phase: 'Synthesize' },
 )
 
@@ -357,6 +381,6 @@ if (!report) {
 
 return {
   report,
-  meta: { product: product || '(mapped from repo)', scope, depth, competitorSegments: competitorResults.length, lenses: LENSES.length },
+  meta: { product: product || '(mapped from repo)', scope, depth, competitorSegments: competitorResults.length, lenses: successfulLenses.length },
   counts: { rawIdeas: allIdeas.length, shortlisted: features.length, specced: clean.length },
 }

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -36,11 +36,18 @@ const parsedArgs =
     ? (() => { try { return { ok: true, value: JSON.parse(args) } } catch { return { ok: false } } })()
     : { ok: true, value: typeof args === 'undefined' ? {} : args }
 
-if (!parsedArgs.ok || !isPlainArgsObject(parsedArgs.value)) {
+if (!parsedArgs.ok) {
   return { error: 'invalid-args', reason: 'malformed-json-args' }
 }
+if (!isPlainArgsObject(parsedArgs.value)) {
+  return { error: 'invalid-args', reason: 'args-not-an-object' }
+}
 const ARGS = parsedArgs.value
-const product = ARGS.product || ''
+const productInput = ARGS.product === undefined ? '' : ARGS.product
+if (typeof productInput !== 'string') {
+  return { error: 'invalid-args', reason: 'invalid-product' }
+}
+const product = productInput.trim()
 
 const VALID_SCOPES = ['mixed', 'internal', 'competitor']
 const VALID_DEPTHS = ['exhaustive', 'quick']
@@ -133,7 +140,7 @@ const IDEAS_SCHEMA = {
     ideas: { type: 'array', items: { type: 'object', properties: {
       title: { type: 'string' }, description: { type: 'string' }, lens: { type: 'string' },
       valueHypothesis: { type: 'string' }, evidence: { type: 'string' }, effort: { type: 'string', enum: ['S', 'M', 'L'] },
-    }, required: ['title', 'description', 'valueHypothesis'] } },
+    }, required: ['title', 'description', 'valueHypothesis', 'evidence', 'effort'] } },
   },
   required: ['ideas'],
 }
@@ -241,11 +248,12 @@ const emphasis = !hasCompetitorData
 
 // ---- Phase 2: Ideate ------------------------------------------------------
 phase('Ideate')
-// Bound inventory and competitor data independently, not as one combined
-// blob - a large inventory alone can exceed MAX_CONTEXT_CHARS and truncate
-// before the competitors key is ever serialized, silently zeroing out
-// competitor evidence even when hasCompetitorData is true.
-const groundContext = `Inventory: ${boundedJson(inventory)}\nCompetitor research: ${boundedJson(competitorResults)}`
+// Inventory is a single mapped object, reused as-is everywhere below - unlike
+// competitor/idea/feature collections it doesn't grow with fan-out, so it is
+// never bounded: truncating it would silently hide already-built features
+// from novelty checks in every downstream phase. Only competitor research
+// (which grows with segment count) gets a character budget here.
+const groundContext = `Inventory: ${JSON.stringify(inventory)}\nCompetitor research: ${boundedJson(competitorResults)}`
 
 const ideaResults = await parallel(LENSES.map((lens) => () => agent(
   `${CONTEXT}\n\nGround truth (current-product inventory + competitor research):\n${groundContext}\n\nYou are a PRODUCT IDEATOR working the "${lens.name}" lens: ${lens.brief}\n\n${emphasis}\n\nPropose new, value-adding features or improvements through this lens. Rules: never propose anything the inventory shows already exists; ground every idea in either a concrete product gap or a named competitor precedent; prefer depth and specificity over a long list of shallow ideas. For each idea give: title, description, the lens, the user-value hypothesis, the evidence (the gap or competitor it comes from), and a rough effort estimate (S, M, or L).`,
@@ -262,7 +270,7 @@ if (!allIdeas.length) {
 // ---- Phase 3: Shortlist (barrier: needs every idea at once to dedup) ------
 phase('Shortlist')
 const shortlist = await agent(
-  `${CONTEXT}\n\nHere are ${allIdeas.length} candidate ideas from parallel ideators across different lenses:\n${JSON.stringify(allIdeas)}\n\nCurrent-product inventory:\n${boundedJson(inventory)}\n\nYou are the CURATOR. Merge duplicate and near-duplicate ideas into single consolidated items. Remove anything that already exists or is trivial. Rank the survivors by value-to-effort and select the TOP ${SHORTLIST_TARGET} for full speccing. For each selected item return: a clear title, a merged description, why it matters (value), rough effort, and the supporting evidence (gaps and/or competitors).`,
+  `${CONTEXT}\n\nHere are ${allIdeas.length} candidate ideas from parallel ideators across different lenses:\n${JSON.stringify(allIdeas)}\n\nCurrent-product inventory:\n${JSON.stringify(inventory)}\n\nYou are the CURATOR. Merge duplicate and near-duplicate ideas into single consolidated items. Remove anything that already exists or is trivial. Rank the survivors by value-to-effort and select the TOP ${SHORTLIST_TARGET} for full speccing. For each selected item return: a clear title, a merged description, why it matters (value), rough effort, and the supporting evidence (gaps and/or competitors).`,
   { label: 'curate:shortlist', phase: 'Shortlist', schema: SHORTLIST_SCHEMA },
 )
 
@@ -275,17 +283,19 @@ log(`${features.length} features shortlisted for spec + validation`)
 
 // ---- Phase 4: Spec + adversarial validate (pipeline, per feature) --------
 phase('Spec & Validate')
-const invJson = boundedJson(inventory)
+const invJson = JSON.stringify(inventory)
 const specced = await pipeline(
   features,
   (f) => agent(
     `${CONTEXT}\n\nCurrent-product inventory (for feasibility grounding):\n${invJson}\n\nWrite a crisp product + engineering spec for this feature:\n${JSON.stringify(f)}\n\nInclude: problem statement, proposed solution, user value, how it fits the existing architecture and stack (data-model changes, new pages/components/endpoints, interface implications), rough scope/milestones, success metrics, and open questions/risks. Be concrete about implementation given the current codebase.`,
     { label: `spec:${f.title}`, phase: 'Spec & Validate', schema: SPEC_SCHEMA },
   ),
-  (spec, f) => agent(
-    `${CONTEXT}\n\nAdversarially validate this feature spec. Be a skeptic: your job is to find why it might NOT be worth building.\n\nFeature: ${JSON.stringify(f)}\nSpec: ${JSON.stringify(spec)}\nCurrent-product inventory: ${invJson}\n\nAssess: (1) is it genuinely NEW versus what already exists? (2) real, sizable user value or just nice-to-have? (3) feasible in the current architecture and stack? (4) real competitor precedent or user demand, or speculative? (5) maintenance burden. Return a verdict (build / maybe / drop), a 1-10 confidence score, the strongest objections, and concrete refinements that would make it stronger.`,
-    { label: `validate:${f.title}`, phase: 'Spec & Validate', schema: VERDICT_SCHEMA },
-  ).then((v) => (v ? { feature: f, spec, verdict: v } : null)),
+  (spec, f) => spec
+    ? agent(
+        `${CONTEXT}\n\nAdversarially validate this feature spec. Be a skeptic: your job is to find why it might NOT be worth building.\n\nFeature: ${JSON.stringify(f)}\nSpec: ${JSON.stringify(spec)}\nCurrent-product inventory: ${invJson}\n\nAssess: (1) is it genuinely NEW versus what already exists? (2) real, sizable user value or just nice-to-have? (3) feasible in the current architecture and stack? (4) real competitor precedent or user demand, or speculative? (5) maintenance burden. Return a verdict (build / maybe / drop), a 1-10 confidence score, the strongest objections, and concrete refinements that would make it stronger.`,
+        { label: `validate:${f.title}`, phase: 'Spec & Validate', schema: VERDICT_SCHEMA },
+      ).then((v) => (v ? { feature: f, spec, verdict: v } : null))
+    : null,
 )
 
 const clean = specced.filter(Boolean)

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -24,15 +24,20 @@ export const meta = {
 // `args` can cross the Workflow tool boundary as an already-parsed object or as
 // a JSON string (harness-dependent). Normalize to an object so scope/depth are
 // honored rather than silently falling back to the expensive exhaustive default.
-const ARGS = typeof args === 'string'
-  ? (() => { try { return JSON.parse(args) || {} } catch { return {} } })()
-  : (args || {})
+const ARGS =
+  typeof args === 'string'
+    ? (() => { try { return JSON.parse(args) || {} } catch { return {} } })()
+    : typeof args === 'undefined'
+      ? {}
+      : (args || {})
 const product = ARGS.product || ''
 
 const VALID_SCOPES = ['mixed', 'internal', 'competitor']
 const VALID_DEPTHS = ['exhaustive', 'quick']
-const rawScope = String(ARGS.scope || 'mixed').trim().toLowerCase()
-const rawDepth = String(ARGS.depth || 'exhaustive').trim().toLowerCase()
+const scopeInput = ARGS.scope === undefined ? 'mixed' : ARGS.scope
+const depthInput = ARGS.depth === undefined ? 'exhaustive' : ARGS.depth
+const rawScope = typeof scopeInput === 'string' ? scopeInput.trim().toLowerCase() : ''
+const rawDepth = typeof depthInput === 'string' ? depthInput.trim().toLowerCase() : ''
 if (!VALID_SCOPES.includes(rawScope) || !VALID_DEPTHS.includes(rawDepth)) {
   return {
     error: 'invalid-args',
@@ -196,6 +201,10 @@ const ideaResults = await parallel(LENSES.map((lens) => () => agent(
 
 const allIdeas = ideaResults.filter(Boolean).flatMap((r) => (r && r.ideas) || [])
 log(`${allIdeas.length} raw ideas from ${LENSES.length} lenses`)
+if (!allIdeas.length) {
+  log('No ideas survived ideation - cannot curate a shortlist. Aborting.')
+  return { error: 'empty-ideation' }
+}
 
 // ---- Phase 3: Shortlist (barrier: needs every idea at once to dedup) ------
 phase('Shortlist')
@@ -223,7 +232,7 @@ const specced = await pipeline(
   (spec, f) => agent(
     `${CONTEXT}\n\nAdversarially validate this feature spec. Be a skeptic: your job is to find why it might NOT be worth building.\n\nFeature: ${JSON.stringify(f)}\nSpec: ${JSON.stringify(spec)}\nCurrent-product inventory: ${invJson}\n\nAssess: (1) is it genuinely NEW versus what already exists? (2) real, sizable user value or just nice-to-have? (3) feasible in the current architecture and stack? (4) real competitor precedent or user demand, or speculative? (5) maintenance burden. Return a verdict (build / maybe / drop), a 1-10 confidence score, the strongest objections, and concrete refinements that would make it stronger.`,
     { label: `validate:${f.title}`, phase: 'Spec & Validate', schema: VERDICT_SCHEMA },
-  ).then((v) => ({ feature: f, spec, verdict: v })),
+  ).then((v) => (v ? { feature: f, spec, verdict: v } : null)),
 )
 
 const clean = specced.filter(Boolean)

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -1,6 +1,6 @@
 // The Workflow harness statically extracts this `meta` object from source text
 // and executes the rest of this file's body inside its own async wrapper - it
-// does not load this file as a plain Node ES module. The `export` keyword above
+// does not load this file as a plain Node ES module. The `export` keyword below
 // and the top-level `await`/`return` further down are both legal only under
 // that harness-specific execution model, not under `node script.js`.
 export const meta = {
@@ -162,8 +162,8 @@ const SPEC_SCHEMA = {
   properties: {
     title: { type: 'string' }, problem: { type: 'string' }, solution: { type: 'string' },
     userValue: { type: 'string' }, architectureFit: { type: 'string' },
-    scope: { type: 'array', items: { type: 'string' } },
-    successMetrics: { type: 'array', items: { type: 'string' } },
+    scope: { type: 'array', minItems: 1, items: { type: 'string' } },
+    successMetrics: { type: 'array', minItems: 1, items: { type: 'string' } },
     openQuestions: { type: 'array', items: { type: 'string' } },
   },
   required: ['title', 'problem', 'solution', 'userValue', 'architectureFit', 'scope', 'successMetrics', 'openQuestions'],

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -125,7 +125,18 @@ const truncateField = (s) => (typeof s === 'string' && s.length > MAX_FIELD_CHAR
 // would leave any oversized extra field completely uncapped regardless of
 // how well the known fields are truncated.
 const compactCompetitor = (c) => {
-  const cap = (arr) => ((arr && arr.length > 3 ? arr.slice(0, 3) : arr) || []).map(truncateField)
+  // Blindly slicing the first 3 entries can drop the only nonblank one if it
+  // isn't among them (e.g. ["", " ", "", "actual capability"]) - the same
+  // hasSubstance check downstream still sees the full unbounded array and
+  // reports the track as usable, while compaction silently kept only filler.
+  // Prioritize nonblank entries so real evidence survives capping first.
+  const isSubstantive = (s) => typeof s === 'string' && s.trim().length > 0
+  const cap = (arr) => {
+    const list = arr || []
+    const substantive = list.filter(isSubstantive)
+    const filler = list.filter((s) => !isSubstantive(s))
+    return [...substantive, ...filler].slice(0, 3).map(truncateField)
+  }
   return { name: truncateField(c.name), url: truncateField(c.url), whatItIs: truncateField(c.whatItIs), notableFeatures: cap(c.notableFeatures), lessonsForUs: cap(c.lessonsForUs) }
 }
 const boundedCompetitorJson = (results) => {
@@ -197,10 +208,17 @@ const COMPETITOR_SCHEMA = {
   required: ['competitors'],
 }
 
+// maxItems bounds ideas per lens at the source - unlike allIdeas/clean
+// (ranked/selected collections downstream that must never be
+// character-truncated, see docs/learnings.md), this caps how many ideas a
+// single ideator can generate in the first place, so the curator's prompt
+// can't be blown up by one over-eager lens without ever needing to drop an
+// already-generated candidate.
+const MAX_IDEAS_PER_LENS = 10
 const IDEAS_SCHEMA = {
   type: 'object',
   properties: {
-    ideas: { type: 'array', items: { type: 'object', properties: {
+    ideas: { type: 'array', maxItems: MAX_IDEAS_PER_LENS, items: { type: 'object', properties: {
       title: { type: 'string' }, description: { type: 'string' }, lens: { type: 'string' },
       valueHypothesis: { type: 'string' }, evidence: { type: 'string' }, effort: { type: 'string', enum: ['S', 'M', 'L'] },
     }, required: ['title', 'description', 'lens', 'valueHypothesis', 'evidence', 'effort'] } },

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -242,14 +242,19 @@ const SHORTLIST_SCHEMA = {
   required: ['features'],
 }
 
+// maxLength/maxItems bound each spec at the source, same reasoning as
+// IDEAS_SCHEMA above - up to SHORTLIST_MAX specs get concatenated into one
+// synthesizer prompt via JSON.stringify(clean), so an unbounded scalar or
+// array field on even one spec can overflow that prompt regardless of how
+// many specs there are.
 const SPEC_SCHEMA = {
   type: 'object',
   properties: {
-    title: { type: 'string' }, problem: { type: 'string', pattern: '\\S' }, solution: { type: 'string', pattern: '\\S' },
-    userValue: { type: 'string', pattern: '\\S' }, architectureFit: { type: 'string', pattern: '\\S' },
-    scope: { type: 'array', minItems: 1, items: { type: 'string', pattern: '\\S' } },
-    successMetrics: { type: 'array', minItems: 1, items: { type: 'string', pattern: '\\S' } },
-    openQuestions: { type: 'array', items: { type: 'string' } },
+    title: { type: 'string', maxLength: 100 }, problem: { type: 'string', pattern: '\\S', maxLength: 500 }, solution: { type: 'string', pattern: '\\S', maxLength: 500 },
+    userValue: { type: 'string', pattern: '\\S', maxLength: 400 }, architectureFit: { type: 'string', pattern: '\\S', maxLength: 500 },
+    scope: { type: 'array', minItems: 1, maxItems: 10, items: { type: 'string', pattern: '\\S', maxLength: 150 } },
+    successMetrics: { type: 'array', minItems: 1, maxItems: 10, items: { type: 'string', pattern: '\\S', maxLength: 150 } },
+    openQuestions: { type: 'array', maxItems: 10, items: { type: 'string', maxLength: 200 } },
   },
   required: ['title', 'problem', 'solution', 'userValue', 'architectureFit', 'scope', 'successMetrics', 'openQuestions'],
 }

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -1,0 +1,229 @@
+export const meta = {
+  name: 'feature-discovery',
+  description:
+    'Exhaustive multi-agent discovery of new value-adding features for a product: map the current product from its repo, research competitors, ideate across product lenses, dedup and shortlist, spec and adversarially validate the winners, then synthesize a ranked roadmap.',
+  phases: [
+    { title: 'Ground' },
+    { title: 'Ideate' },
+    { title: 'Shortlist' },
+    { title: 'Spec & Validate' },
+    { title: 'Synthesize' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Parameters (passed via the Workflow tool's `args`)
+//   product: string  - one-line description of the product. Optional; if
+//                      omitted, agents infer it from the current repository.
+//   scope:   'mixed' | 'internal' | 'competitor'   (default 'mixed')
+//   depth:   'exhaustive' | 'quick'                 (default 'exhaustive')
+// The product is ALWAYS mapped first regardless of scope, because ideation
+// must know what already exists to avoid re-proposing it. `scope` controls
+// whether competitor research runs and where ideators look for gaps.
+// ---------------------------------------------------------------------------
+// `args` can cross the Workflow tool boundary as an already-parsed object or as
+// a JSON string (harness-dependent). Normalize to an object so scope/depth are
+// honored rather than silently falling back to the expensive exhaustive default.
+const ARGS = typeof args === 'string'
+  ? (() => { try { return JSON.parse(args) || {} } catch { return {} } })()
+  : (args || {})
+const product = ARGS.product || ''
+const scope = ARGS.scope || 'mixed'
+const depth = ARGS.depth || 'exhaustive'
+const includeCompetitors = scope !== 'internal'
+const emphasis =
+  scope === 'internal'
+    ? 'Focus ideas on gaps in the existing product.'
+    : scope === 'competitor'
+      ? 'Focus ideas on capabilities competitors have that this product lacks.'
+      : 'Draw ideas from a balanced mix of internal gaps and competitor precedent.'
+
+const PRODUCT = product
+  ? `The product is: ${product}.`
+  : 'The product is the one built in the current repository; infer what it is from the code, README, and docs.'
+
+const CONTEXT = `${PRODUCT} Its source code is the current working directory. Map what it does from the repo: entry points and routes, data models, content, services, config, and docs. If a connected MCP server or CLI exposes live product data, you may call it to inspect real usage.`
+
+const ALL_LENSES = [
+  { key: 'discoverability', name: 'Discoverability & acquisition', brief: 'how people and AI agents find the product and its content: search, SEO, structured data, machine-readable surfaces, integrations, shareable and programmatic access.' },
+  { key: 'core-value', name: 'Core value & depth', brief: 'the richness, completeness, and freshness of the product\'s core objects and the primary workflows built on them.' },
+  { key: 'user-ux', name: 'User & contributor UX', brief: 'onboarding, the core task flows, editing and correction, and how data or content stays up to date.' },
+  { key: 'monetization', name: 'Monetization & sustainability', brief: 'ethical, non-annoying ways the product can fund itself: subscriptions, usage tiers, sponsorship, paid placement, pro access.' },
+  { key: 'engagement', name: 'Engagement & retention', brief: 'reasons for users to return: accounts, notifications, digests, collections, collaboration, following.' },
+  { key: 'trust', name: 'Trust, quality & credibility', brief: 'how the product earns trust: verification, moderation, provenance, ratings, transparency about data and sources.' },
+  { key: 'ia-nav', name: 'Information architecture & navigation', brief: 'how content and features are organized and traversed: filtering, faceting, related-entity links, comparison, cross-surface flows.' },
+]
+
+const LENSES = depth === 'quick' ? ALL_LENSES.slice(0, 4) : ALL_LENSES
+const SEGMENT_COUNT = depth === 'quick' ? 2 : 4
+const SHORTLIST_TARGET = depth === 'quick' ? '5-6' : '8-12'
+
+// ---- Schemas --------------------------------------------------------------
+const INVENTORY_SCHEMA = {
+  type: 'object',
+  properties: {
+    features: { type: 'array', items: { type: 'object', properties: { name: { type: 'string' }, description: { type: 'string' }, files: { type: 'array', items: { type: 'string' } } }, required: ['name', 'description'] } },
+    dataTypes: { type: 'array', items: { type: 'object', properties: { name: { type: 'string' }, fields: { type: 'array', items: { type: 'string' } }, notes: { type: 'string' } }, required: ['name'] } },
+    interfaces: { type: 'array', items: { type: 'string' } },
+    gaps: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['features', 'gaps'],
+}
+
+const SEGMENTS_SCHEMA = {
+  type: 'object',
+  properties: {
+    segments: { type: 'array', items: { type: 'object', properties: {
+      key: { type: 'string' }, focus: { type: 'string' }, angle: { type: 'string' },
+    }, required: ['key', 'focus'] } },
+  },
+  required: ['segments'],
+}
+
+const COMPETITOR_SCHEMA = {
+  type: 'object',
+  properties: {
+    segment: { type: 'string' },
+    competitors: { type: 'array', items: { type: 'object', properties: {
+      name: { type: 'string' }, url: { type: 'string' }, whatItIs: { type: 'string' },
+      notableFeatures: { type: 'array', items: { type: 'string' } },
+      lessonsForUs: { type: 'array', items: { type: 'string' } },
+    }, required: ['name', 'whatItIs'] } },
+  },
+  required: ['competitors'],
+}
+
+const IDEAS_SCHEMA = {
+  type: 'object',
+  properties: {
+    ideas: { type: 'array', items: { type: 'object', properties: {
+      title: { type: 'string' }, description: { type: 'string' }, lens: { type: 'string' },
+      valueHypothesis: { type: 'string' }, evidence: { type: 'string' }, effort: { type: 'string', enum: ['S', 'M', 'L'] },
+    }, required: ['title', 'description', 'valueHypothesis'] } },
+  },
+  required: ['ideas'],
+}
+
+const SHORTLIST_SCHEMA = {
+  type: 'object',
+  properties: {
+    features: { type: 'array', items: { type: 'object', properties: {
+      title: { type: 'string' }, description: { type: 'string' }, value: { type: 'string' },
+      effort: { type: 'string' }, evidence: { type: 'string' },
+    }, required: ['title', 'description'] } },
+  },
+  required: ['features'],
+}
+
+const SPEC_SCHEMA = {
+  type: 'object',
+  properties: {
+    title: { type: 'string' }, problem: { type: 'string' }, solution: { type: 'string' },
+    userValue: { type: 'string' }, architectureFit: { type: 'string' },
+    scope: { type: 'array', items: { type: 'string' } },
+    successMetrics: { type: 'array', items: { type: 'string' } },
+    openQuestions: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['title', 'problem', 'solution'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: {
+    verdict: { type: 'string', enum: ['build', 'maybe', 'drop'] },
+    confidence: { type: 'number' },
+    objections: { type: 'array', items: { type: 'string' } },
+    refinements: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['verdict', 'confidence'],
+}
+
+// ---- Phase 1: Ground ------------------------------------------------------
+phase('Ground')
+log(`scope=${scope}, depth=${depth} - mapping the product${includeCompetitors ? ` + planning ${SEGMENT_COUNT} competitor tracks` : ''}`)
+
+const groundThunks = [
+  () => agent(
+    `${CONTEXT}\n\nYou are the PRODUCT-MAPPER. Explore this repository thoroughly: entry points and routes, components, the data and content files and their shapes, services, any externally callable interfaces (HTTP APIs, MCP tools, CLIs), config, and docs. Produce a precise inventory of what the product does TODAY: every user-facing feature or surface, every content/data type and its fields, every callable interface, and any obvious gaps, rough edges, or half-finished areas you notice. Cite concrete file paths.`,
+    { label: 'map:current-product', phase: 'Ground', schema: INVENTORY_SCHEMA },
+  ),
+]
+if (includeCompetitors) {
+  groundThunks.push(() => agent(
+    `${CONTEXT}\n\nYou are the SEGMENT PLANNER. Based on what this product is, propose ${SEGMENT_COUNT} distinct competitor or market segments worth researching to find features this product could adopt. Cover different angles: direct competitors, adjacent tools, best-in-class examples of a specific capability, and how modern products in this space expose themselves to AI agents. For each segment return a short key, a focus (what kinds of products or sites to research), and the angle to study them from.`,
+    { label: 'plan:competitor-segments', phase: 'Ground', schema: SEGMENTS_SCHEMA },
+  ))
+}
+
+const ground = await parallel(groundThunks)
+const inventory = ground[0]
+if (!inventory) {
+  log('Product mapping failed - cannot ground ideation. Aborting.')
+  return { error: 'product-mapping-failed' }
+}
+
+const segments = includeCompetitors && ground[1] && ground[1].segments ? ground[1].segments : []
+if (includeCompetitors && !segments.length) log('Segment planner returned nothing - proceeding without competitor research.')
+
+const competitorResults = segments.length
+  ? (await parallel(segments.map((seg) => () => agent(
+      `${CONTEXT}\n\nYou are a COMPETITOR ANALYST focused on: ${seg.focus}. Use web search and fetch to research real, current products and sites in this segment. For each, capture what it is, its URL, the notable features or content that make it valuable, how it handles ${seg.angle || 'its core job'}, and what this product could learn or adopt. Prioritize concrete, verifiable features over generic advice.`,
+      { label: `competitor:${seg.key}`, phase: 'Ground', schema: COMPETITOR_SCHEMA },
+    )))).filter(Boolean)
+  : []
+
+// ---- Phase 2: Ideate ------------------------------------------------------
+phase('Ideate')
+const groundContext = JSON.stringify({ inventory, competitors: competitorResults })
+
+const ideaResults = await parallel(LENSES.map((lens) => () => agent(
+  `${CONTEXT}\n\nGround truth (current-product inventory + competitor research):\n${groundContext}\n\nYou are a PRODUCT IDEATOR working the "${lens.name}" lens: ${lens.brief}\n\n${emphasis}\n\nPropose new, value-adding features or improvements through this lens. Rules: never propose anything the inventory shows already exists; ground every idea in either a concrete product gap or a named competitor precedent; prefer depth and specificity over a long list of shallow ideas. For each idea give: title, description, the lens, the user-value hypothesis, the evidence (the gap or competitor it comes from), and a rough effort estimate (S, M, or L).`,
+  { label: `ideate:${lens.key}`, phase: 'Ideate', schema: IDEAS_SCHEMA },
+)))
+
+const allIdeas = ideaResults.filter(Boolean).flatMap((r) => (r && r.ideas) || [])
+log(`${allIdeas.length} raw ideas from ${LENSES.length} lenses`)
+
+// ---- Phase 3: Shortlist (barrier: needs every idea at once to dedup) ------
+phase('Shortlist')
+const shortlist = await agent(
+  `${CONTEXT}\n\nHere are ${allIdeas.length} candidate ideas from parallel ideators across different lenses:\n${JSON.stringify(allIdeas)}\n\nCurrent-product inventory:\n${JSON.stringify(inventory)}\n\nYou are the CURATOR. Merge duplicate and near-duplicate ideas into single consolidated items. Remove anything that already exists or is trivial. Rank the survivors by value-to-effort and select the TOP ${SHORTLIST_TARGET} for full speccing. For each selected item return: a clear title, a merged description, why it matters (value), rough effort, and the supporting evidence (gaps and/or competitors).`,
+  { label: 'curate:shortlist', phase: 'Shortlist', schema: SHORTLIST_SCHEMA },
+)
+
+const features = (shortlist && shortlist.features) || []
+if (!features.length) {
+  log('Curator returned no features. Aborting before spec phase.')
+  return { error: 'empty-shortlist', ideaCount: allIdeas.length }
+}
+log(`${features.length} features shortlisted for spec + validation`)
+
+// ---- Phase 4: Spec + adversarial validate (pipeline, per feature) --------
+phase('Spec & Validate')
+const invJson = JSON.stringify(inventory)
+const specced = await pipeline(
+  features,
+  (f) => agent(
+    `${CONTEXT}\n\nCurrent-product inventory (for feasibility grounding):\n${invJson}\n\nWrite a crisp product + engineering spec for this feature:\n${JSON.stringify(f)}\n\nInclude: problem statement, proposed solution, user value, how it fits the existing architecture and stack (data-model changes, new pages/components/endpoints, interface implications), rough scope/milestones, success metrics, and open questions/risks. Be concrete about implementation given the current codebase.`,
+    { label: `spec:${f.title}`, phase: 'Spec & Validate', schema: SPEC_SCHEMA },
+  ),
+  (spec, f) => agent(
+    `${CONTEXT}\n\nAdversarially validate this feature spec. Be a skeptic: your job is to find why it might NOT be worth building.\n\nFeature: ${JSON.stringify(f)}\nSpec: ${JSON.stringify(spec)}\nCurrent-product inventory: ${invJson}\n\nAssess: (1) is it genuinely NEW versus what already exists? (2) real, sizable user value or just nice-to-have? (3) feasible in the current architecture and stack? (4) real competitor precedent or user demand, or speculative? (5) maintenance burden. Return a verdict (build / maybe / drop), a 1-10 confidence score, the strongest objections, and concrete refinements that would make it stronger.`,
+    { label: `validate:${f.title}`, phase: 'Spec & Validate', schema: VERDICT_SCHEMA },
+  ).then((v) => ({ feature: f, spec, verdict: v })),
+)
+
+const clean = specced.filter(Boolean)
+
+// ---- Phase 5: Synthesize --------------------------------------------------
+phase('Synthesize')
+const report = await agent(
+  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${JSON.stringify(competitorResults)}\nSpecced & validated features: ${JSON.stringify(clean)}\n\nStructure the report as: (1) a short executive summary; (2) key gaps found, split into internal gaps and gaps versus competitors; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
+  { label: 'synthesize:report', phase: 'Synthesize' },
+)
+
+return {
+  report,
+  meta: { product: product || '(mapped from repo)', scope, depth, competitorSegments: competitorResults.length, lenses: LENSES.length },
+  counts: { rawIdeas: allIdeas.length, shortlisted: features.length, specced: clean.length },
+}

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -1,3 +1,8 @@
+// The Workflow harness statically extracts this `meta` object from source text
+// and executes the rest of this file's body inside its own async wrapper - it
+// does not load this file as a plain Node ES module. The `export` keyword above
+// and the top-level `await`/`return` further down are both legal only under
+// that harness-specific execution model, not under `node script.js`.
 export const meta = {
   name: 'feature-discovery',
   description:
@@ -24,12 +29,14 @@ export const meta = {
 // `args` can cross the Workflow tool boundary as an already-parsed object or as
 // a JSON string (harness-dependent). Normalize to an object so scope/depth are
 // honored rather than silently falling back to the expensive exhaustive default.
-const ARGS =
+const parsedArgs =
   typeof args === 'string'
-    ? (() => { try { return JSON.parse(args) || {} } catch { return {} } })()
-    : typeof args === 'undefined'
-      ? {}
-      : (args || {})
+    ? (() => { try { return { ok: true, value: JSON.parse(args) } } catch { return { ok: false } } })()
+    : { ok: true, value: typeof args === 'undefined' ? {} : (args || {}) }
+if (!parsedArgs.ok) {
+  return { error: 'invalid-args', reason: 'malformed-json-args' }
+}
+const ARGS = parsedArgs.value || {}
 const product = ARGS.product || ''
 
 const VALID_SCOPES = ['mixed', 'internal', 'competitor']
@@ -193,7 +200,13 @@ if (!inventory) {
 }
 
 const segments = includeCompetitors && ground[1] && ground[1].segments ? ground[1].segments : []
-if (includeCompetitors && !segments.length) log('Segment planner returned nothing - proceeding without competitor research.')
+if (includeCompetitors && !segments.length) {
+  if (scope === 'competitor') {
+    log('Segment planner returned nothing for a competitor-focused run - aborting rather than reporting on missing competitor data.')
+    return { error: 'competitor-research-failed' }
+  }
+  log('Segment planner returned nothing - proceeding without competitor research.')
+}
 
 const competitorResults = segments.length
   ? (await parallel(segments.map((seg) => () => agent(
@@ -201,6 +214,15 @@ const competitorResults = segments.length
       { label: `competitor:${seg.key}`, phase: 'Ground', schema: COMPETITOR_SCHEMA },
     )))).filter(Boolean)
   : []
+
+// Segments planned but every analyst still failed (e.g. WebSearch/WebFetch not
+// pre-approved in the session - Workflow sub-agents run in the background and
+// can't prompt for tool approval). Same failure mode as the segment-planning
+// guard above, just one step later in the pipeline.
+if (scope === 'competitor' && includeCompetitors && segments.length && !competitorResults.length) {
+  log('Competitor research produced no results for a competitor-focused run - aborting rather than reporting on missing data.')
+  return { error: 'competitor-research-failed' }
+}
 
 // ---- Phase 2: Ideate ------------------------------------------------------
 phase('Ideate')
@@ -221,7 +243,7 @@ if (!allIdeas.length) {
 // ---- Phase 3: Shortlist (barrier: needs every idea at once to dedup) ------
 phase('Shortlist')
 const shortlist = await agent(
-  `${CONTEXT}\n\nHere are ${allIdeas.length} candidate ideas from parallel ideators across different lenses:\n${boundedJson(allIdeas)}\n\nCurrent-product inventory:\n${boundedJson(inventory)}\n\nYou are the CURATOR. Merge duplicate and near-duplicate ideas into single consolidated items. Remove anything that already exists or is trivial. Rank the survivors by value-to-effort and select the TOP ${SHORTLIST_TARGET} for full speccing. For each selected item return: a clear title, a merged description, why it matters (value), rough effort, and the supporting evidence (gaps and/or competitors).`,
+  `${CONTEXT}\n\nHere are ${allIdeas.length} candidate ideas from parallel ideators across different lenses:\n${JSON.stringify(allIdeas)}\n\nCurrent-product inventory:\n${boundedJson(inventory)}\n\nYou are the CURATOR. Merge duplicate and near-duplicate ideas into single consolidated items. Remove anything that already exists or is trivial. Rank the survivors by value-to-effort and select the TOP ${SHORTLIST_TARGET} for full speccing. For each selected item return: a clear title, a merged description, why it matters (value), rough effort, and the supporting evidence (gaps and/or competitors).`,
   { label: 'curate:shortlist', phase: 'Shortlist', schema: SHORTLIST_SCHEMA },
 )
 
@@ -256,7 +278,7 @@ if (!clean.length) {
 // ---- Phase 5: Synthesize --------------------------------------------------
 phase('Synthesize')
 const report = await agent(
-  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedJson(competitorResults)}\nSpecced & validated features: ${boundedJson(clean)}\n\nStructure the report as: (1) a short executive summary; (2) key gaps found, split into internal gaps and gaps versus competitors; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
+  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedJson(competitorResults)}\nSpecced & validated features: ${JSON.stringify(clean)}\n\nStructure the report as: (1) a short executive summary; (2) key gaps found, split into internal gaps and gaps versus competitors; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
   { label: 'synthesize:report', phase: 'Synthesize' },
 )
 

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -114,7 +114,7 @@ const INVENTORY_SCHEMA = {
 const SEGMENTS_SCHEMA = {
   type: 'object',
   properties: {
-    segments: { type: 'array', items: { type: 'object', properties: {
+    segments: { type: 'array', maxItems: SEGMENT_COUNT, items: { type: 'object', properties: {
       key: { type: 'string' }, focus: { type: 'string' }, angle: { type: 'string' },
     }, required: ['key', 'focus'] } },
   },
@@ -140,7 +140,7 @@ const IDEAS_SCHEMA = {
     ideas: { type: 'array', items: { type: 'object', properties: {
       title: { type: 'string' }, description: { type: 'string' }, lens: { type: 'string' },
       valueHypothesis: { type: 'string' }, evidence: { type: 'string' }, effort: { type: 'string', enum: ['S', 'M', 'L'] },
-    }, required: ['title', 'description', 'valueHypothesis', 'evidence', 'effort'] } },
+    }, required: ['title', 'description', 'lens', 'valueHypothesis', 'evidence', 'effort'] } },
   },
   required: ['ideas'],
 }
@@ -176,7 +176,7 @@ const VERDICT_SCHEMA = {
     objections: { type: 'array', items: { type: 'string' } },
     refinements: { type: 'array', items: { type: 'string' } },
   },
-  required: ['verdict', 'confidence'],
+  required: ['verdict', 'confidence', 'objections', 'refinements'],
 }
 
 // ---- Phase 1: Ground ------------------------------------------------------
@@ -214,15 +214,19 @@ if (includeCompetitors && !segments.length) {
 
 const competitorResults = segments.length
   ? (await parallel(segments.map((seg) => () => agent(
-      `${CONTEXT}\n\nYou are a COMPETITOR ANALYST focused on: ${seg.focus}. Use web search and fetch to research real, current products and sites in this segment. For each, capture what it is, its URL, the notable features or content that make it valuable, how it handles ${seg.angle || 'its core job'}, and what this product could learn or adopt. Prioritize concrete, verifiable features over generic advice.`,
+      `${CONTEXT}\n\nYou are a COMPETITOR ANALYST focused on: ${seg.focus}. Use WebSearch and WebFetch to research real, current products and sites in this segment. For each, capture what it is, its URL, the notable features or content that make it valuable, how it handles ${seg.angle || 'its core job'}, and what this product could learn or adopt. Prioritize concrete, verifiable features over generic advice.`,
       { label: `competitor:${seg.key}`, phase: 'Ground', schema: COMPETITOR_SCHEMA },
     )))).filter(Boolean)
   : []
 
 // A truthy per-segment result can still carry zero competitors (the schema
 // allows `{ competitors: [] }`), so count the flattened total rather than just
-// how many analyst calls returned something.
-const competitorCount = competitorResults.reduce((sum, r) => sum + ((r && r.competitors) || []).length, 0)
+// how many analyst calls returned something. Only `name`+`whatItIs` are
+// schema-required, so a competitor entry can be little more than a label
+// ("Rival: a tool") - count only entries with actual substance (notable
+// features or lessons), not just array presence.
+const hasSubstance = (c) => c && (((c.notableFeatures && c.notableFeatures.length) || 0) + ((c.lessonsForUs && c.lessonsForUs.length) || 0)) > 0
+const competitorCount = competitorResults.reduce((sum, r) => sum + ((r && r.competitors) || []).filter(hasSubstance).length, 0)
 const hasCompetitorData = competitorCount > 0
 
 // Segments planned but every analyst still failed or returned nothing usable

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -310,12 +310,16 @@ if (!allIdeas.length) {
   log('No ideas survived ideation - cannot curate a shortlist. Aborting.')
   return { error: 'empty-ideation' }
 }
-// A lens whose ideator call failed is indistinguishable downstream from a
-// lens that legitimately had nothing to add - both just contribute zero
-// ideas. Note the count so the synthesizer doesn't report full lens coverage
-// it didn't actually get.
-const lensCoverageNote = successfulLenses.length < LENSES.length
-  ? ` ${LENSES.length - successfulLenses.length} of ${LENSES.length} ideation lens(es) failed to return results and were skipped - mention this gap in the executive summary rather than silently omitting it.`
+// A lens whose ideator call failed outright is indistinguishable downstream
+// from one that completed but genuinely found nothing to propose - both just
+// contribute zero ideas. A truthy `{ ideas: [] }` response still counts
+// toward successfulLenses (the call didn't fail), so it doesn't by itself
+// mean the lens is missing - only lenses that contributed zero ideas overall
+// are worth flagging as a gap, same principle as the hasSubstance filter used
+// for competitor tracks above.
+const contributingLenses = successfulLenses.filter((r) => r.ideas && r.ideas.length)
+const lensCoverageNote = contributingLenses.length < LENSES.length
+  ? ` ${LENSES.length - contributingLenses.length} of ${LENSES.length} ideation lens(es) failed to return results or found nothing to propose and are not reflected below - mention this gap in the executive summary rather than silently omitting it.`
   : ''
 
 // ---- Phase 3: Shortlist (barrier: needs every idea at once to dedup) ------
@@ -391,6 +395,13 @@ if (!report) {
 
 return {
   report,
-  meta: { product: product || '(mapped from repo)', scope, depth, competitorSegments: competitorResults.length, lenses: successfulLenses.length },
+  meta: {
+    product: product || '(mapped from repo)',
+    scope,
+    depth,
+    competitorSegmentsPlanned: segments.length,
+    competitorSegmentsCompleted: usableTrackCount,
+    lenses: contributingLenses.length,
+  },
   counts: { rawIdeas: allIdeas.length, shortlisted: features.length, specced: clean.length },
 }

--- a/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
+++ b/plugins/feature-discovery/skills/feature-discovery/scripts/feature-discovery.workflow.js
@@ -100,6 +100,25 @@ const boundedJson = (value) => {
     : json
 }
 
+// competitorResults is one entry per researched segment - unlike inventory
+// (a single object), it genuinely grows with segment count, so it still needs
+// a budget. But bounding the whole serialized array as one string means later
+// segments can be entirely excluded once earlier ones consume the budget,
+// while hasCompetitorData/competitorCount are computed from the full,
+// untruncated data - silently reporting success while omitting whole tracks.
+// Split the budget evenly per segment instead, so every segment keeps at
+// least a proportional share of representation.
+const boundedCompetitorJson = (results) => {
+  if (!results.length) return '[]'
+  const perSegmentBudget = Math.max(1, Math.floor(MAX_CONTEXT_CHARS / results.length))
+  return `[${results.map((r) => {
+    const json = JSON.stringify(r)
+    return json.length > perSegmentBudget
+      ? `${json.slice(0, perSegmentBudget)}...(truncated)`
+      : json
+  }).join(', ')}]`
+}
+
 // ---- Schemas --------------------------------------------------------------
 const INVENTORY_SCHEMA = {
   type: 'object',
@@ -115,7 +134,7 @@ const INVENTORY_SCHEMA = {
 const SEGMENTS_SCHEMA = {
   type: 'object',
   properties: {
-    segments: { type: 'array', maxItems: SEGMENT_COUNT, items: { type: 'object', properties: {
+    segments: { type: 'array', minItems: SEGMENT_COUNT, maxItems: SEGMENT_COUNT, items: { type: 'object', properties: {
       key: { type: 'string' }, focus: { type: 'string' }, angle: { type: 'string' },
     }, required: ['key', 'focus'] } },
   },
@@ -258,7 +277,7 @@ phase('Ideate')
 // never bounded: truncating it would silently hide already-built features
 // from novelty checks in every downstream phase. Only competitor research
 // (which grows with segment count) gets a character budget here.
-const groundContext = `Inventory: ${JSON.stringify(inventory)}\nCompetitor research: ${boundedJson(competitorResults)}`
+const groundContext = `Inventory: ${JSON.stringify(inventory)}\nCompetitor research: ${boundedCompetitorJson(competitorResults)}`
 
 const ideaResults = await parallel(LENSES.map((lens) => () => agent(
   `${CONTEXT}\n\nGround truth (current-product inventory + competitor research):\n${groundContext}\n\nYou are a PRODUCT IDEATOR working the "${lens.name}" lens: ${lens.brief}\n\n${emphasis}\n\nPropose new, value-adding features or improvements through this lens. Rules: never propose anything the inventory shows already exists; ground every idea in either a concrete product gap or a named competitor precedent; prefer depth and specificity over a long list of shallow ideas. For each idea give: title, description, the lens, the user-value hypothesis, the evidence (the gap or competitor it comes from), and a rough effort estimate (S, M, or L).`,
@@ -297,7 +316,7 @@ const specced = await pipeline(
   ),
   (spec, f) => spec
     ? agent(
-        `${CONTEXT}\n\nAdversarially validate this feature spec. Be a skeptic: your job is to find why it might NOT be worth building.\n\nFeature: ${JSON.stringify(f)}\nSpec: ${JSON.stringify(spec)}\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedJson(competitorResults)}\n\nAssess: (1) is it genuinely NEW versus what already exists? (2) real, sizable user value or just nice-to-have? (3) feasible in the current architecture and stack? (4) real competitor precedent or user demand, or speculative - check this against the competitor research above, not just the feature's own evidence claim? (5) maintenance burden. Return a verdict (build / maybe / drop), a 1-10 confidence score, the strongest objections, and concrete refinements that would make it stronger.`,
+        `${CONTEXT}\n\nAdversarially validate this feature spec. Be a skeptic: your job is to find why it might NOT be worth building.\n\nFeature: ${JSON.stringify(f)}\nSpec: ${JSON.stringify(spec)}\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedCompetitorJson(competitorResults)}\n\nAssess: (1) is it genuinely NEW versus what already exists? (2) real, sizable user value or just nice-to-have? (3) feasible in the current architecture and stack? (4) real competitor precedent or user demand, or speculative - check this against the competitor research above, not just the feature's own evidence claim? (5) maintenance burden. Return a verdict (build / maybe / drop), a 1-10 confidence score, the strongest objections, and concrete refinements that would make it stronger.`,
         { label: `validate:${f.title}`, phase: 'Spec & Validate', schema: VERDICT_SCHEMA },
       ).then((v) => (v ? { feature: f, spec, verdict: v } : null))
     : null,
@@ -315,7 +334,7 @@ const gapsInstruction = hasCompetitorData
   ? 'key gaps found, split into internal gaps and gaps versus competitors'
   : 'key gaps found in the existing product (no competitor research was available for this run)'
 const report = await agent(
-  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedJson(competitorResults)}\nSpecced & validated features: ${JSON.stringify(clean)}\n\nStructure the report as: (1) a short executive summary; (2) ${gapsInstruction}; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
+  `${CONTEXT}\n\nYou are the SYNTHESIZER. Produce the final report in polished Markdown for the product owner.\n\nInputs:\nCurrent-product inventory: ${invJson}\nCompetitor research: ${boundedCompetitorJson(competitorResults)}\nSpecced & validated features: ${JSON.stringify(clean)}\n\nStructure the report as: (1) a short executive summary; (2) ${gapsInstruction}; (3) a RANKED roadmap table (rank, feature, value, effort, verdict, confidence); (4) a full spec section per recommended feature (only those the validator rated build or maybe, strongest first), incorporating the validator's refinements; (5) a short list of dropped ideas with one-line reasons; (6) a "quick wins vs bigger bets" split. Write in plain, skimmable prose. Use plain dashes, never em dashes.`,
   { label: 'synthesize:report', phase: 'Synthesize' },
 )
 


### PR DESCRIPTION
## What

Adds a new standalone plugin, **feature-discovery**, that turns "what should we build next?" into a researched, ranked roadmap. It runs a deterministic multi-agent `Workflow` pipeline over five phases:

**Ground** (map the repo + research competitors) → **Ideate** (7 value lenses in parallel) → **Shortlist** (dedup + rank) → **Spec & Validate** (spec writer + adversarial skeptic per feature) → **Synthesize** (ranked-roadmap Markdown report).

Ported from the open-source [feature-discovery-skill](https://github.com/fabianhug/feature-discovery-skill) by Fabian Hug (MIT).

## Why standalone (not a `pm` sub-skill)

It's a distinct capability from `pm:brainstorm`: brainstorm goes **deep on one feature** (interactive Q&A, one spec); this goes **wide across the whole product** (competitor research + ranked roadmap of many candidates). It's also the first plugin here to depend on the `Workflow` tool, so it declares that as a `compatibility:` prerequisite (mirroring how `cdt` declares its Agent-Teams flag).

## Key decisions

- **Engine started as a verbatim port, adapted through review** — prompts, 7 JSON schemas, and the 7 lenses began byte-for-byte from source, but diverged substantially across this PR's review cycles: argument validation/normalization, schema bounds (min/max item counts, required + nonblank content), hard-fail guards for empty ground/ideation/shortlist/validation/synthesis results, character-budgeted and per-record-compacted competitor research, and partial-fan-out coverage reporting (competitor tracks, ideation lenses, spec/validate pairs) were all added in response to review feedback. See the Credit section in SKILL.md/README.md for the current framing.
- **`${CLAUDE_SKILL_DIR}` script path** — the source's hardcoded `.claude/skills/...` path (and my first draft's `${CLAUDE_PLUGIN_ROOT}`) don't resolve from a skill body; `${CLAUDE_SKILL_DIR}` is the documented skill-body variable. Documented as a learning in `docs/learnings.md`.
- **Model-invocable** kept enabled (faithful to source), with a description guardrail against casual triggering given the ~35-40 agent fan-out at full depth.

## Verification

- `bun scripts/validate-plugins.mjs` — all 4 checks pass (11 plugins, no orphans, valid frontmatter)
- `node --check` on the engine; unit-tested the args normalization across string/object/undefined inputs
- **Live end-to-end run** (`scope: internal, depth: quick`): 19/19 agents, 0 errors, produced a full report (51→12→7 funnel earlier; 6 specced this run). The run also confirmed the args fix works in the real harness (`meta.scope=internal`, `meta.depth=quick`).

## Note (out of scope, pre-existing)

The live run surfaced pre-existing README drift unrelated to this change: cdt is described as "four modes" but ships five (adds `bugfix`); the tree's `ci-review # 10 review agents` annotation is stale. Left for a separate docs cleanup to keep this PR focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `feature-discovery` plugin and `/feature-discovery` command.
  * Introduced a guided workflow for researching products and competitors, generating ideas, ranking opportunities, validating proposals, and producing roadmap reports.
  * Added configurable product, scope, and analysis-depth options.
  * Results can be viewed as an artifact and optionally saved for later reference.
  * Added safeguards for incomplete research, invalid inputs, and unavailable competitor data.

* **Documentation**
  * Added installation, usage, workflow, licensing, and troubleshooting guidance.
  * Updated plugin listings, installation instructions, repository documentation, and guidance for referencing bundled tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
