### PR TITLE
docs: correct cdt mode count to five in README plugin table

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A monorepo of [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plug
 | Plugin | Category | Install | Description |
 |--------|----------|---------|-------------|
 | [council](./plugins/council/) | Code Review | Plugin or Skill | Orchestrate Gemini 3.6 Flash, Codex, GLM-5.2, and Kimi K3 for consensus-driven reviews |
-| [cdt](./plugins/cdt/) | Development | Plugin only | Multi-agent dev team with four modes: plan, dev, full, and auto via Agent Teams |
+| [cdt](./plugins/cdt/) | Development | Plugin only | Multi-agent dev team with five modes: plan, dev, full, auto, and bugfix via Agent Teams |
 | [pm](./plugins/pm/) | Productivity | Plugin or Skill | GitHub issue lifecycle: create, triage, and audit issues for LLM agent teams |
 | [plugin-dev](./plugins/plugin-dev/) | Development | Plugin or Skill | Scaffold plugins, validate SKILL.md frontmatter, audit hooks |
 | [temporal](./plugins/temporal/) | Development | Plugin or Skill | Temporal durable execution: CLI, SDK patterns, workflow orchestration |


### PR DESCRIPTION
## What

`README.md:13` described `cdt` as having **four** modes; it has **five**. Adds the missing `bugfix` mode.

**Before:** `Multi-agent dev team with four modes: plan, dev, full, and auto via Agent Teams`
**After:** `Multi-agent dev team with five modes: plan, dev, full, auto, and bugfix via Agent Teams`

Matches the SSoT (`.claude-plugin/marketplace.json`): _"Multi-agent development workflow with five modes: plan, dev, full, auto, and bugfix."_

Closes #237.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the `cdt` plugin documentation to list five Agent Teams modes, including plan, dev, full, auto, and bugfix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->