### PR TITLE
feat(cdt): strengthen reviewer teammate prompt with concrete checklist

### DIFF
--- a/plugins/cdt/skills/cdt/references/dev-workflow.md
+++ b/plugins/cdt/skills/cdt/references/dev-workflow.md
@@ -210,6 +210,16 @@ Teammate tool:
     - Inconsistencies with existing codebase patterns
     Your job is to find real problems. If everything is genuinely clean, approve — but never rubber-stamp.
 
+    Review checklist — check each for every changed file:
+    - Silent failures: No .get()/dict.get() fallbacks masking genuine missing keys
+    - Error handling: Exception handlers catch specific types, not bare except/catch
+    - Null safety: null/undefined/empty values don't pass through filters to overwrite existing data
+    - Trust boundaries: Client-provided IDs can't modify resources the user doesn't own
+    - Data integrity: Upsert operations don't reset timestamps or create duplicates
+    - Error paths: Error handling code is inside the try block, not after it
+    - State consistency: Error paths release locks, invalidate caches, clean up partial state
+    - Doc accuracy: Docstrings reference fields that exist; README describes implemented behavior
+
     3. Use /council to validate your review (quick quality for routine, review security or review architecture for critical concerns)
     4. Scan for stubs: rg "TODO|FIXME|HACK|XXX|stub"
     5. Blocking issues → message developer with file:line + fix suggestion


### PR DESCRIPTION
## Summary

Expands the CDT reviewer teammate prompt in `plugins/cdt/skills/cdt/references/dev-workflow.md` with an 8-item empirical review checklist covering:
- Silent failures (`.get()`/`dict.get()` masking missing keys)
- Error handling (typed exception catches)
- Null safety (filter bypass protection)
- Trust boundaries (ID ownership verification)
- Data integrity (safe upsert operations)
- Error paths (code placement inside try blocks)
- State consistency (lock release, cache invalidation, cleanup on errors)
- Doc accuracy (docstring fields and README claims)

Closes #155
Part of #149

## Verification

- `bun run validate` passed
- Prompt length stays compact (~55 lines)