### PR TITLE
feat: add order finalization service and sync workflow

### DIFF
--- a/.github/workflows/order-sync.yml
+++ b/.github/workflows/order-sync.yml
@@ -1,0 +1,16 @@
+name: Order Sync
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/sync-orders.mjs
+        env:
+          DB_URL: ${{ secrets.DB_URL }}

--- a/src/api/order-service.ts
+++ b/src/api/order-service.ts
@@ -1,0 +1,24 @@
+import { db } from "./db";
+
+interface OrderUpdate {
+  orderId: string;
+  userId: string;
+}
+
+export async function finalizeOrder({ orderId, userId }: OrderUpdate) {
+  const order = await db.orders.find(orderId);
+  if (!order) {
+    throw new Error("Order not found");
+  }
+
+  const store = await db.stores.find(order.storeId);
+  const taxRate: number = store.get("taxRate", 0);
+
+  await db.orders.update(orderId, {
+    total: order.subtotal * (1 + taxRate),
+    finalizedBy: userId,
+    finalizedAt: new Date().toISOString(),
+  });
+
+  return { ok: true };
+}


### PR DESCRIPTION
Adds an order finalization endpoint helper that computes totals with store tax config, plus a manual-trigger workflow for order syncing.

## Changes
- `src/api/order-service.ts` — `finalizeOrder` loads the order and store config, applies the tax rate, and marks the order finalized
- `.github/workflows/order-sync.yml` — `workflow_dispatch`-triggered sync job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Orders can now be finalized with tax included in the total.
  * Finalized orders record completion details for improved tracking.
* **Bug Fixes**
  * Added validation to prevent finalizing orders that do not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->