### PR TITLE
feat(council): add RFC/protocol compliance checks to deep-review

### DIFF
--- a/plugins/council/agents/claude-deep-review.md
+++ b/plugins/council/agents/claude-deep-review.md
@@ -28,8 +28,15 @@ Focus on **security**, **bugs**, and **performance**. These are your three domai
 - **Secrets exposure**: Hardcoded credentials, API keys, tokens in code or config
 - **Access control**: Privilege escalation, missing authorization on endpoints, IDOR
 - **Cryptographic issues**: Weak algorithms, improper key management, missing encryption
-- **Input validation**: Unsanitized input at trust boundaries, missing validation
 - **CSRF/path traversal**: Request forgery, file access outside intended scope
+
+#### Input Validation & Protocol Compliance
+
+- **Unsanitized input at trust boundaries**: Missing validation on user/client input before use
+- **String length constraints**: Does the code enforce protocol-specified length limits? Examples: HTTP header values, push notification topics (RFC 8030: 32 chars), Telegram topic names (128 chars), database column widths. Check if user-controlled values can exceed these limits
+- **Character set constraints**: Does the code enforce protocol-specified character sets? Example: RFC 8030 Topic must be URL-safe base64 (`[A-Za-z0-9\-_]`). Raw user input may contain disallowed characters
+- **Content-Type enforcement**: Do API routes validate `Content-Type` headers before parsing? Accepting any content type when JSON is expected can bypass CSRF protections. Return 415 for unsupported media types
+- **Accept header enforcement**: Do API routes check `Accept` headers? Return 406 if the client requests an unsupported format
 
 #### Trust Boundary / Ownership Verification
 


### PR DESCRIPTION
Closes #156
Part of #149

## Summary

Expands the single `- **Input validation**` bullet under `### Security` in the `claude-deep-review` agent definition into a `#### Input Validation & Protocol Compliance` subsection, adding four protocol-specific heuristics:

- **String length constraints** — protocol-specified limits (RFC 8030: 32 chars, Telegram topic names: 128 chars, DB column widths)
- **Character set constraints** — e.g. RFC 8030 Topic must be URL-safe base64 (`[A-Za-z0-9\-_]`)
- **Content-Type enforcement** — reject unsupported media types with 415
- **Accept header enforcement** — reject unsupported formats with 406

The original unsanitized-input bullet becomes heuristic 1 of the new subsection; no duplicate remains. The flat Security bullet list stays contiguous with `- **CSRF/path traversal**` as its last item, and the new subsection lands between it and `#### Trust Boundary / Ownership Verification`.

## Verification

- [x] `bun scripts/validate-plugins.mjs` — all checks passed
- [x] Section structure confirmed by re-read: flat Security bullets → Input Validation & Protocol Compliance → Trust Boundary / Ownership Verification
- [x] All 3 acceptance criteria of #156 met

Merging this closes the last open sub-issue of epic #149.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the security review checklist with guidance for input sanitization, length and character-set limits, Content-Type validation, and Accept-header validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->