### PR TITLE
fix(ci-review): add deterministic post-review script for reliable review posting (#255)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -96,7 +96,7 @@ jobs:
           # CI is the point of this workflow. A main-pinned checkout would defeat that.
           plugin_marketplaces: './'
           plugins: 'ci-review@rube-cc-skills'
-          prompt: "/ci-review ${{ steps.resolve.outputs.pr }} ${{ steps.resolve.outputs.flag }}"
+          prompt: "/ci-review ${{ steps.resolve.outputs.pr }} ${{ steps.resolve.outputs.flag }} -- You must execute the Step 6 and Step 7 Bash commands to post the review to GitHub before completing."
           # AskUserQuestion is deliberately omitted — interactive tools are
           # suppressed in CI even though the skill frontmatter lists it
           # gh api is scoped broadly (not per-endpoint): the plugin's posting layer

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -96,7 +96,7 @@ jobs:
           # CI is the point of this workflow. A main-pinned checkout would defeat that.
           plugin_marketplaces: './'
           plugins: 'ci-review@rube-cc-skills'
-          prompt: "/ci-review ${{ steps.resolve.outputs.pr }} ${{ steps.resolve.outputs.flag }} -- You must execute the Step 6 and Step 7 Bash commands to post the review to GitHub before completing."
+          prompt: "/ci-review ${{ steps.resolve.outputs.pr }} ${{ steps.resolve.outputs.flag }}"
           # AskUserQuestion is deliberately omitted — interactive tools are
           # suppressed in CI even though the skill frontmatter lists it
           # gh api is scoped broadly (not per-endpoint): the plugin's posting layer

--- a/plugins/ci-review/hooks/hooks.json
+++ b/plugins/ci-review/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/check-review-posted.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/ci-review/scripts/check-review-posted.sh
+++ b/plugins/ci-review/scripts/check-review-posted.sh
@@ -125,7 +125,7 @@ fi
 cat <<'JSON'
 {
   "decision": "block",
-  "reason": "MANDATORY REVIEW NOT POSTED: You must execute Step 7 (`sh plugins/ci-review/scripts/post-review.sh <PR#>`) via the Bash tool to post the review to GitHub before finishing."
+  "reason": "MANDATORY REVIEW NOT POSTED: You must execute Step 7 (`sh plugins/ci-review/scripts/post-review.sh <PR#> \"\${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json\"`) via the Bash tool to post the review to GitHub before finishing."
 }
 JSON
 

--- a/plugins/ci-review/scripts/check-review-posted.sh
+++ b/plugins/ci-review/scripts/check-review-posted.sh
@@ -86,7 +86,8 @@ printf '%s\n' "$PR_NUMBER" | grep -qE '^[1-9][0-9]*$' || exit 0
 
 # --- check if review already posted in this session ------------------------
 
-SUCCESS_MARKER="${TMPDIR:-/tmp}/ci-review-posted-${PR_NUMBER}.txt"
+REPO_SLUG=$(printf '%s' "${OWNER}_${REPO}" | tr '/:.' '_')
+SUCCESS_MARKER="${TMPDIR:-/tmp}/ci-review-posted-${REPO_SLUG}-${PR_NUMBER}.txt"
 if [ -f "$SUCCESS_MARKER" ]; then
   # Review already posted successfully in this session
   exit 0

--- a/plugins/ci-review/scripts/check-review-posted.sh
+++ b/plugins/ci-review/scripts/check-review-posted.sh
@@ -27,10 +27,35 @@ fi
 
 # --- check prerequisites ---------------------------------------------------
 
-command -v gh >/dev/null 2>&1 || exit 0
-command -v jq >/dev/null 2>&1 || exit 0
-gh auth status >/dev/null 2>&1 || exit 0
+if ! command -v gh >/dev/null 2>&1; then
+  cat <<'JSON'
+{
+  "decision": "block",
+  "reason": "MANDATORY REVIEW NOT POSTED: gh CLI is not installed. Install gh to submit review."
+}
+JSON
+  exit 0
+fi
 
+if ! command -v jq >/dev/null 2>&1; then
+  cat <<'JSON'
+{
+  "decision": "block",
+  "reason": "MANDATORY REVIEW NOT POSTED: jq is not installed. Install jq to build payload."
+}
+JSON
+  exit 0
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  cat <<'JSON'
+{
+  "decision": "block",
+  "reason": "MANDATORY REVIEW NOT POSTED: gh is not authenticated. Run gh auth login to submit review."
+}
+JSON
+  exit 0
+fi
 # --- detect repository -----------------------------------------------------
 
 OWNER_REPO="${GITHUB_REPOSITORY}"

--- a/plugins/ci-review/scripts/check-review-posted.sh
+++ b/plugins/ci-review/scripts/check-review-posted.sh
@@ -114,6 +114,10 @@ if [ -n "$POST_SCRIPT" ] && [ -f "$POST_SCRIPT" ]; then
     if sh "$POST_SCRIPT" "$PR_NUMBER" "$PAYLOAD_FILE" "${OWNER}/${REPO}" >&2; then
       exit 0
     fi
+  else
+    if sh "$POST_SCRIPT" "$PR_NUMBER" "${OWNER}/${REPO}" >&2; then
+      exit 0
+    fi
   fi
 fi
 

--- a/plugins/ci-review/scripts/check-review-posted.sh
+++ b/plugins/ci-review/scripts/check-review-posted.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+# check-review-posted.sh — Stop hook for ci-review
+#
+# Intercepts session termination to guarantee a review was posted to GitHub.
+# If no review starting with "## CI Review" has been posted, executes
+# post-review.sh to ensure the mandatory review contract is fulfilled.
+
+set -e
+
+# --- drain stdin (hook payload) --------------------------------------------
+
+PAYLOAD=""
+if [ ! -t 0 ]; then
+  PAYLOAD=$(cat)
+fi
+
+if [ -n "$PAYLOAD" ]; then
+  if command -v jq >/dev/null 2>&1; then
+    if printf '%s' "$PAYLOAD" | jq -e '.stop_hook_active == true' >/dev/null 2>&1; then
+      exit 0
+    fi
+  else
+    if printf '%s' "$PAYLOAD" | grep -Eq '"stop_hook_active"[[:space:]]*:[[:space:]]*true'; then
+      exit 0
+    fi
+  fi
+fi
+
+# --- check prerequisites ---------------------------------------------------
+
+command -v gh >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+gh auth status >/dev/null 2>&1 || exit 0
+
+# --- detect repository -----------------------------------------------------
+
+OWNER_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+[ -z "$OWNER_REPO" ] && exit 0
+OWNER="${OWNER_REPO%%/*}"
+REPO="${OWNER_REPO#*/}"
+[ -z "$OWNER" ] || [ -z "$REPO" ] && exit 0
+
+# --- detect PR number ------------------------------------------------------
+
+PR_NUMBER=""
+
+# Check if payload file exists with PR number
+for f in "${TMPDIR:-/tmp}"/ci-review-payload-*.json; do
+  if [ -f "$f" ]; then
+    NUM=$(printf '%s\n' "$f" | sed -n 's/.*ci-review-payload-\([0-9]*\)\.json/\1/p')
+    if [ -n "$NUM" ]; then
+      PR_NUMBER="$NUM"
+      PAYLOAD_FILE="$f"
+      break
+    fi
+  fi
+done
+
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null || true)
+fi
+
+[ -z "$PR_NUMBER" ] && exit 0
+printf '%s\n' "$PR_NUMBER" | grep -qE '^[1-9][0-9]*$' || exit 0
+
+# --- check if review already posted ----------------------------------------
+
+RECENT_REVIEWS=$(gh api --paginate --slurp "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/reviews" 2>/dev/null || echo "[]")
+HAS_POST=$(printf '%s' "$RECENT_REVIEWS" | jq '
+  [ .[][]? | select((.body // "") | startswith("## CI Review")) ] | length
+' 2>/dev/null || echo 0)
+
+if [ "$HAS_POST" -gt 0 ]; then
+  # Review already posted successfully
+  exit 0
+fi
+
+# Also check PR comments fallback
+RECENT_COMMENTS=$(gh api --paginate --slurp "repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" 2>/dev/null || echo "[]")
+HAS_COMMENT=$(printf '%s' "$RECENT_COMMENTS" | jq '
+  [ .[][]? | select((.body // "") | startswith("## CI Review")) ] | length
+' 2>/dev/null || echo 0)
+
+if [ "$HAS_COMMENT" -gt 0 ]; then
+  # Fallback comment already posted successfully
+  exit 0
+fi
+
+# --- locate and run post-review.sh -----------------------------------------
+
+POST_SCRIPT=""
+if [ -n "$CLAUDE_PLUGIN_ROOT" ] && [ -f "$CLAUDE_PLUGIN_ROOT/scripts/post-review.sh" ]; then
+  POST_SCRIPT="$CLAUDE_PLUGIN_ROOT/scripts/post-review.sh"
+elif [ -f "plugins/ci-review/scripts/post-review.sh" ]; then
+  POST_SCRIPT="plugins/ci-review/scripts/post-review.sh"
+fi
+
+if [ -n "$POST_SCRIPT" ] && [ -x "$POST_SCRIPT" ]; then
+  if [ -n "$PAYLOAD_FILE" ] && [ -f "$PAYLOAD_FILE" ]; then
+    sh "$POST_SCRIPT" "$PR_NUMBER" "$PAYLOAD_FILE" "${OWNER}/${REPO}" >&2 || true
+  else
+    sh "$POST_SCRIPT" "$PR_NUMBER" "${OWNER}/${REPO}" >&2 || true
+  fi
+  exit 0
+fi
+
+# If script could not be executed directly, block stop to prompt model
+cat <<'JSON'
+{
+  "decision": "block",
+  "reason": "MANDATORY REVIEW NOT POSTED: You must execute Step 7 (`sh plugins/ci-review/scripts/post-review.sh <PR#>`) via the Bash tool to post the review to GitHub before finishing."
+}
+JSON
+
+exit 0

--- a/plugins/ci-review/scripts/check-review-posted.sh
+++ b/plugins/ci-review/scripts/check-review-posted.sh
@@ -111,10 +111,11 @@ fi
 
 if [ -n "$POST_SCRIPT" ] && [ -f "$POST_SCRIPT" ]; then
   if [ -n "$PAYLOAD_FILE" ] && [ -f "$PAYLOAD_FILE" ]; then
-    if sh "$POST_SCRIPT" "$PR_NUMBER" "$PAYLOAD_FILE" "${OWNER}/${REPO}" >&2; then
-      exit 0
-    fi
+    sh "$POST_SCRIPT" "$PR_NUMBER" "$PAYLOAD_FILE" "${OWNER}/${REPO}" >&2 || true
+  else
+    sh "$POST_SCRIPT" "$PR_NUMBER" "${OWNER}/${REPO}" >&2 || true
   fi
+  exit 0
 fi
 
 # If posting failed or script was unavailable, block termination to prompt agent

--- a/plugins/ci-review/scripts/check-review-posted.sh
+++ b/plugins/ci-review/scripts/check-review-posted.sh
@@ -111,11 +111,14 @@ fi
 
 if [ -n "$POST_SCRIPT" ] && [ -f "$POST_SCRIPT" ]; then
   if [ -n "$PAYLOAD_FILE" ] && [ -f "$PAYLOAD_FILE" ]; then
-    sh "$POST_SCRIPT" "$PR_NUMBER" "$PAYLOAD_FILE" "${OWNER}/${REPO}" >&2 || true
+    if sh "$POST_SCRIPT" "$PR_NUMBER" "$PAYLOAD_FILE" "${OWNER}/${REPO}" >&2; then
+      exit 0
+    fi
   else
-    sh "$POST_SCRIPT" "$PR_NUMBER" "${OWNER}/${REPO}" >&2 || true
+    if sh "$POST_SCRIPT" "$PR_NUMBER" "${OWNER}/${REPO}" >&2; then
+      exit 0
+    fi
   fi
-  exit 0
 fi
 
 # If posting failed or script was unavailable, block termination to prompt agent

--- a/plugins/ci-review/scripts/check-review-posted.sh
+++ b/plugins/ci-review/scripts/check-review-posted.sh
@@ -40,26 +40,15 @@ fi
 [ -z "$OWNER_REPO" ] && exit 0
 OWNER="${OWNER_REPO%%/*}"
 REPO="${OWNER_REPO#*/}"
-[ -z "$OWNER" ] || [ -z "$REPO" ] && exit 0
+if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
+  exit 0
+fi
 
 # --- detect PR number ------------------------------------------------------
 
 PR_NUMBER=""
-PAYLOAD_FILE=""
 
-# Check if payload file exists with PR number
-for f in "${TMPDIR:-/tmp}"/ci-review-payload-*.json; do
-  if [ -f "$f" ]; then
-    NUM=$(printf '%s\n' "$f" | sed -n 's/.*ci-review-payload-\([0-9]*\)\.json/\1/p')
-    if [ -n "$NUM" ]; then
-      PR_NUMBER="$NUM"
-      PAYLOAD_FILE="$f"
-      break
-    fi
-  fi
-done
-
-if [ -z "$PR_NUMBER" ] && [ -n "$GITHUB_REF" ]; then
+if [ -n "$GITHUB_REF" ]; then
   PR_NUMBER=$(printf '%s\n' "$GITHUB_REF" | sed -n 's|refs/pull/\([0-9]*\)/.*|\1|p')
 fi
 
@@ -78,6 +67,13 @@ if [ -f "$SUCCESS_MARKER" ]; then
   exit 0
 fi
 
+# --- check for matching PR payload file ------------------------------------
+
+PAYLOAD_FILE=""
+if [ -f "${TMPDIR:-/tmp}/ci-review-payload-${PR_NUMBER}.json" ]; then
+  PAYLOAD_FILE="${TMPDIR:-/tmp}/ci-review-payload-${PR_NUMBER}.json"
+fi
+
 # --- locate and run post-review.sh -----------------------------------------
 
 POST_SCRIPT=""
@@ -89,11 +85,22 @@ fi
 
 if [ -n "$POST_SCRIPT" ] && [ -f "$POST_SCRIPT" ]; then
   if [ -n "$PAYLOAD_FILE" ] && [ -f "$PAYLOAD_FILE" ]; then
-    sh "$POST_SCRIPT" "$PR_NUMBER" "$PAYLOAD_FILE" "${OWNER}/${REPO}" >&2 || true
+    if sh "$POST_SCRIPT" "$PR_NUMBER" "$PAYLOAD_FILE" "${OWNER}/${REPO}" >&2; then
+      exit 0
+    fi
   else
-    sh "$POST_SCRIPT" "$PR_NUMBER" "${OWNER}/${REPO}" >&2 || true
+    if sh "$POST_SCRIPT" "$PR_NUMBER" "${OWNER}/${REPO}" >&2; then
+      exit 0
+    fi
   fi
-  exit 0
 fi
+
+# If posting failed or script was unavailable, block termination to prompt agent
+cat <<'JSON'
+{
+  "decision": "block",
+  "reason": "MANDATORY REVIEW NOT POSTED: You must execute Step 7 (`sh plugins/ci-review/scripts/post-review.sh <PR#>`) via the Bash tool to post the review to GitHub before finishing."
+}
+JSON
 
 exit 0

--- a/plugins/ci-review/scripts/check-review-posted.sh
+++ b/plugins/ci-review/scripts/check-review-posted.sh
@@ -114,10 +114,6 @@ if [ -n "$POST_SCRIPT" ] && [ -f "$POST_SCRIPT" ]; then
     if sh "$POST_SCRIPT" "$PR_NUMBER" "$PAYLOAD_FILE" "${OWNER}/${REPO}" >&2; then
       exit 0
     fi
-  else
-    if sh "$POST_SCRIPT" "$PR_NUMBER" "${OWNER}/${REPO}" >&2; then
-      exit 0
-    fi
   fi
 fi
 

--- a/plugins/ci-review/scripts/check-review-posted.sh
+++ b/plugins/ci-review/scripts/check-review-posted.sh
@@ -2,8 +2,7 @@
 # check-review-posted.sh — Stop hook for ci-review
 #
 # Intercepts session termination to guarantee a review was posted to GitHub.
-# If no review starting with "## CI Review" has been posted, executes
-# post-review.sh to ensure the mandatory review contract is fulfilled.
+# If no review was posted in this session, executes post-review.sh.
 
 set -e
 
@@ -34,7 +33,10 @@ gh auth status >/dev/null 2>&1 || exit 0
 
 # --- detect repository -----------------------------------------------------
 
-OWNER_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+OWNER_REPO="${GITHUB_REPOSITORY}"
+if [ -z "$OWNER_REPO" ]; then
+  OWNER_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+fi
 [ -z "$OWNER_REPO" ] && exit 0
 OWNER="${OWNER_REPO%%/*}"
 REPO="${OWNER_REPO#*/}"
@@ -43,6 +45,7 @@ REPO="${OWNER_REPO#*/}"
 # --- detect PR number ------------------------------------------------------
 
 PR_NUMBER=""
+PAYLOAD_FILE=""
 
 # Check if payload file exists with PR number
 for f in "${TMPDIR:-/tmp}"/ci-review-payload-*.json; do
@@ -56,6 +59,10 @@ for f in "${TMPDIR:-/tmp}"/ci-review-payload-*.json; do
   fi
 done
 
+if [ -z "$PR_NUMBER" ] && [ -n "$GITHUB_REF" ]; then
+  PR_NUMBER=$(printf '%s\n' "$GITHUB_REF" | sed -n 's|refs/pull/\([0-9]*\)/.*|\1|p')
+fi
+
 if [ -z "$PR_NUMBER" ]; then
   PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null || true)
 fi
@@ -63,26 +70,11 @@ fi
 [ -z "$PR_NUMBER" ] && exit 0
 printf '%s\n' "$PR_NUMBER" | grep -qE '^[1-9][0-9]*$' || exit 0
 
-# --- check if review already posted ----------------------------------------
+# --- check if review already posted in this session ------------------------
 
-RECENT_REVIEWS=$(gh api --paginate --slurp "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/reviews" 2>/dev/null || echo "[]")
-HAS_POST=$(printf '%s' "$RECENT_REVIEWS" | jq '
-  [ .[][]? | select((.body // "") | startswith("## CI Review")) ] | length
-' 2>/dev/null || echo 0)
-
-if [ "$HAS_POST" -gt 0 ]; then
-  # Review already posted successfully
-  exit 0
-fi
-
-# Also check PR comments fallback
-RECENT_COMMENTS=$(gh api --paginate --slurp "repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" 2>/dev/null || echo "[]")
-HAS_COMMENT=$(printf '%s' "$RECENT_COMMENTS" | jq '
-  [ .[][]? | select((.body // "") | startswith("## CI Review")) ] | length
-' 2>/dev/null || echo 0)
-
-if [ "$HAS_COMMENT" -gt 0 ]; then
-  # Fallback comment already posted successfully
+SUCCESS_MARKER="${TMPDIR:-/tmp}/ci-review-posted-${PR_NUMBER}.txt"
+if [ -f "$SUCCESS_MARKER" ]; then
+  # Review already posted successfully in this session
   exit 0
 fi
 
@@ -95,7 +87,7 @@ elif [ -f "plugins/ci-review/scripts/post-review.sh" ]; then
   POST_SCRIPT="plugins/ci-review/scripts/post-review.sh"
 fi
 
-if [ -n "$POST_SCRIPT" ] && [ -x "$POST_SCRIPT" ]; then
+if [ -n "$POST_SCRIPT" ] && [ -f "$POST_SCRIPT" ]; then
   if [ -n "$PAYLOAD_FILE" ] && [ -f "$PAYLOAD_FILE" ]; then
     sh "$POST_SCRIPT" "$PR_NUMBER" "$PAYLOAD_FILE" "${OWNER}/${REPO}" >&2 || true
   else
@@ -103,13 +95,5 @@ if [ -n "$POST_SCRIPT" ] && [ -x "$POST_SCRIPT" ]; then
   fi
   exit 0
 fi
-
-# If script could not be executed directly, block stop to prompt model
-cat <<'JSON'
-{
-  "decision": "block",
-  "reason": "MANDATORY REVIEW NOT POSTED: You must execute Step 7 (`sh plugins/ci-review/scripts/post-review.sh <PR#>`) via the Bash tool to post the review to GitHub before finishing."
-}
-JSON
 
 exit 0

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -150,12 +150,15 @@ jq -r '
   end
 ' "$RAW_PAYLOAD_FILE" > "$_tmpdir/body.md"
 
-# Extract comments array (ensuring valid structure)
+# Extract comments array (ensuring valid structure and safe line parsing)
 jq '
   if .comments and (.comments | type == "array") then
-    [ .comments[] | select(.path and .line and .body) | {
+    [ .comments[] | select(.path and .line and .body) |
+      (try (.line | tonumber) catch null) as $l |
+      select($l != null and $l > 0) |
+      {
         path: (.path | tostring),
-        line: (.line | tonumber),
+        line: $l,
         side: (.side // "RIGHT" | tostring),
         body: (.body | tostring)
       }
@@ -163,7 +166,7 @@ jq '
   else
     []
   end
-' "$RAW_PAYLOAD_FILE" > "$_tmpdir/comments.json"
+' "$RAW_PAYLOAD_FILE" > "$_tmpdir/comments.json" || jq -n '[]' > "$_tmpdir/comments.json"
 
 COMMENTS_COUNT=$(jq 'length' "$_tmpdir/comments.json")
 

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -164,7 +164,7 @@ jq '
       {
         path: (.path | tostring),
         line: $l,
-        side: (.side // "RIGHT" | tostring),
+        side: "RIGHT",
         body: (.body | tostring)
       }
     ]

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -174,6 +174,13 @@ COMMENTS_COUNT=$(jq 'length' "$_tmpdir/comments.json")
 
 POSTED_URL=""
 
+# Helper to record successful post marker and exit
+mark_success() {
+  echo "Review posted: $POSTED_URL"
+  echo "$POSTED_URL" > "${TMPDIR:-/tmp}/ci-review-posted-${PR_NUMBER}.txt" 2>/dev/null || true
+  exit 0
+}
+
 # Helper function to post review via API
 post_review_api() {
   _pra_payload_file="$1"
@@ -256,8 +263,7 @@ build_review_payload "$_tmpdir/body.md" "$CURRENT_COMMENTS" "$PRIMARY_PAYLOAD"
 echo "Attempting to post PR review on ${OWNER}/${REPO}#${PR_NUMBER} (${COMMENTS_COUNT} inline comments)..." >&2
 
 if post_review_api "$PRIMARY_PAYLOAD"; then
-  echo "Review posted: $POSTED_URL"
-  exit 0
+  mark_success
 fi
 
 API_ERROR=$(cat "$_tmpdir/api_error.txt" 2>/dev/null || echo "Unknown error")
@@ -282,8 +288,7 @@ if [ "$COMMENTS_COUNT" -gt 0 ]; then
     PRUNED_PAYLOAD="$_tmpdir/payload_pruned.json"
     build_review_payload "$_tmpdir/body.md" "$_tmpdir/comments_pruned.json" "$PRUNED_PAYLOAD"
     if post_review_api "$PRUNED_PAYLOAD"; then
-      echo "Review posted: $POSTED_URL"
-      exit 0
+      mark_success
     fi
     API_ERROR=$(cat "$_tmpdir/api_error.txt" 2>/dev/null || echo "Unknown error")
     echo "Pruned review POST failed: $API_ERROR" >&2
@@ -300,8 +305,7 @@ jq -n '[]' > "$_tmpdir/empty_comments.json"
 build_review_payload "$BODY_WITH_COMMENTS" "$_tmpdir/empty_comments.json" "$BODY_ONLY_PAYLOAD"
 
 if post_review_api "$BODY_ONLY_PAYLOAD"; then
-  echo "Review posted: $POSTED_URL"
-  exit 0
+  mark_success
 fi
 
 API_ERROR=$(cat "$_tmpdir/api_error.txt" 2>/dev/null || echo "Unknown error")
@@ -314,8 +318,7 @@ cp "$BODY_WITH_COMMENTS" "$PR_COMMENT_BODY"
 printf '\n\n*(Posted as PR comment — review API unavailable)*\n' >> "$PR_COMMENT_BODY"
 
 if post_pr_comment "$PR_COMMENT_BODY"; then
-  echo "Review posted: $POSTED_URL"
-  exit 0
+  mark_success
 fi
 
 COMMENT_ERROR=$(cat "$_tmpdir/comment_error.txt" 2>/dev/null || echo "Unknown error")

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -41,11 +41,11 @@ PAYLOAD_FILE=""
 OWNER_REPO=""
 
 if [ $# -eq 0 ]; then
-  PAYLOAD_FILE="-"
+  PAYLOAD_FILE=""
 elif [ $# -eq 1 ]; then
   if printf '%s\n' "$1" | grep -qE '^[1-9][0-9]*$'; then
     PR_NUMBER="$1"
-    PAYLOAD_FILE="-"
+    PAYLOAD_FILE=""
   else
     PAYLOAD_FILE="$1"
   fi
@@ -83,14 +83,15 @@ RAW_PAYLOAD_FILE="$_tmpdir/raw_payload.json"
 
 if [ -n "$PAYLOAD_FILE" ] && [ "$PAYLOAD_FILE" != "-" ]; then
   if [ ! -f "$PAYLOAD_FILE" ]; then
-    die "Payload file not found: $PAYLOAD_FILE"
+    echo "{}" > "$RAW_PAYLOAD_FILE"
+  else
+    cp "$PAYLOAD_FILE" "$RAW_PAYLOAD_FILE" || echo "{}" > "$RAW_PAYLOAD_FILE"
   fi
-  cp "$PAYLOAD_FILE" "$RAW_PAYLOAD_FILE" || die "Failed to copy payload file: $PAYLOAD_FILE"
+elif [ "$PAYLOAD_FILE" = "-" ]; then
+  cat > "$RAW_PAYLOAD_FILE" || echo "{}" > "$RAW_PAYLOAD_FILE"
 else
-  # Read from stdin if no file given or "-" specified
-  cat > "$RAW_PAYLOAD_FILE" || die "Failed to read payload from stdin"
+  echo "{}" > "$RAW_PAYLOAD_FILE"
 fi
-
 # Ensure valid JSON
 if ! jq empty "$RAW_PAYLOAD_FILE" 2>/dev/null; then
   die "Invalid JSON in review payload file"

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -160,7 +160,7 @@ jq '
   if .comments and (.comments | type == "array") then
     [ .comments[] | select((.path | type == "string" and length > 0) and .line and (.body | type == "string" and length > 0)) |
       (try (.line | tonumber) catch null) as $l |
-      select($l != null and $l > 0) |
+      select($l != null and ($l | floor == .) and $l > 0) |
       {
         path: (.path | tostring),
         line: $l,
@@ -182,7 +182,8 @@ POSTED_URL=""
 # Helper to record successful post marker and exit
 mark_success() {
   echo "Review posted: $POSTED_URL"
-  echo "$POSTED_URL" > "${TMPDIR:-/tmp}/ci-review-posted-${PR_NUMBER}.txt" 2>/dev/null || true
+  _ms_repo_slug=$(printf '%s' "${OWNER}_${REPO}" | tr '/:.' '_')
+  echo "$POSTED_URL" > "${TMPDIR:-/tmp}/ci-review-posted-${_ms_repo_slug}-${PR_NUMBER}.txt" 2>/dev/null || true
   exit 0
 }
 

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -199,7 +199,7 @@ post_review_api() {
       --input "$_pra_payload_file" \
       > "$_pra_response_file" 2> "$_pra_error_file"; then
     POSTED_URL=$(jq -r '.html_url // empty' "$_pra_response_file" 2>/dev/null || true)
-    if [ -n "$POSTED_URL" ] && [ "$POSTED_URL" != "null" ]; then
+    if [ -n "$POSTED_URL" ] && [ "$POSTED_URL" != "null" ] && printf '%s\n' "$POSTED_URL" | grep -qE '^https?://'; then
       return 0
     fi
   fi
@@ -218,7 +218,7 @@ post_pr_comment() {
       -F "body=@${_ppc_body_file}" \
       > "$_ppc_response_file" 2> "$_ppc_error_file"; then
     POSTED_URL=$(jq -r '.html_url // empty' "$_ppc_response_file" 2>/dev/null || true)
-    if [ -n "$POSTED_URL" ] && [ "$POSTED_URL" != "null" ]; then
+    if [ -n "$POSTED_URL" ] && [ "$POSTED_URL" != "null" ] && printf '%s\n' "$POSTED_URL" | grep -qE '^https?://'; then
       return 0
     fi
   fi

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -173,16 +173,16 @@ POSTED_URL=""
 
 # Helper function to post review via API
 post_review_api() {
-  local payload_file="$1"
-  local response_file="$_tmpdir/api_response.json"
-  local error_file="$_tmpdir/api_error.txt"
+  _pra_payload_file="$1"
+  _pra_response_file="$_tmpdir/api_response.json"
+  _pra_error_file="$_tmpdir/api_error.txt"
 
-  rm -f "$response_file" "$error_file"
+  rm -f "$_pra_response_file" "$_pra_error_file"
   if gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/reviews" \
       --method POST \
-      --input "$payload_file" \
-      > "$response_file" 2> "$error_file"; then
-    POSTED_URL=$(jq -r '.html_url // empty' "$response_file" 2>/dev/null || true)
+      --input "$_pra_payload_file" \
+      > "$_pra_response_file" 2> "$_pra_error_file"; then
+    POSTED_URL=$(jq -r '.html_url // empty' "$_pra_response_file" 2>/dev/null || true)
     if [ -n "$POSTED_URL" ] && [ "$POSTED_URL" != "null" ]; then
       return 0
     fi
@@ -192,16 +192,16 @@ post_review_api() {
 
 # Helper function to post general PR comment
 post_pr_comment() {
-  local body_file="$1"
-  local response_file="$_tmpdir/comment_response.json"
-  local error_file="$_tmpdir/comment_error.txt"
+  _ppc_body_file="$1"
+  _ppc_response_file="$_tmpdir/comment_response.json"
+  _ppc_error_file="$_tmpdir/comment_error.txt"
 
-  rm -f "$response_file" "$error_file"
+  rm -f "$_ppc_response_file" "$_ppc_error_file"
   if gh api "repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" \
       --method POST \
-      -F "body=@${body_file}" \
-      > "$response_file" 2> "$error_file"; then
-    POSTED_URL=$(jq -r '.html_url // empty' "$response_file" 2>/dev/null || true)
+      -F "body=@${_ppc_body_file}" \
+      > "$_ppc_response_file" 2> "$_ppc_error_file"; then
+    POSTED_URL=$(jq -r '.html_url // empty' "$_ppc_response_file" 2>/dev/null || true)
     if [ -n "$POSTED_URL" ] && [ "$POSTED_URL" != "null" ]; then
       return 0
     fi
@@ -211,39 +211,37 @@ post_pr_comment() {
 
 # Helper to construct review payload JSON
 build_review_payload() {
-  local body_file="$1"
-  local comments_file="$2"
-  local out_file="$3"
+  _brp_body_file="$1"
+  _brp_comments_file="$2"
+  _brp_out_file="$3"
 
-  local num_comments
-  num_comments=$(jq 'length' "$comments_file")
+  _brp_num_comments=$(jq 'length' "$_brp_comments_file")
 
-  if [ "$num_comments" -gt 0 ]; then
+  if [ "$_brp_num_comments" -gt 0 ]; then
     jq -n \
       --arg event "COMMENT" \
-      --rawfile body "$body_file" \
-      --slurpfile comments "$comments_file" \
-      '{event: $event, body: $body, comments: $comments[0]}' > "$out_file"
+      --rawfile body "$_brp_body_file" \
+      --slurpfile comments "$_brp_comments_file" \
+      '{event: $event, body: $body, comments: $comments[0]}' > "$_brp_out_file"
   else
     jq -n \
       --arg event "COMMENT" \
-      --rawfile body "$body_file" \
-      '{event: $event, body: $body}' > "$out_file"
+      --rawfile body "$_brp_body_file" \
+      '{event: $event, body: $body}' > "$_brp_out_file"
   fi
 }
 
 # Helper to build body with all inline comments appended
 build_body_with_inline_comments() {
-  local body_file="$1"
-  local comments_file="$2"
-  local out_file="$3"
+  _bbi_body_file="$1"
+  _bbi_comments_file="$2"
+  _bbi_out_file="$3"
 
-  cp "$body_file" "$out_file"
-  local num_comments
-  num_comments=$(jq 'length' "$comments_file")
-  if [ "$num_comments" -gt 0 ]; then
-    printf '\n\n### Inline Findings (Moved to Body)\n\n' >> "$out_file"
-    jq -r '.[] | "- **`" + .path + ":" + (.line | tostring) + "`**\n\n" + .body + "\n"' "$comments_file" >> "$out_file"
+  cp "$_bbi_body_file" "$_bbi_out_file"
+  _bbi_num_comments=$(jq 'length' "$_bbi_comments_file")
+  if [ "$_bbi_num_comments" -gt 0 ]; then
+    printf '\n\n### Inline Findings (Moved to Body)\n\n' >> "$_bbi_out_file"
+    jq -r '.[] | "- **`" + .path + ":" + (.line | tostring) + "`**\n\n" + .body + "\n"' "$_bbi_comments_file" >> "$_bbi_out_file"
   fi
 }
 
@@ -265,14 +263,27 @@ echo "Initial review POST failed: $API_ERROR" >&2
 # Attempt 1.1: If comments existed and error mentions line/comment issues, retry with invalid comment pruning
 if [ "$COMMENTS_COUNT" -gt 0 ]; then
   echo "Attempting recovery: checking for invalid inline comments..." >&2
-  # Prune any comment where path or line might be invalid if identifiable, or try single-comment pruning
-  # If error response contains errors array with field details, parse them
-  if jq -e '.errors' "$_tmpdir/api_response.json" >/dev/null 2>&1; then
-    # Try filtering out comments that failed validation
-    jq '
-      # Keep comments that are valid
-      .
+  PR_DIFF_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || true)
+  if [ -n "$PR_DIFF_FILES" ]; then
+    jq --arg diff_files "$PR_DIFF_FILES" '
+      ($diff_files | split("\n")) as $valid_files |
+      [ .[] | select(.path as $p | $valid_files | index($p)) ]
     ' "$CURRENT_COMMENTS" > "$_tmpdir/comments_pruned.json"
+  else
+    cp "$CURRENT_COMMENTS" "$_tmpdir/comments_pruned.json"
+  fi
+
+  PRUNED_COUNT=$(jq 'length' "$_tmpdir/comments_pruned.json" 2>/dev/null || echo 0)
+  if [ "$PRUNED_COUNT" -lt "$COMMENTS_COUNT" ] && [ "$PRUNED_COUNT" -gt 0 ]; then
+    echo "Pruned $((COMMENTS_COUNT - PRUNED_COUNT)) comments not in PR diff; retrying review POST with $PRUNED_COUNT comments..." >&2
+    PRUNED_PAYLOAD="$_tmpdir/payload_pruned.json"
+    build_review_payload "$_tmpdir/body.md" "$_tmpdir/comments_pruned.json" "$PRUNED_PAYLOAD"
+    if post_review_api "$PRUNED_PAYLOAD"; then
+      echo "Review posted: $POSTED_URL"
+      exit 0
+    fi
+    API_ERROR=$(cat "$_tmpdir/api_error.txt" 2>/dev/null || echo "Unknown error")
+    echo "Pruned review POST failed: $API_ERROR" >&2
   fi
 fi
 

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -52,7 +52,7 @@ elif [ $# -eq 1 ]; then
 elif [ $# -eq 2 ]; then
   if printf '%s\n' "$1" | grep -qE '^[1-9][0-9]*$'; then
     PR_NUMBER="$1"
-    if printf '%s\n' "$2" | grep -qE '^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$' && [ ! -f "$2" ]; then
+    if [ ! -f "$2" ] && printf '%s\n' "$2" | grep -qE '^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$' && ! printf '%s\n' "$2" | grep -qE '\.(json|md|txt)$'; then
       OWNER_REPO="$2"
       PAYLOAD_FILE=""
     else
@@ -158,7 +158,7 @@ jq -r '
 # Extract comments array (ensuring valid structure and safe line parsing)
 jq '
   if .comments and (.comments | type == "array") then
-    [ .comments[] | select(.path and .line and .body) |
+    [ .comments[] | select((.path | type == "string" and length > 0) and .line and (.body | type == "string" and length > 0)) |
       (try (.line | tonumber) catch null) as $l |
       select($l != null and $l > 0) |
       {

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -160,7 +160,7 @@ jq '
   if .comments and (.comments | type == "array") then
     [ .comments[] | select((.path | type == "string" and length > 0) and .line and (.body | type == "string" and length > 0)) |
       (try (.line | tonumber) catch null) as $l |
-      select($l != null and ($l | floor == .) and $l > 0) |
+      select($l != null and ($l | floor == $l) and $l > 0) |
       {
         path: (.path | tostring),
         line: $l,

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -52,7 +52,12 @@ elif [ $# -eq 1 ]; then
 elif [ $# -eq 2 ]; then
   if printf '%s\n' "$1" | grep -qE '^[1-9][0-9]*$'; then
     PR_NUMBER="$1"
-    PAYLOAD_FILE="$2"
+    if printf '%s\n' "$2" | grep -qE '^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$' && [ ! -f "$2" ]; then
+      OWNER_REPO="$2"
+      PAYLOAD_FILE=""
+    else
+      PAYLOAD_FILE="$2"
+    fi
   else
     PAYLOAD_FILE="$1"
     if printf '%s\n' "$2" | grep -qE '^[1-9][0-9]*$'; then

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -1,0 +1,308 @@
+#!/bin/sh
+# post-review.sh — Deterministic GitHub PR review posting with error recovery
+# Usage: post-review.sh <PR_NUMBER> [PAYLOAD_FILE] [OWNER/REPO]
+# Or:    post-review.sh [PAYLOAD_FILE] (with PR_NUMBER inside JSON or detected from git)
+#
+# Accepts a JSON payload containing:
+#   {
+#     "body": "## CI Review\n...",
+#     "comments": [
+#       { "path": "src/foo.ts", "line": 10, "side": "RIGHT", "body": "..." }
+#     ]
+#   }
+# If no findings or empty comments, posts a body-only review.
+# If the reviews API fails, executes the fallback chain:
+#   1. Retry without invalid inline comments
+#   2. Fall back to body-only review (inline findings appended to body)
+#   3. Fall back to general PR issue comment
+#
+# Exits 0 on successful post and outputs "Review posted: <URL>".
+# Exits 1 on total failure and outputs "POSTING FAILED: <reason>" to stderr.
+
+set -e
+
+# --- helpers ---------------------------------------------------------------
+
+die() {
+  echo "POSTING FAILED: $1" >&2
+  exit 1
+}
+
+# --- prerequisites ---------------------------------------------------------
+
+command -v gh >/dev/null 2>&1  || die "gh CLI not found — install from https://cli.github.com"
+command -v jq >/dev/null 2>&1  || die "jq not found — install from https://jqlang.github.io/jq"
+gh auth status >/dev/null 2>&1 || die "gh not authenticated — run: gh auth login"
+
+# --- arg parsing -----------------------------------------------------------
+
+PR_NUMBER=""
+PAYLOAD_FILE=""
+OWNER_REPO=""
+
+if [ $# -eq 0 ]; then
+  PAYLOAD_FILE="-"
+elif [ $# -eq 1 ]; then
+  if printf '%s\n' "$1" | grep -qE '^[1-9][0-9]*$'; then
+    PR_NUMBER="$1"
+    PAYLOAD_FILE="-"
+  else
+    PAYLOAD_FILE="$1"
+  fi
+elif [ $# -eq 2 ]; then
+  if printf '%s\n' "$1" | grep -qE '^[1-9][0-9]*$'; then
+    PR_NUMBER="$1"
+    PAYLOAD_FILE="$2"
+  else
+    PAYLOAD_FILE="$1"
+    if printf '%s\n' "$2" | grep -qE '^[1-9][0-9]*$'; then
+      PR_NUMBER="$2"
+    else
+      OWNER_REPO="$2"
+    fi
+  fi
+else
+  if printf '%s\n' "$1" | grep -qE '^[1-9][0-9]*$'; then
+    PR_NUMBER="$1"
+    PAYLOAD_FILE="$2"
+    OWNER_REPO="$3"
+  else
+    PAYLOAD_FILE="$1"
+    PR_NUMBER="$2"
+    OWNER_REPO="$3"
+  fi
+fi
+# --- temp files & cleanup --------------------------------------------------
+
+_tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/post-review.XXXXXX") || die "Failed to create temporary directory"
+trap 'rm -rf "$_tmpdir"' EXIT
+
+# --- read input payload ----------------------------------------------------
+
+RAW_PAYLOAD_FILE="$_tmpdir/raw_payload.json"
+
+if [ -n "$PAYLOAD_FILE" ] && [ "$PAYLOAD_FILE" != "-" ]; then
+  if [ ! -f "$PAYLOAD_FILE" ]; then
+    die "Payload file not found: $PAYLOAD_FILE"
+  fi
+  cp "$PAYLOAD_FILE" "$RAW_PAYLOAD_FILE"
+else
+  # Read from stdin if no file given or "-" specified
+  cat > "$RAW_PAYLOAD_FILE"
+fi
+
+# Ensure valid JSON
+if ! jq empty "$RAW_PAYLOAD_FILE" 2>/dev/null; then
+  die "Invalid JSON in review payload file"
+fi
+
+# Extract PR number from JSON if not provided on CLI
+if [ -z "$PR_NUMBER" ]; then
+  JSON_PR=$(jq -r '(.pr_number // .pull_request // .pr // empty) | tostring' "$RAW_PAYLOAD_FILE" 2>/dev/null || true)
+  if [ -n "$JSON_PR" ] && printf '%s\n' "$JSON_PR" | grep -qE '^[0-9]+$'; then
+    PR_NUMBER="$JSON_PR"
+  fi
+fi
+
+# Extract owner/repo from JSON if not provided on CLI
+if [ -z "$OWNER_REPO" ]; then
+  JSON_OWNER_REPO=$(jq -r '(.owner_repo // .repo // empty) | tostring' "$RAW_PAYLOAD_FILE" 2>/dev/null || true)
+  if [ -n "$JSON_OWNER_REPO" ] && printf '%s\n' "$JSON_OWNER_REPO" | grep -q '/'; then
+    OWNER_REPO="$JSON_OWNER_REPO"
+  fi
+fi
+
+# --- repo detection --------------------------------------------------------
+
+if [ -n "$OWNER_REPO" ]; then
+  OWNER="${OWNER_REPO%%/*}"
+  REPO="${OWNER_REPO#*/}"
+else
+  OWNER_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || die "Could not determine repository — run from a git repo or pass owner/repo"
+  OWNER="${OWNER_REPO%%/*}"
+  REPO="${OWNER_REPO#*/}"
+fi
+
+if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
+  die "Could not parse owner/repo: ${OWNER_REPO}"
+fi
+
+# --- PR number detection ---------------------------------------------------
+
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null) || die "No PR specified and could not detect PR for current branch"
+fi
+
+if [ -z "$PR_NUMBER" ] || ! printf '%s\n' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+  die "Invalid PR number: ${PR_NUMBER}"
+fi
+
+# --- normalize review body and comments ------------------------------------
+
+# Extract or construct review body
+jq -r '
+  if .body and (.body | type == "string") and (.body | length > 0) then
+    .body
+  elif .summary and (.summary | type == "string") then
+    "## CI Review\n\n" + .summary
+  else
+    "## CI Review\n\nNo actionable issues found."
+  end
+' "$RAW_PAYLOAD_FILE" > "$_tmpdir/body.md"
+
+# Extract comments array (ensuring valid structure)
+jq '
+  if .comments and (.comments | type == "array") then
+    [ .comments[] | select(.path and .line and .body) | {
+        path: (.path | tostring),
+        line: (.line | tonumber),
+        side: (.side // "RIGHT" | tostring),
+        body: (.body | tostring)
+      }
+    ]
+  else
+    []
+  end
+' "$RAW_PAYLOAD_FILE" > "$_tmpdir/comments.json"
+
+COMMENTS_COUNT=$(jq 'length' "$_tmpdir/comments.json")
+
+# --- posting logic & retry chain -------------------------------------------
+
+POSTED_URL=""
+
+# Helper function to post review via API
+post_review_api() {
+  local payload_file="$1"
+  local response_file="$_tmpdir/api_response.json"
+  local error_file="$_tmpdir/api_error.txt"
+
+  rm -f "$response_file" "$error_file"
+  if gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/reviews" \
+      --method POST \
+      --input "$payload_file" \
+      > "$response_file" 2> "$error_file"; then
+    POSTED_URL=$(jq -r '.html_url // empty' "$response_file" 2>/dev/null || true)
+    if [ -n "$POSTED_URL" ] && [ "$POSTED_URL" != "null" ]; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# Helper function to post general PR comment
+post_pr_comment() {
+  local body_file="$1"
+  local response_file="$_tmpdir/comment_response.json"
+  local error_file="$_tmpdir/comment_error.txt"
+
+  rm -f "$response_file" "$error_file"
+  if gh api "repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" \
+      --method POST \
+      -F "body=@${body_file}" \
+      > "$response_file" 2> "$error_file"; then
+    POSTED_URL=$(jq -r '.html_url // empty' "$response_file" 2>/dev/null || true)
+    if [ -n "$POSTED_URL" ] && [ "$POSTED_URL" != "null" ]; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# Helper to construct review payload JSON
+build_review_payload() {
+  local body_file="$1"
+  local comments_file="$2"
+  local out_file="$3"
+
+  local num_comments
+  num_comments=$(jq 'length' "$comments_file")
+
+  if [ "$num_comments" -gt 0 ]; then
+    jq -n \
+      --arg event "COMMENT" \
+      --rawfile body "$body_file" \
+      --slurpfile comments "$comments_file" \
+      '{event: $event, body: $body, comments: $comments[0]}' > "$out_file"
+  else
+    jq -n \
+      --arg event "COMMENT" \
+      --rawfile body "$body_file" \
+      '{event: $event, body: $body}' > "$out_file"
+  fi
+}
+
+# Helper to build body with all inline comments appended
+build_body_with_inline_comments() {
+  local body_file="$1"
+  local comments_file="$2"
+  local out_file="$3"
+
+  cp "$body_file" "$out_file"
+  local num_comments
+  num_comments=$(jq 'length' "$comments_file")
+  if [ "$num_comments" -gt 0 ]; then
+    printf '\n\n### Inline Findings (Moved to Body)\n\n' >> "$out_file"
+    jq -r '.[] | "- **`" + .path + ":" + (.line | tostring) + "`**\n\n" + .body + "\n"' "$comments_file" >> "$out_file"
+  fi
+}
+
+# Attempt 1: Standard review POST with inline comments (if any)
+CURRENT_COMMENTS="$_tmpdir/comments.json"
+PRIMARY_PAYLOAD="$_tmpdir/payload_primary.json"
+build_review_payload "$_tmpdir/body.md" "$CURRENT_COMMENTS" "$PRIMARY_PAYLOAD"
+
+echo "Attempting to post PR review on ${OWNER}/${REPO}#${PR_NUMBER} (${COMMENTS_COUNT} inline comments)..." >&2
+
+if post_review_api "$PRIMARY_PAYLOAD"; then
+  echo "Review posted: $POSTED_URL"
+  exit 0
+fi
+
+API_ERROR=$(cat "$_tmpdir/api_error.txt" 2>/dev/null || echo "Unknown error")
+echo "Initial review POST failed: $API_ERROR" >&2
+
+# Attempt 1.1: If comments existed and error mentions line/comment issues, retry with invalid comment pruning
+if [ "$COMMENTS_COUNT" -gt 0 ]; then
+  echo "Attempting recovery: checking for invalid inline comments..." >&2
+  # Prune any comment where path or line might be invalid if identifiable, or try single-comment pruning
+  # If error response contains errors array with field details, parse them
+  if jq -e '.errors' "$_tmpdir/api_response.json" >/dev/null 2>&1; then
+    # Try filtering out comments that failed validation
+    jq '
+      # Keep comments that are valid
+      .
+    ' "$CURRENT_COMMENTS" > "$_tmpdir/comments_pruned.json"
+  fi
+fi
+
+# Attempt 2: Fall back to body-only review (move inline comments to body)
+echo "Attempting fallback: posting body-only review..." >&2
+BODY_WITH_COMMENTS="$_tmpdir/body_all.md"
+build_body_with_inline_comments "$_tmpdir/body.md" "$_tmpdir/comments.json" "$BODY_WITH_COMMENTS"
+
+BODY_ONLY_PAYLOAD="$_tmpdir/payload_body_only.json"
+jq -n '[]' > "$_tmpdir/empty_comments.json"
+build_review_payload "$BODY_WITH_COMMENTS" "$_tmpdir/empty_comments.json" "$BODY_ONLY_PAYLOAD"
+
+if post_review_api "$BODY_ONLY_PAYLOAD"; then
+  echo "Review posted: $POSTED_URL"
+  exit 0
+fi
+
+API_ERROR=$(cat "$_tmpdir/api_error.txt" 2>/dev/null || echo "Unknown error")
+echo "Body-only review POST failed: $API_ERROR" >&2
+
+# Attempt 3: Fall back to PR issue comment
+echo "Attempting fallback: posting as PR issue comment..." >&2
+PR_COMMENT_BODY="$_tmpdir/pr_comment_body.md"
+cp "$BODY_WITH_COMMENTS" "$PR_COMMENT_BODY"
+printf '\n\n*(Posted as PR comment — review API unavailable)*\n' >> "$PR_COMMENT_BODY"
+
+if post_pr_comment "$PR_COMMENT_BODY"; then
+  echo "Review posted: $POSTED_URL"
+  exit 0
+fi
+
+COMMENT_ERROR=$(cat "$_tmpdir/comment_error.txt" 2>/dev/null || echo "Unknown error")
+die "All posting attempts failed. Review API: $API_ERROR; Comment API: $COMMENT_ERROR"

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -85,10 +85,10 @@ if [ -n "$PAYLOAD_FILE" ] && [ "$PAYLOAD_FILE" != "-" ]; then
   if [ ! -f "$PAYLOAD_FILE" ]; then
     die "Payload file not found: $PAYLOAD_FILE"
   fi
-  cp "$PAYLOAD_FILE" "$RAW_PAYLOAD_FILE"
+  cp "$PAYLOAD_FILE" "$RAW_PAYLOAD_FILE" || die "Failed to copy payload file: $PAYLOAD_FILE"
 else
   # Read from stdin if no file given or "-" specified
-  cat > "$RAW_PAYLOAD_FILE"
+  cat > "$RAW_PAYLOAD_FILE" || die "Failed to read payload from stdin"
 fi
 
 # Ensure valid JSON
@@ -99,7 +99,7 @@ fi
 # Extract PR number from JSON if not provided on CLI
 if [ -z "$PR_NUMBER" ]; then
   JSON_PR=$(jq -r '(.pr_number // .pull_request // .pr // empty) | tostring' "$RAW_PAYLOAD_FILE" 2>/dev/null || true)
-  if [ -n "$JSON_PR" ] && printf '%s\n' "$JSON_PR" | grep -qE '^[0-9]+$'; then
+  if [ -n "$JSON_PR" ] && printf '%s\n' "$JSON_PR" | grep -qE '^[1-9][0-9]*$'; then
     PR_NUMBER="$JSON_PR"
   fi
 fi
@@ -107,7 +107,7 @@ fi
 # Extract owner/repo from JSON if not provided on CLI
 if [ -z "$OWNER_REPO" ]; then
   JSON_OWNER_REPO=$(jq -r '(.owner_repo // .repo // empty) | tostring' "$RAW_PAYLOAD_FILE" 2>/dev/null || true)
-  if [ -n "$JSON_OWNER_REPO" ] && printf '%s\n' "$JSON_OWNER_REPO" | grep -q '/'; then
+  if [ -n "$JSON_OWNER_REPO" ] && printf '%s\n' "$JSON_OWNER_REPO" | grep -qE '^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$'; then
     OWNER_REPO="$JSON_OWNER_REPO"
   fi
 fi
@@ -133,7 +133,7 @@ if [ -z "$PR_NUMBER" ]; then
   PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null) || die "No PR specified and could not detect PR for current branch"
 fi
 
-if [ -z "$PR_NUMBER" ] || ! printf '%s\n' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+if [ -z "$PR_NUMBER" ] || ! printf '%s\n' "$PR_NUMBER" | grep -qE '^[1-9][0-9]*$'; then
   die "Invalid PR number: ${PR_NUMBER}"
 fi
 

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -263,7 +263,7 @@ fi
 API_ERROR=$(cat "$_tmpdir/api_error.txt" 2>/dev/null || echo "Unknown error")
 echo "Initial review POST failed: $API_ERROR" >&2
 
-# Attempt 1.1: If comments existed and error mentions line/comment issues, retry with invalid comment pruning
+# Attempt 1.1: If inline comments failed, prune comments targeting files outside the PR diff and retry
 if [ "$COMMENTS_COUNT" -gt 0 ]; then
   echo "Attempting recovery: checking for invalid inline comments..." >&2
   PR_DIFF_FILES=$(gh pr diff "$PR_NUMBER" --repo "${OWNER}/${REPO}" --name-only 2>/dev/null || true)

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -83,12 +83,11 @@ RAW_PAYLOAD_FILE="$_tmpdir/raw_payload.json"
 
 if [ -n "$PAYLOAD_FILE" ] && [ "$PAYLOAD_FILE" != "-" ]; then
   if [ ! -f "$PAYLOAD_FILE" ]; then
-    echo "{}" > "$RAW_PAYLOAD_FILE"
-  else
-    cp "$PAYLOAD_FILE" "$RAW_PAYLOAD_FILE" || echo "{}" > "$RAW_PAYLOAD_FILE"
+    die "Payload file not found: $PAYLOAD_FILE"
   fi
+  cp "$PAYLOAD_FILE" "$RAW_PAYLOAD_FILE" || die "Failed to copy payload file: $PAYLOAD_FILE"
 elif [ "$PAYLOAD_FILE" = "-" ]; then
-  cat > "$RAW_PAYLOAD_FILE" || echo "{}" > "$RAW_PAYLOAD_FILE"
+  cat > "$RAW_PAYLOAD_FILE" || die "Failed to read payload from stdin"
 else
   echo "{}" > "$RAW_PAYLOAD_FILE"
 fi
@@ -267,7 +266,7 @@ echo "Initial review POST failed: $API_ERROR" >&2
 # Attempt 1.1: If comments existed and error mentions line/comment issues, retry with invalid comment pruning
 if [ "$COMMENTS_COUNT" -gt 0 ]; then
   echo "Attempting recovery: checking for invalid inline comments..." >&2
-  PR_DIFF_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || true)
+  PR_DIFF_FILES=$(gh pr diff "$PR_NUMBER" --repo "${OWNER}/${REPO}" --name-only 2>/dev/null || true)
   if [ -n "$PR_DIFF_FILES" ]; then
     jq --arg diff_files "$PR_DIFF_FILES" '
       ($diff_files | split("\n")) as $valid_files |

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -405,17 +405,24 @@ For each surviving finding:
    - List any body-only findings (not in diff) under "### Findings Not in Diff"
    - If no findings survived: use the "No Findings" template (`## CI Review\n\nNo actionable issues found. Reviewed <N> files across <M> changed lines.\n\n**Profile**: <profile>`)
 
-4. **Write review payload to file** `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
+4. **Construct review payload file** `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
+   Write the review body markdown to `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md` and inline comments to `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json`, then use `jq` to safely encode the payload (preventing invalid JSON from multi-paragraph markdown or special characters):
    ```bash
-   cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
-   {
-     "body": "<REVIEW_BODY>",
-     "comments": [ ...inline comments... ]
-   }
+   cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
+   <REVIEW_BODY>
    EOF
-   ```
-   If there are no inline comments, set `"comments": []`.
 
+   cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json"
+   [ ...inline comments... ]
+   EOF
+
+   jq -n \
+     --rawfile body "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md" \
+     --slurpfile comments "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json" \
+     '{body: $body, comments: ($comments[0] // [])}' \
+     > "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
+   ```
+   If there are no inline comments, write `[]` to `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json`.
 After the payload file is written, emit the Step-6 phase-end marker:
 
 ```bash

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -350,9 +350,7 @@ A single generic signal (severity tag alone or type keyword alone) is NOT suffic
 
 Track the count of findings excluded by this pass as `EXISTING_DEDUP_COUNT`.
 
-**If no findings survive filtering:** Build a no-findings review body using the template from REVIEW-POSTING.md section 3 ("No Findings"), write the payload in Step 6 with `"comments": []`, and run Step 7 to post it.
-
-After all scorers have returned and filtering/deduplication is complete, emit the Step-5 phase-end marker:
+After all scorers have returned and filtering/deduplication is complete, emit the Step-5 phase-end marker, then proceed to Step 6 to construct the review payload (mandatory on all runs, including zero-findings runs):
 
 ```bash
 echo "[ci-review] Step 5 done elapsed=$(( $(date +%s) - <STEP5_START_EPOCH> ))s"
@@ -385,26 +383,31 @@ date +%s   # remember this epoch for the phase-end call
 | comment-analyzer | comment-accuracy |
 | type-analyzer | type-design |
 
-For each surviving finding:
+Construct the review body markdown and inline comments according to the findings status:
 
-1. **Determine if it's inline-eligible**: Check if the finding's `file` appears in the PR diff and the `line` is in a changed hunk. If yes → inline comment. If no → body-only finding.
+- **When surviving findings exist (findings > 0):**
+  1. **Determine inline eligibility**: Check if the finding's `file` appears in the PR diff and the `line` is in a changed hunk. If yes → inline comment. If no → body-only finding.
+  2. **Build inline comment objects**:
+     ```json
+     {
+       "path": "<file>",
+       "line": <line_number>,
+       "side": "RIGHT",
+       "body": "**[<severity>] <type>**\n\n<description>\n\n**Recommendation:** <recommendation>\n\n`Found by: <agent-name>`"
+     }
+     ```
+  3. **Build review body**: Summary with profile, finding counts by severity, focus text if provided, and body-only findings under "### Findings Not in Diff".
 
-2. **Build inline comment object**:
-   ```json
-   {
-     "path": "<file>",
-     "line": <line_number>,
-     "side": "RIGHT",
-     "body": "**[<severity>] <type>**\n\n<description>\n\n**Recommendation:** <recommendation>\n\n`Found by: <agent-name>`"
-   }
-   ```
+- **When zero findings exist (findings == 0):**
+  1. Set review body to the standard "No Findings" template:
+     ```markdown
+     ## CI Review
 
-3. **Build review body**:
-   - Summary with profile, finding counts by severity
-   - If focus text was provided, mention it
-   - List any body-only findings (not in diff) under "### Findings Not in Diff"
-   - If no findings survived: use the "No Findings" template (`## CI Review\n\nNo actionable issues found. Reviewed <N> files across <M> changed lines.\n\n**Profile**: <profile>`)
+     No actionable issues found. Reviewed <N> files across <M> changed lines.
 
+     **Profile**: <profile>
+     ```
+  2. Set inline comments to empty array `[]`.
 4. **Construct review payload file** `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
    Write the review body markdown to `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md` and inline comments to `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json`, then use `jq` to safely encode the payload (preventing invalid JSON from multi-paragraph markdown or special characters):
    ```bash
@@ -431,8 +434,7 @@ echo "::endgroup::"
 ```
 
 ### Step 7: Post Review
-
-Single-call timing variant. Step 7 deterministically posts the review payload built in Step 6 by executing `post-review.sh`. The script automatically handles GitHub API review submission, invalid inline comment retries, body-only review fallback, and PR issue comment fallback:
+Single-call timing variant. Step 7 deterministically posts the review payload built in Step 6 by executing `post-review.sh`. This step is mandatory on every run (including zero-findings runs). The script automatically handles GitHub API review submission, invalid inline comment retries, body-only review fallback, and PR issue comment fallback:
 
 ```bash
 echo "::group::[ci-review] Step 7: Post Review"
@@ -456,9 +458,9 @@ echo "::endgroup::"
 exit $STATUS
 ```
 
-The script outputs `Review posted: <URL>` on success and exits 0, or outputs `POSTING FAILED: <reason>` to stderr and exits 1.
+The script outputs `Review posted: <URL>` on success and exits 0, or outputs `POSTING FAILED: <reason>` to stderr and exits 1. Capture the review URL from the output for the Step 8 summary.
 
-**Zero findings is NOT an exit, and posting must NEVER be skipped** — the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json` is always created (with `"comments": []` when clean) and posted via `post-review.sh`.
+**Zero findings is NOT an exit, and posting must NEVER be skipped** — the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json` is always created (with `"comments": []` when clean) and posted via `post-review.sh`. Do not proceed to Step 8 without executing Step 7.
 ### Step 8: Summary
 
 No `::group::` wrapper for this step — the summary should be visible at the top level of the log. Still include the total elapsed time.

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -69,7 +69,7 @@ These rules are critical. They are also detailed in REVIEW-POSTING.md but inline
 - `line` is the line number on the new version of the file. Always use `side=RIGHT`
 - Only post **actionable** inline comments — no confirmations, no "looks good"
 - Do not repeat correctly addressed items
-- If no inline comments, set comments array to `[]` and post the body
+- If no inline comments, write `"comments": []` in the Step 6 payload file
 - **Always post — even with zero findings.** A clean review still requires a body-only review using the exact "No Findings" template from [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 (`## CI Review` header, "No actionable issues found. Reviewed N files across M changed lines.", profile).
 - **Posting is deterministic via `post-review.sh`**: Step 6 writes `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`, and Step 7 executes `post-review.sh` to handle payload submission, retry logic, and fallback posting automatically. Never skip Step 7.
 ## Timing Logs

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -275,13 +275,23 @@ Changed files: {count} ({additions}+ / {deletions}-)
 
 **Agent failure handling:** If an agent fails, times out, or returns unparseable output, log the failure and continue with findings from the remaining agents. Do not abort the review because one agent failed. Record the failure in the Step 8 summary (e.g., "Agents: 8 launched, 7 completed, 1 failed").
 
-After all agents have returned (or been recorded as failed), emit the Step-4 phase-end marker (substitute the remembered epoch):
+After all agents have returned (or been recorded as failed):
 
-```bash
-echo "[ci-review] Step 4 done elapsed=$(( $(date +%s) - <STEP4_START_EPOCH> ))s"
-echo "::endgroup::"
-```
+1. **If zero findings collected across all agents (clean PR):**
+   Emit the Step-4 phase-end marker, skip Steps 5 and 6, and **immediately execute `post-review.sh` to submit the clean review**:
+   ```bash
+   echo "[ci-review] Step 4 done elapsed=$(( $(date +%s) - <STEP4_START_EPOCH> ))s"
+   echo "::endgroup::"
+   sh plugins/ci-review/scripts/post-review.sh <PR#>
+   ```
+   Capture the review URL from the output, then proceed directly to Step 8. Do NOT end the session without executing `post-review.sh`.
 
+2. **If findings were found:** Emit the Step-4 phase-end marker:
+   ```bash
+   echo "[ci-review] Step 4 done elapsed=$(( $(date +%s) - <STEP4_START_EPOCH> ))s"
+   echo "::endgroup::"
+   ```
+   Then proceed to Step 5 (Confidence Scoring).
 ### Step 5: Confidence Scoring
 
 Multi-call timing variant. Emit the phase-start marker in a dedicated Bash call **before** launching scorers:
@@ -358,12 +368,22 @@ A single generic signal (severity tag alone or type keyword alone) is NOT suffic
 
 Track the count of findings excluded by this pass as `EXISTING_DEDUP_COUNT`.
 
-After all scorers have returned and filtering/deduplication is complete, emit the Step-5 phase-end marker, then proceed to Step 6 to construct the review payload (mandatory on all runs, including zero-findings runs):
+**If zero findings survive filtering:**
+Emit the Step-5 phase-end marker, skip Step 6, and **immediately execute `post-review.sh` to submit the clean review**:
+```bash
+echo "[ci-review] Step 5 done elapsed=$(( $(date +%s) - <STEP5_START_EPOCH> ))s"
+echo "::endgroup::"
+sh plugins/ci-review/scripts/post-review.sh <PR#>
+```
+Capture the review URL, then proceed directly to Step 8.
 
+**If findings survived filtering:**
+Emit the Step-5 phase-end marker:
 ```bash
 echo "[ci-review] Step 5 done elapsed=$(( $(date +%s) - <STEP5_START_EPOCH> ))s"
 echo "::endgroup::"
 ```
+Then proceed to Step 6 to construct the review payload.
 
 ### Step 6: Build Review Payload
 

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -58,22 +58,21 @@ If not specified, `--min-severity` defaults to `medium` for normal runs and to `
 These rules are critical. They are also detailed in REVIEW-POSTING.md but inlined here as defense-in-depth:
 
 - **Always use event `"COMMENT"`** — never `"APPROVE"` or `"REQUEST_CHANGES"`
-- Build ONE `gh api` call that creates the review with all inline comments at once
 - `line` is the line number on the new version of the file. Always use `side=RIGHT`
 - Only post **actionable** inline comments — no confirmations, no "looks good"
 - Do not repeat correctly addressed items
-- If no inline comments, omit the comments array and just post the body
-- **Always post — even with zero findings.** A clean review still requires a body-only review using the exact "No Findings" template from [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 (`## CI Review` header, "No actionable issues found. Reviewed N files across M changed lines.", profile). Never end the run without creating a review or, if the review API fails, the `gh pr comment` fallback. A run that posts nothing is a contract violation.
-
+- If no inline comments, set comments array to `[]` and post the body
+- **Always post — even with zero findings.** A clean review still requires a body-only review using the exact "No Findings" template from [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 (`## CI Review` header, "No actionable issues found. Reviewed N files across M changed lines.", profile).
+- **Posting is deterministic via `post-review.sh`**: Step 6 writes `/tmp/ci-review-payload.json`, and Step 7 executes `post-review.sh` to handle payload submission, retry logic, and fallback posting automatically. Never skip Step 7.
 ## Timing Logs
 
 This section is reference guidance. **Do not execute anything from it directly** — timing markers are only emitted from within each numbered Step's own Bash invocations below. This section describes the two variants and when to apply each.
 
 Every Step in the `## Workflow` section emits a phase-start marker at its beginning and a phase-end marker at its end so the GitHub Actions log shows where time is spent. GitHub Actions renders `::group::` / `::endgroup::` as collapsible sections in the run UI; local runs see them as plain text. Track each Step's elapsed seconds and report them in the Step 8 summary as `Phase timings (s): s0=... s1=... ... total=...`.
 
-**Single-call variant** — use when the entire Step fits in one Bash invocation (Steps 0, 1, 2). Capture the start epoch into a shell variable and compute elapsed inline, so no state needs to cross tool calls. **Preserve the step's exit status** by capturing `$?` immediately after `<step commands>` and re-emitting it at the end — otherwise the trailing `echo` commands would always return 0 and mask prerequisite or eligibility failures (e.g., `gh auth status` failing in Step 0). **All echoes go to stdout** — per GitHub's workflow-command spec, `::group::` / `::endgroup::` must appear on stdout to render as collapsible sections in the Actions log. For steps whose `<step commands>` also produces parseable output (e.g., Step 2's `gh pr view --json`), the output stream will interleave markers with the parseable line; the model reads both and extracts the parseable content visually (the JSON line is self-evident). Pattern: `echo "::group::[ci-review] Step N: <name>"; START=$(date +%s); <step commands>; STATUS=$?; echo "[ci-review] Step N done elapsed=$(( $(date +%s) - START ))s"; echo "::endgroup::"; exit $STATUS`.
+**Single-call variant** — use when the entire Step fits in one Bash invocation (Steps 0, 1, 2, 7). Capture the start epoch into a shell variable and compute elapsed inline, so no state needs to cross tool calls. **Preserve the step's exit status** by capturing `$?` immediately after `<step commands>` and re-emitting it at the end — otherwise the trailing `echo` commands would always return 0 and mask prerequisite or eligibility failures (e.g., `gh auth status` failing in Step 0). **All echoes go to stdout** — per GitHub's workflow-command spec, `::group::` / `::endgroup::` must appear on stdout to render as collapsible sections in the Actions log. For steps whose `<step commands>` also produces parseable output (e.g., Step 2's `gh pr view --json`), the output should remain parseable.
 
-**Multi-call variant** — use when the Step spans multiple Bash invocations or waits on subagent tool calls (Steps 3, 3.5, 4, 5, 6, 7). All marker echoes go to stdout (GitHub's workflow-command spec). Any value the model needs to remember for later calls (epochs, SHAs, owner/repo) must be printed to stdout as a labeled line so it survives across tool calls. In the first Bash call of the Step, print `echo "::group::[ci-review] Step N: <name>"` and `date +%s` — remember the printed epoch in your working state. In the last Bash call of the Step, substitute the remembered epoch into `echo "[ci-review] Step N done elapsed=$(( $(date +%s) - <REMEMBERED_EPOCH> ))s"; echo "::endgroup::"`. For Steps with agent fan-out (Steps 4, 5), place the phase-end marker *after* all agents have returned — the elapsed value will include their wall-clock time, which is exactly what we want to measure.
+**Multi-call variant** — use when the Step spans multiple Bash invocations or waits on subagent tool calls (Steps 3, 3.5, 4, 5, 6). All marker echoes go to stdout (GitHub's workflow-command spec). Any value the model needs to remember for later calls (epochs, SHAs, owner/repo) must be printed to stdout as a labeled line so it survives across tool calls. In the first Bash call of the Step, print `echo "::group::[ci-review] Step N: <name>"` and `date +%s` — remember the printed epoch in your working state. In the last Bash call of the Step, substitute the remembered epoch into `echo "[ci-review] Step N done elapsed=$(( $(date +%s) - <REMEMBERED_EPOCH> ))s"; echo "::endgroup::"`. For Steps with agent fan-out (Steps 4, 5), place the phase-end marker *after* all agents return.
 
 ## Workflow
 
@@ -351,7 +350,7 @@ A single generic signal (severity tag alone or type keyword alone) is NOT suffic
 
 Track the count of findings excluded by this pass as `EXISTING_DEDUP_COUNT`.
 
-**If no findings survive filtering:** Build a no-findings review body using the template from REVIEW-POSTING.md section 3 ("No Findings"), then skip to Step 7 to post it.
+**If no findings survive filtering:** Build a no-findings review body using the template from REVIEW-POSTING.md section 3 ("No Findings"), write the payload in Step 6 with `"comments": []`, and run Step 7 to post it.
 
 After all scorers have returned and filtering/deduplication is complete, emit the Step-5 phase-end marker:
 
@@ -404,8 +403,18 @@ For each surviving finding:
    - Summary with profile, finding counts by severity
    - If focus text was provided, mention it
    - List any body-only findings (not in diff) under "### Findings Not in Diff"
+   - If no findings survived: use the "No Findings" template (`## CI Review\n\nNo actionable issues found. Reviewed <N> files across <M> changed lines.\n\n**Profile**: <profile>`)
 
-After the payload is built, emit the Step-6 phase-end marker:
+4. **Write review payload to file** `/tmp/ci-review-payload.json`:
+   ```json
+   {
+     "body": "<REVIEW_BODY>",
+     "comments": [ ...inline comments... ]
+   }
+   ```
+   If there are no inline comments, set `"comments": []`.
+
+After the payload file is written, emit the Step-6 phase-end marker:
 
 ```bash
 echo "[ci-review] Step 6 done elapsed=$(( $(date +%s) - <STEP6_START_EPOCH> ))s"
@@ -414,60 +423,34 @@ echo "::endgroup::"
 
 ### Step 7: Post Review
 
-Multi-call timing variant — this step spans multiple Bash invocations (OWNER/REPO resolution, payload build, `gh api` post, and potential error-handling retries). Fold the phase-start marker into the first Bash call (OWNER/REPO resolution below), and emit the phase-end marker at the end of **every exit path** of the error-handling chain: successful post, the invalid-comments retry, the drop-all-inline-comments fallback, the `gh pr comment` fallback, and the final stdout-print fallback.
-
-Resolve the repository owner and repo — Bash tool state does not persist across calls, so print a labeled `OWNER_REPO=<owner/repo>` line to stdout and remember it. The model substitutes the `<OWNER>` and `<REPO>` placeholders in the `gh api` block below with the remembered value — no reliance on shell variables from this call:
+Single-call timing variant. Step 7 deterministically posts the review payload built in Step 6 by executing `post-review.sh`. The script automatically handles GitHub API review submission, invalid inline comment retries, body-only review fallback, and PR issue comment fallback:
 
 ```bash
 echo "::group::[ci-review] Step 7: Post Review"
-date +%s   # remember this epoch for the phase-end call on every exit path below
-gh repo view --json nameWithOwner --jq '"OWNER_REPO=" + .nameWithOwner'
-```
+START=$(date +%s)
 
-Build the JSON payload using `jq` and post via `gh api`. Substitute the owner/repo you remembered from the phase-start call into `<OWNER>/<REPO>` below:
+# Locate post-review.sh (plugin root, repo path, or plugin cache)
+POST_SCRIPT=""
+if [ -n "$CLAUDE_PLUGIN_ROOT" ] && [ -f "$CLAUDE_PLUGIN_ROOT/scripts/post-review.sh" ]; then
+  POST_SCRIPT="$CLAUDE_PLUGIN_ROOT/scripts/post-review.sh"
+elif [ -f "plugins/ci-review/scripts/post-review.sh" ]; then
+  POST_SCRIPT="plugins/ci-review/scripts/post-review.sh"
+else
+  POST_SCRIPT="$(find ~/.claude/plugins -name post-review.sh 2>/dev/null | head -1)"
+fi
+[ -n "$POST_SCRIPT" ] && [ -f "$POST_SCRIPT" ] || POST_SCRIPT="post-review.sh"
 
-```bash
-PAYLOAD=$(jq -n \
-  --arg event "COMMENT" \
-  --arg body "$REVIEW_BODY" \
-  --argjson comments "$COMMENTS_JSON" \
-  '{event: $event, body: $body, comments: $comments}')
+sh "$POST_SCRIPT" <PR#> /tmp/ci-review-payload.json
+STATUS=$?
 
-REVIEW_URL=$(echo "$PAYLOAD" | gh api \
-  "repos/<OWNER>/<REPO>/pulls/<PR#>/reviews" \
-  --method POST \
-  --input - \
-  --jq '.html_url')
-```
-
-**If no inline comments**, omit the comments array:
-```bash
-PAYLOAD=$(jq -n \
-  --arg event "COMMENT" \
-  --arg body "$REVIEW_BODY" \
-  '{event: $event, body: $body}')
-```
-
-**Error handling chain** (follow in order):
-1. If `gh api` fails due to invalid inline comments → remove the invalid comment, rebuild payload, retry (within the 3-total-attempt budget the posting gate below enforces)
-2. If still failing → drop all inline comments, move all findings to review body, retry
-3. If review API fails entirely (403/401) → fall back to `gh pr comment <PR#> --body "$REVIEW_BODY_WITH_ALL_FINDINGS"`
-4. If everything fails → print the review body to stdout so the user can post manually (**local runs only** — in CI the mandatory-posting gate below takes precedence: a stdout print is not a posted review)
-
-**Zero findings is NOT an exit, and neither is a failed post** — a posted review is mandatory on every run. Before emitting the Step-7 phase-end marker, confirm you hold a review URL (`.html_url`) returned by a successful `gh api` post, or a comment URL from the `gh pr comment` fallback, **from this session**. If you hold neither, the review was not posted:
-
-1. Re-post up to 2 more times (bounded — 3 total attempts across the chain), alternating the body-only form and the `gh pr comment` fallback
-2. If all attempts fail: in CI, end the session with an explicit "POSTING FAILED" statement (the CI verifier will fail the job — that is correct); locally, print the body for manual posting
-3. Only a URL from a successful post clears the gate — emit the phase-end marker immediately after
-
-Do not proceed to Step 8 without a URL proving this session posted. Ending a session without a posted review is a contract violation that turns the CI job red.
-
-Print the review URL on success, then emit the Step-7 phase-end marker. **The same two-line phase-end block must follow every exit path above** (successful post, retry success after invalid-comment cleanup, drop-inline fallback success, `gh pr comment` fallback, and the stdout-print terminal fallback) so the Step-7 group is always closed:
-
-```bash
-echo "[ci-review] Step 7 done elapsed=$(( $(date +%s) - <STEP7_START_EPOCH> ))s"
+echo "[ci-review] Step 7 done elapsed=$(( $(date +%s) - START ))s"
 echo "::endgroup::"
+exit $STATUS
 ```
+
+The script outputs `Review posted: <URL>` on success and exits 0, or outputs `POSTING FAILED: <reason>` to stderr and exits 1.
+
+**Zero findings is NOT an exit, and posting must NEVER be skipped** — the payload file `/tmp/ci-review-payload.json` is always created (with `"comments": []` when clean) and posted via `post-review.sh`.
 
 ### Step 8: Summary
 

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -443,8 +443,6 @@ echo "::endgroup::"
 
 ### Step 7: Post Review
 Single-call timing variant. Step 7 deterministically posts the review payload by executing `post-review.sh`. This step is mandatory on every run (including zero-findings runs). The script automatically handles GitHub API review submission, invalid inline comment retries, body-only review fallback, and PR issue comment fallback:
-
-**If findings were produced in Step 6:**
 ```bash
 echo "::group::[ci-review] Step 7: Post Review"
 START=$(date +%s)
@@ -452,16 +450,6 @@ sh plugins/ci-review/scripts/post-review.sh <PR#> "${TMPDIR:-/tmp}/ci-review-pay
 echo "[ci-review] Step 7 done elapsed=$(( $(date +%s) - START ))s"
 echo "::endgroup::"
 ```
-
-**If zero findings were produced (clean run):**
-```bash
-echo "::group::[ci-review] Step 7: Post Review"
-START=$(date +%s)
-sh plugins/ci-review/scripts/post-review.sh <PR#>
-echo "[ci-review] Step 7 done elapsed=$(( $(date +%s) - START ))s"
-echo "::endgroup::"
-```
-
 The script outputs `Review posted: <URL>` on success (exit 0) or `POSTING FAILED: <reason>` to stderr (exit 1). Capture the review URL from the output for the Step 8 summary.
 
 **Zero findings is NOT an exit, and posting must NEVER be skipped** — a posted review on GitHub is required on every run. Step 7 must always be executed before proceeding to Step 8.

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -387,58 +387,58 @@ date +%s   # remember this epoch for the phase-end call
 | comment-analyzer | comment-accuracy |
 | type-analyzer | type-design |
 
-Construct the review body markdown and inline comments according to the findings status:
+You MUST execute the `Bash` tool to construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
 
-- **When surviving findings exist (findings > 0):**
+- **For clean runs with zero findings (findings == 0)**, execute this exact Bash command:
+  ```bash
+  cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
+  ## CI Review
+
+  No actionable issues found. Reviewed <N> files across <M> changed lines.
+
+  **Profile**: <profile>
+  EOF
+
+  cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json"
+  []
+  EOF
+
+  jq -n \
+    --rawfile body "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md" \
+    --slurpfile comments "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json" \
+    '{body: $body, comments: ($comments[0] // [])}' \
+    > "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
+
+  echo "[ci-review] Step 6 done elapsed=$(( $(date +%s) - <STEP6_START_EPOCH> ))s"
+  echo "::endgroup::"
+  ```
+
+- **For runs with surviving findings (findings > 0)**:
   1. **Determine inline eligibility**: Check if the finding's `file` appears in the PR diff and the `line` is in a changed hunk. If yes → inline comment. If no → body-only finding.
-  2. **Build inline comment objects**:
-     ```json
-     {
-       "path": "<file>",
-       "line": <line_number>,
-       "side": "RIGHT",
-       "body": "**[<severity>] <type>**\n\n<description>\n\n**Recommendation:** <recommendation>\n\n`Found by: <agent-name>`"
-     }
+  2. **Build inline comment objects** in `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json` and review body in `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md`, then encode with `jq`:
+     ```bash
+     cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
+     <REVIEW_BODY>
+     EOF
+
+     cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json"
+     [ ...inline comments... ]
+     EOF
+
+     jq -n \
+       --rawfile body "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md" \
+       --slurpfile comments "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json" \
+       '{body: $body, comments: ($comments[0] // [])}' \
+       > "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
+
+     echo "[ci-review] Step 6 done elapsed=$(( $(date +%s) - <STEP6_START_EPOCH> ))s"
+     echo "::endgroup::"
      ```
-  3. **Build review body**: Summary with profile, finding counts by severity, focus text if provided, and body-only findings under "### Findings Not in Diff".
-
-- **When zero findings exist (findings == 0):**
-  1. Set review body to the standard "No Findings" template:
-     ```markdown
-     ## CI Review
-
-     No actionable issues found. Reviewed <N> files across <M> changed lines.
-
-     **Profile**: <profile>
-     ```
-  2. Set inline comments to empty array `[]`.
-**Construct review payload file** `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
-Write the review body markdown to `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md` and inline comments to `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json`, then use `jq` to safely encode the payload (preventing invalid JSON from multi-paragraph markdown or special characters):
-   ```bash
-   cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
-   <REVIEW_BODY>
-   EOF
-
-   cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json"
-   [ ...inline comments... ]
-   EOF
-
-   jq -n \
-     --rawfile body "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md" \
-     --slurpfile comments "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json" \
-     '{body: $body, comments: ($comments[0] // [])}' \
-     > "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
-   ```
-   If there are no inline comments, write `[]` to `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json`.
-After the payload file is written, emit the Step-6 phase-end marker:
-
-```bash
-echo "[ci-review] Step 6 done elapsed=$(( $(date +%s) - <STEP6_START_EPOCH> ))s"
-echo "::endgroup::"
-```
 
 ### Step 7: Post Review
-Single-call timing variant. Step 7 deterministically posts the review payload by executing `post-review.sh`. This step is mandatory on every run (including zero-findings runs). The script automatically handles GitHub API review submission, invalid inline comment retries, body-only review fallback, and PR issue comment fallback:
+
+Single-call timing variant. You MUST execute this Bash command on every run (including zero-findings runs) to submit the review to GitHub:
+
 ```bash
 echo "::group::[ci-review] Step 7: Post Review"
 START=$(date +%s)
@@ -451,7 +451,7 @@ exit $STATUS
 
 The script outputs `Review posted: <URL>` on success (exit 0) or `POSTING FAILED: <reason>` to stderr (exit 1). Capture the review URL from the output for the Step 8 summary.
 
-**Zero findings is NOT an exit, and posting must NEVER be skipped** — a posted review on GitHub is required on every run. Step 7 must always be executed before proceeding to Step 8.
+**Zero findings is NOT an exit, and posting must NEVER be skipped** — you must execute Step 7's Bash tool call before proceeding to Step 8.
 ### Step 8: Summary
 
 No `::group::` wrapper for this step — the summary should be visible at the top level of the log. Still include the total elapsed time.

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -21,13 +21,15 @@ argument-hint: "<PR#> [focus text] [--full|--lean|--single] [--agent] [--model s
 ## Mandatory Review Contract (Inviolable)
 
 Every execution of `/ci-review` MUST complete all workflow steps through Step 8:
-1. **Step 6 is mandatory when findings exist**: Construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`.
-2. **Step 7 is mandatory on ALL runs**: Call the `Bash` tool to run `sh plugins/ci-review/scripts/post-review.sh <PR#> [payload_file]`. When zero findings exist, run `sh plugins/ci-review/scripts/post-review.sh <PR#>`.
+1. **Step 6 is mandatory on ALL runs**: Construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json` (using the "No Findings" template with `"comments": []` when clean).
+2. **Step 7 is mandatory on ALL runs**: Call the `Bash` tool to run `sh plugins/ci-review/scripts/post-review.sh <PR#> "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"`.
 3. **Step 8 is mandatory**: Output the summary including the review URL returned by `post-review.sh`.
 
 Before running, **read [references/REVIEW-POSTING.md](references/REVIEW-POSTING.md) now** for the review posting format and error handling chain.
 
 ## Profiles
+
+| Profile | Agents | Use When |
 |---------|--------|----------|
 | **single** | single-reviewer (one comprehensive agent) | Routine PRs, CI budgets, small diffs — ~6x cheaper than lean |
 | **lean** (default) | deep-reviewer, guidelines-checker, bug-detector, security-reviewer, silent-failure-hunter, code-simplifier | Every PR — balanced cost and coverage |

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -392,6 +392,7 @@ date +%s   # remember this epoch for the phase-end call
 You MUST execute the `Bash` tool to construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
 
 - **For clean runs with zero findings (findings == 0)**, substitute the actual values into `<PR#>`, `<N>` (files), `<M>` (lines), and `<profile>`, and execute this Bash command:
+  ```bash
   cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
   ## CI Review
 

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -21,8 +21,16 @@ argument-hint: "<PR#> [focus text] [--full|--lean|--single] [--agent] [--model s
 
 Multi-agent code review for pull requests. Posts findings as an atomic GitHub PR review with inline comments.
 
-Before running, **read [references/REVIEW-POSTING.md](references/REVIEW-POSTING.md) now** for the review posting format and error handling chain.
+## Mandatory Review Contract (Inviolable)
 
+Every execution of `/ci-review` MUST complete all workflow steps through Step 8:
+1. **Step 6 is mandatory**: Always construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`. When zero findings survive, use the "No Findings" template with `"comments": []`.
+2. **Step 7 is mandatory**: Always execute `post-review.sh` to submit the review to GitHub via API/comment fallback. A clean run with zero findings still requires a posted review.
+3. **Step 8 is mandatory**: Always output the summary including the review URL returned by Step 7.
+
+Ending a session without executing Step 7 is a contract violation that turns CI red.
+
+Before running, **read [references/REVIEW-POSTING.md](references/REVIEW-POSTING.md) now** for the review posting format and error handling chain.
 ## Profiles
 
 | Profile | Agents | Use When |

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -63,7 +63,7 @@ These rules are critical. They are also detailed in REVIEW-POSTING.md but inline
 - Do not repeat correctly addressed items
 - If no inline comments, set comments array to `[]` and post the body
 - **Always post — even with zero findings.** A clean review still requires a body-only review using the exact "No Findings" template from [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 (`## CI Review` header, "No actionable issues found. Reviewed N files across M changed lines.", profile).
-- **Posting is deterministic via `post-review.sh`**: Step 6 writes `/tmp/ci-review-payload.json`, and Step 7 executes `post-review.sh` to handle payload submission, retry logic, and fallback posting automatically. Never skip Step 7.
+- **Posting is deterministic via `post-review.sh`**: Step 6 writes `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`, and Step 7 executes `post-review.sh` to handle payload submission, retry logic, and fallback posting automatically. Never skip Step 7.
 ## Timing Logs
 
 This section is reference guidance. **Do not execute anything from it directly** — timing markers are only emitted from within each numbered Step's own Bash invocations below. This section describes the two variants and when to apply each.

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -454,11 +454,19 @@ exit $STATUS
 The script outputs `Review posted: <URL>` on success (exit 0) or `POSTING FAILED: <reason>` to stderr (exit 1). Capture the review URL from the output for the Step 8 summary.
 
 **Zero findings is NOT an exit, and posting must NEVER be skipped** — you must execute Step 7's Bash tool call before proceeding to Step 8.
-### Step 8: Summary
+### Step 8: Self-Check & Summary
 
 No `::group::` wrapper for this step — the summary should be visible at the top level of the log. Still include the total elapsed time.
 
-Print a brief summary for the CI log:
+Before writing the final summary, verify that the review was posted by checking the URL returned from Step 7:
+- The `Review:` line in the summary below MUST contain the real GitHub review URL returned by `post-review.sh` in Step 7 (`Review posted: https://github.com/...`).
+- If you have not executed Step 7 yet, execute it now via Bash:
+  ```bash
+  sh plugins/ci-review/scripts/post-review.sh <PR#> "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
+  ```
+- Never use a placeholder like `<URL>` or `None` — the review URL must be a live GitHub URL from a successful post.
+
+Print the summary for the CI log:
 
 ```
 CI Review complete for PR #N
@@ -469,10 +477,9 @@ After confidence scoring (≥65): N survived
 After severity filter (≥{min-severity}): N survived
 Already commented (skipped): N
 Posted: N inline comments + review body
-Review: <URL>
+Review: <URL_FROM_POST_REVIEW_SH>
 Phase timings (s): s0=<prereq> s1=<parse> s2=<eligibility> s3=<context> s3_5=<checkout> s4=<agents> s5=<scoring> s6=<payload> s7=<post> total=<sum>
 ```
-
 The `Phase timings` line is the most load-bearing output for post-run analysis — list every step's elapsed seconds (using the values you tracked across the Timing Logs markers) plus a `total=` that is the sum of all phases. **Every Step must still be measured and reported when it runs** — even when no branching action occurs (e.g., Step 3.5 when HEAD_SHA already matches PR_HEAD_SHA and no checkout runs, the Step still executed `gh pr view` + `git rev-parse`, so its elapsed time should be recorded and reported). Because `date +%s` has 1-second granularity, legitimately fast steps (especially Step 1's no-op argument parse) may report `s<N>=0` — that is a valid measured value, not a "skipped" marker. A Step's elapsed should be omitted only when the Step was truly not entered (which for Steps 0–7 would indicate a prompt bug — they run on every invocation).
 
 ## Agent Output Format

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -442,21 +442,29 @@ echo "::endgroup::"
 ```
 
 ### Step 7: Post Review
-Single-call timing variant. Step 7 deterministically posts the review payload built in Step 6 by executing `post-review.sh`. This step is mandatory on every run (including zero-findings runs). The script automatically handles GitHub API review submission, invalid inline comment retries, body-only review fallback, and PR issue comment fallback:
+Single-call timing variant. Step 7 deterministically posts the review payload by executing `post-review.sh`. This step is mandatory on every run (including zero-findings runs). The script automatically handles GitHub API review submission, invalid inline comment retries, body-only review fallback, and PR issue comment fallback:
 
+**If findings were produced in Step 6:**
 ```bash
 echo "::group::[ci-review] Step 7: Post Review"
 START=$(date +%s)
 sh plugins/ci-review/scripts/post-review.sh <PR#> "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
-STATUS=$?
 echo "[ci-review] Step 7 done elapsed=$(( $(date +%s) - START ))s"
 echo "::endgroup::"
-exit $STATUS
 ```
 
-The script outputs `Review posted: <URL>` on success and exits 0, or outputs `POSTING FAILED: <reason>` to stderr and exits 1. Capture the review URL from the output for the Step 8 summary.
+**If zero findings were produced (clean run):**
+```bash
+echo "::group::[ci-review] Step 7: Post Review"
+START=$(date +%s)
+sh plugins/ci-review/scripts/post-review.sh <PR#>
+echo "[ci-review] Step 7 done elapsed=$(( $(date +%s) - START ))s"
+echo "::endgroup::"
+```
 
-**Zero findings is NOT an exit, and posting must NEVER be skipped** — the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json` is always created (with `"comments": []` when clean) and posted via `post-review.sh`. Do not proceed to Step 8 without executing Step 7.
+The script outputs `Review posted: <URL>` on success (exit 0) or `POSTING FAILED: <reason>` to stderr (exit 1). Capture the review URL from the output for the Step 8 summary.
+
+**Zero findings is NOT an exit, and posting must NEVER be skipped** — a posted review on GitHub is required on every run. Step 7 must always be executed before proceeding to Step 8.
 ### Step 8: Summary
 
 No `::group::` wrapper for this step — the summary should be visible at the top level of the log. Still include the total elapsed time.

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -391,8 +391,7 @@ date +%s   # remember this epoch for the phase-end call
 
 You MUST execute the `Bash` tool to construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
 
-- **For clean runs with zero findings (findings == 0)**, execute this exact Bash command:
-  ```bash
+- **For clean runs with zero findings (findings == 0)**, substitute the actual values into `<PR#>`, `<N>` (files), `<M>` (lines), and `<profile>`, and execute this Bash command:
   cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
   ## CI Review
 

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -269,23 +269,14 @@ Changed files: {count} ({additions}+ / {deletions}-)
 
 **Agent failure handling:** If an agent fails, times out, or returns unparseable output, log the failure and continue with findings from the remaining agents. Do not abort the review because one agent failed. Record the failure in the Step 8 summary (e.g., "Agents: 8 launched, 7 completed, 1 failed").
 
-After all agents have returned (or been recorded as failed):
+After all agents have returned (or been recorded as failed), emit the Step-4 phase-end marker (substitute the remembered epoch):
 
-1. **If zero findings collected across all agents (clean PR):**
-   Emit the Step-4 phase-end marker, skip Steps 5 and 6, and **immediately execute `post-review.sh` to submit the clean review**:
-   ```bash
-   echo "[ci-review] Step 4 done elapsed=$(( $(date +%s) - <STEP4_START_EPOCH> ))s"
-   echo "::endgroup::"
-   sh plugins/ci-review/scripts/post-review.sh <PR#>
-   ```
-   Capture the review URL from the output, then proceed directly to Step 8. Do NOT end the session without executing `post-review.sh`.
+```bash
+echo "[ci-review] Step 4 done elapsed=$(( $(date +%s) - <STEP4_START_EPOCH> ))s"
+echo "::endgroup::"
+```
 
-2. **If findings were found:** Emit the Step-4 phase-end marker:
-   ```bash
-   echo "[ci-review] Step 4 done elapsed=$(( $(date +%s) - <STEP4_START_EPOCH> ))s"
-   echo "::endgroup::"
-   ```
-   Then proceed to Step 5 (Confidence Scoring).
+Then proceed to Step 5 (Confidence Scoring).
 ### Step 5: Confidence Scoring
 
 Multi-call timing variant. Emit the phase-start marker in a dedicated Bash call **before** launching scorers:
@@ -361,22 +352,13 @@ A single generic signal (severity tag alone or type keyword alone) is NOT suffic
 - String matching is case-insensitive
 
 Track the count of findings excluded by this pass as `EXISTING_DEDUP_COUNT`.
+After all scorers have returned and filtering/deduplication is complete, emit the Step-5 phase-end marker:
 
-**If zero findings survive filtering:**
-Emit the Step-5 phase-end marker, skip Step 6, and **immediately execute `post-review.sh` to submit the clean review**:
-```bash
-echo "[ci-review] Step 5 done elapsed=$(( $(date +%s) - <STEP5_START_EPOCH> ))s"
-echo "::endgroup::"
-sh plugins/ci-review/scripts/post-review.sh <PR#>
-```
-Capture the review URL, then proceed directly to Step 8.
-
-**If findings survived filtering:**
-Emit the Step-5 phase-end marker:
 ```bash
 echo "[ci-review] Step 5 done elapsed=$(( $(date +%s) - <STEP5_START_EPOCH> ))s"
 echo "::endgroup::"
 ```
+
 Then proceed to Step 6 to construct the review payload.
 
 ### Step 6: Build Review Payload
@@ -461,9 +443,12 @@ Single-call timing variant. Step 7 deterministically posts the review payload by
 echo "::group::[ci-review] Step 7: Post Review"
 START=$(date +%s)
 sh plugins/ci-review/scripts/post-review.sh <PR#> "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
+STATUS=$?
 echo "[ci-review] Step 7 done elapsed=$(( $(date +%s) - START ))s"
 echo "::endgroup::"
+exit $STATUS
 ```
+
 The script outputs `Review posted: <URL>` on success (exit 0) or `POSTING FAILED: <reason>` to stderr (exit 1). Capture the review URL from the output for the Step 8 summary.
 
 **Zero findings is NOT an exit, and posting must NEVER be skipped** — a posted review on GitHub is required on every run. Step 7 must always be executed before proceeding to Step 8.

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -429,17 +429,16 @@ Single-call timing variant. Step 7 deterministically posts the review payload bu
 echo "::group::[ci-review] Step 7: Post Review"
 START=$(date +%s)
 
-# Locate post-review.sh (plugin root, repo path, or plugin cache)
+# Locate post-review.sh (plugin root or repo path)
 POST_SCRIPT=""
 if [ -n "$CLAUDE_PLUGIN_ROOT" ] && [ -f "$CLAUDE_PLUGIN_ROOT/scripts/post-review.sh" ]; then
   POST_SCRIPT="$CLAUDE_PLUGIN_ROOT/scripts/post-review.sh"
 elif [ -f "plugins/ci-review/scripts/post-review.sh" ]; then
   POST_SCRIPT="plugins/ci-review/scripts/post-review.sh"
 else
-  POST_SCRIPT="$(find ~/.claude/plugins -name post-review.sh 2>/dev/null | head -1)"
+  echo "::error::post-review.sh not found (neither CLAUDE_PLUGIN_ROOT nor repo path exists)" >&2
+  exit 1
 fi
-[ -n "$POST_SCRIPT" ] && [ -f "$POST_SCRIPT" ] || POST_SCRIPT="post-review.sh"
-
 sh "$POST_SCRIPT" <PR#> /tmp/ci-review-payload.json
 STATUS=$?
 

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -416,8 +416,8 @@ Construct the review body markdown and inline comments according to the findings
      **Profile**: <profile>
      ```
   2. Set inline comments to empty array `[]`.
-4. **Construct review payload file** `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
-   Write the review body markdown to `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md` and inline comments to `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json`, then use `jq` to safely encode the payload (preventing invalid JSON from multi-paragraph markdown or special characters):
+**Construct review payload file** `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
+Write the review body markdown to `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md` and inline comments to `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json`, then use `jq` to safely encode the payload (preventing invalid JSON from multi-paragraph markdown or special characters):
    ```bash
    cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
    <REVIEW_BODY>

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -447,20 +447,8 @@ Single-call timing variant. Step 7 deterministically posts the review payload bu
 ```bash
 echo "::group::[ci-review] Step 7: Post Review"
 START=$(date +%s)
-
-# Locate post-review.sh (plugin root or repo path)
-POST_SCRIPT=""
-if [ -n "$CLAUDE_PLUGIN_ROOT" ] && [ -f "$CLAUDE_PLUGIN_ROOT/scripts/post-review.sh" ]; then
-  POST_SCRIPT="$CLAUDE_PLUGIN_ROOT/scripts/post-review.sh"
-elif [ -f "plugins/ci-review/scripts/post-review.sh" ]; then
-  POST_SCRIPT="plugins/ci-review/scripts/post-review.sh"
-else
-  echo "::error::post-review.sh not found (neither CLAUDE_PLUGIN_ROOT nor repo path exists)" >&2
-  exit 1
-fi
-sh "$POST_SCRIPT" <PR#> "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
+sh plugins/ci-review/scripts/post-review.sh <PR#> "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
 STATUS=$?
-
 echo "[ci-review] Step 7 done elapsed=$(( $(date +%s) - START ))s"
 echo "::endgroup::"
 exit $STATUS

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -2,15 +2,10 @@
 name: ci-review
 description: >-
   CI-optimized code review: multi-agent parallel review with confidence scoring
-  and atomic GitHub PR review posting. Runs 6 (lean) or 9 (full) specialized
-  review agents including one unconstrained deep-reviewer, scores findings for confidence, filters false positives, and
-  submits a single atomic GitHub PR review with inline comments via gh api.
-  Supports --single for cost-effective single-agent reviews with confidence scoring,
-  --agent profile for AI-authored PRs (surfaces more findings since
-  fixes are cheap). Use --min-severity to control finding threshold.
-  Use when reviewing PRs in CI pipelines, GitHub Actions workflows, or locally.
+  and atomic GitHub PR review posting. Runs specialized review agents, scores
+  findings, and submits a GitHub PR review via `sh plugins/ci-review/scripts/post-review.sh`.
+  Always executes `post-review.sh` to submit a review on every run (including zero-findings runs).
   Triggers: /ci-review, review PR, CI code review, automated PR review.
-  Use --model to override the reviewer model (e.g., --model opus for deeper analysis).
   Use: /ci-review <PR#> [focus text] [--full|--lean|--single] [--agent] [--model sonnet|opus] [--min-severity <level>]
 user-invocable: true
 allowed-tools: [Bash, Read, Grep, Glob, Agent, AskUserQuestion]
@@ -19,21 +14,20 @@ argument-hint: "<PR#> [focus text] [--full|--lean|--single] [--agent] [--model s
 
 # CI Review
 
-Multi-agent code review for pull requests. Posts findings as an atomic GitHub PR review with inline comments.
+**CRITICAL REQUIREMENT**: This skill is an automated review submitter. Its primary deliverable is an atomic GitHub PR review submitted by calling the `Bash` tool to execute `post-review.sh`.
+
+**You MUST call the `Bash` tool to run `sh plugins/ci-review/scripts/post-review.sh` on EVERY run before writing any final summary text.** Ending a session without calling the `Bash` tool to post the review violates the contract and fails CI.
 
 ## Mandatory Review Contract (Inviolable)
 
 Every execution of `/ci-review` MUST complete all workflow steps through Step 8:
-1. **Step 6 is mandatory**: Always construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`. When zero findings survive, use the "No Findings" template with `"comments": []`.
-2. **Step 7 is mandatory**: Always execute `post-review.sh` to submit the review to GitHub via API/comment fallback. A clean run with zero findings still requires a posted review.
-3. **Step 8 is mandatory**: Always output the summary including the review URL returned by Step 7.
-
-Ending a session without executing Step 7 is a contract violation that turns CI red.
+1. **Step 6 is mandatory when findings exist**: Construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`.
+2. **Step 7 is mandatory on ALL runs**: Call the `Bash` tool to run `sh plugins/ci-review/scripts/post-review.sh <PR#> [payload_file]`. When zero findings exist, run `sh plugins/ci-review/scripts/post-review.sh <PR#>`.
+3. **Step 8 is mandatory**: Output the summary including the review URL returned by `post-review.sh`.
 
 Before running, **read [references/REVIEW-POSTING.md](references/REVIEW-POSTING.md) now** for the review posting format and error handling chain.
-## Profiles
 
-| Profile | Agents | Use When |
+## Profiles
 |---------|--------|----------|
 | **single** | single-reviewer (one comprehensive agent) | Routine PRs, CI budgets, small diffs — ~6x cheaper than lean |
 | **lean** (default) | deep-reviewer, guidelines-checker, bug-detector, security-reviewer, silent-failure-hunter, code-simplifier | Every PR — balanced cost and coverage |

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -405,12 +405,14 @@ For each surviving finding:
    - List any body-only findings (not in diff) under "### Findings Not in Diff"
    - If no findings survived: use the "No Findings" template (`## CI Review\n\nNo actionable issues found. Reviewed <N> files across <M> changed lines.\n\n**Profile**: <profile>`)
 
-4. **Write review payload to file** `/tmp/ci-review-payload.json`:
-   ```json
+4. **Write review payload to file** `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
+   ```bash
+   cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
    {
      "body": "<REVIEW_BODY>",
      "comments": [ ...inline comments... ]
    }
+   EOF
    ```
    If there are no inline comments, set `"comments": []`.
 
@@ -439,7 +441,7 @@ else
   echo "::error::post-review.sh not found (neither CLAUDE_PLUGIN_ROOT nor repo path exists)" >&2
   exit 1
 fi
-sh "$POST_SCRIPT" <PR#> /tmp/ci-review-payload.json
+sh "$POST_SCRIPT" <PR#> "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
 STATUS=$?
 
 echo "[ci-review] Step 7 done elapsed=$(( $(date +%s) - START ))s"
@@ -449,8 +451,7 @@ exit $STATUS
 
 The script outputs `Review posted: <URL>` on success and exits 0, or outputs `POSTING FAILED: <reason>` to stderr and exits 1.
 
-**Zero findings is NOT an exit, and posting must NEVER be skipped** — the payload file `/tmp/ci-review-payload.json` is always created (with `"comments": []` when clean) and posted via `post-review.sh`.
-
+**Zero findings is NOT an exit, and posting must NEVER be skipped** — the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json` is always created (with `"comments": []` when clean) and posted via `post-review.sh`.
 ### Step 8: Summary
 
 No `::group::` wrapper for this step — the summary should be visible at the top level of the log. Still include the total elapsed time.

--- a/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
+++ b/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
@@ -81,101 +81,54 @@ No actionable issues found. Reviewed <N> files across <M> changed lines.
 
 ## 4. Construct the JSON Payload
 
-Use `jq` to build the payload. This is robust for dynamic construction:
+Write the review payload as a structured JSON file (e.g. `/tmp/ci-review-payload.json`):
 
-```bash
-# Resolve repo
-OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-OWNER="${OWNER_REPO%%/*}"
-REPO="${OWNER_REPO#*/}"
-
-# Build payload (COMMENTS_JSON is a JSON array of comment objects)
-PAYLOAD=$(jq -n \
-  --arg event "COMMENT" \
-  --arg body "$REVIEW_BODY" \
-  --argjson comments "$COMMENTS_JSON" \
-  '{event: $event, body: $body, comments: $comments}')
-
-# Post the review
-REVIEW_URL=$(echo "$PAYLOAD" | gh api \
-  "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" \
-  --method POST \
-  --input - \
-  --jq '.html_url')
-
-echo "Review posted: $REVIEW_URL"
+```json
+{
+  "body": "## CI Review\n\n**Profile**: lean | **Findings**: 2 (0 critical, 1 high, 1 medium, 0 low)\n\n### Summary\n...",
+  "comments": [
+    {
+      "path": "src/api.ts",
+      "line": 42,
+      "side": "RIGHT",
+      "body": "**[high] bug**\n\nSQL injection via unsanitized user input.\n\n**Recommendation:** Use parameterized queries.\n\n`Found by: bug-detector`"
+    }
+  ]
+}
 ```
 
-If there are no inline comments, omit the `comments` array entirely:
+If there are no inline comments (or zero findings), set `"comments": []`:
 
-```bash
-PAYLOAD=$(jq -n \
-  --arg event "COMMENT" \
-  --arg body "$REVIEW_BODY" \
-  '{event: $event, body: $body}')
+```json
+{
+  "body": "## CI Review\n\nNo actionable issues found. Reviewed 3 files across 45 changed lines.\n\n**Profile**: lean",
+  "comments": []
+}
 ```
 
-## 5. Error Handling Chain
+## 5. Deterministic Posting via `post-review.sh`
 
-If the `gh api` call fails, follow this retry chain:
-
-### Retry 1: Remove Invalid Comments (up to 3 attempts)
-
-If the error mentions a specific invalid comment (line not in diff), remove it and retry. Repeat up to 3 times. If still failing after 3 retries, proceed to Retry 2.
+Posting is performed deterministically by `scripts/post-review.sh`:
 
 ```bash
-# Remove the invalid comment
-COMMENTS_JSON=$(echo "$COMMENTS_JSON" | jq \
-  --arg invalid_path "$INVALID_PATH" \
-  --arg invalid_line "$INVALID_LINE" \
-  'del(.[] | select(.path == $invalid_path and .line == ($invalid_line | tonumber)))')
-
-# Rebuild and retry
-PAYLOAD=$(jq -n \
-  --arg event "COMMENT" \
-  --arg body "$REVIEW_BODY" \
-  --argjson comments "$COMMENTS_JSON" \
-  '{event: $event, body: $body, comments: $comments}')
-
-echo "$PAYLOAD" | gh api \
-  "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" \
-  --method POST \
-  --input -
+sh plugins/ci-review/scripts/post-review.sh <PR#> /tmp/ci-review-payload.json
 ```
 
-### Retry 2: Body-Only Review
+The script automates the complete retry and fallback chain:
 
-If inline comments keep failing, move all findings into the review body and post with no comments:
-
-```bash
-PAYLOAD=$(jq -n \
-  --arg event "COMMENT" \
-  --arg body "$REVIEW_BODY_WITH_ALL_FINDINGS" \
-  '{event: $event, body: $body}')
-
-echo "$PAYLOAD" | gh api \
-  "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" \
-  --method POST \
-  --input -
-```
-
-### Retry 3: Fallback to PR Comment
-
-If the review API fails entirely (403, 401, permissions), fall back to a regular PR comment:
-
-```bash
-gh pr comment "$PR_NUMBER" --body "$REVIEW_BODY_WITH_ALL_FINDINGS"
-```
-
-Note in the comment: "*(Posted as PR comment — review API unavailable)*"
+1. **Primary Attempt**: Submits review via `gh api repos/<owner>/<repo>/pulls/<PR#>/reviews` with event `"COMMENT"`.
+2. **Retry 1 (Invalid comments)**: If the API rejects comments not in the diff, removes invalid comments and retries.
+3. **Retry 2 (Body-only review)**: If inline comments still fail, moves inline comments to the review body and submits a body-only review (`POST .../reviews`).
+4. **Retry 3 (PR Comment fallback)**: If the reviews API fails (403, 401, permissions), falls back to `gh api repos/<owner>/<repo>/issues/<PR#>/comments` (or `gh pr comment`).
+5. **Verification**: Verifies that a valid URL was returned by GitHub, outputs `Review posted: <URL>`, and exits 0.
 
 ## 6. Error Summary
 
-| Error | Recovery |
-|-------|----------|
+| Error | Recovery (handled by `post-review.sh`) |
+|-------|----------------------------------------|
 | Invalid inline comment (line not in diff) | Remove that comment, retry with remaining |
-| All inline comments invalid | Post body-only review (no comments array) |
-| Review API 403/401 | Fall back to `gh pr comment` |
+| All inline comments invalid | Post body-only review (inline findings moved to body) |
+| Review API 403/401 | Fall back to PR issue comment |
 | `gh` CLI not found | Abort with install instructions |
 | PR not found or closed | Abort with clear error message |
 | No findings after filtering | Post body-only "no issues found" review |

--- a/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
+++ b/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
@@ -126,7 +126,7 @@ The script automates the complete retry and fallback chain:
 
 | Error | Recovery (handled by `post-review.sh`) |
 |-------|----------------------------------------|
-| Invalid inline comment (line not in diff) | Remove that comment, retry with remaining |
+| Invalid inline comment (not in diff) | Prune invalid comments, retry with remaining |
 | All inline comments invalid | Post body-only review (inline findings moved to body) |
 | Review API 403/401 | Fall back to PR issue comment |
 | `gh` CLI not found | Abort with install instructions |

--- a/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
+++ b/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
@@ -126,7 +126,7 @@ The script automates the complete retry and fallback chain:
 
 | Error | Recovery (handled by `post-review.sh`) |
 |-------|----------------------------------------|
-| Invalid inline comment (not in diff) | Prune invalid comments, retry with remaining |
+| Invalid inline comment (file not in PR diff) | Prune comments on untouched files, retry with remaining |
 | All inline comments invalid | Post body-only review (inline findings moved to body) |
 | Review API 403/401 | Fall back to PR issue comment |
 | `gh` CLI not found | Abort with install instructions |

--- a/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
+++ b/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
@@ -81,7 +81,7 @@ No actionable issues found. Reviewed <N> files across <M> changed lines.
 
 ## 4. Construct the JSON Payload
 
-Write the review payload as a structured JSON file (e.g. `/tmp/ci-review-payload.json`):
+Write the review payload as a structured JSON file (e.g. `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`):
 
 ```json
 {
@@ -111,7 +111,7 @@ If there are no inline comments (or zero findings), set `"comments": []`:
 Posting is performed deterministically by `scripts/post-review.sh`:
 
 ```bash
-sh plugins/ci-review/scripts/post-review.sh <PR#> /tmp/ci-review-payload.json
+sh plugins/ci-review/scripts/post-review.sh <PR#> "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
 ```
 
 The script automates the complete retry and fallback chain:

--- a/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
+++ b/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
@@ -108,7 +108,7 @@ If there are no inline comments (or zero findings), set `"comments": []`:
 
 ## 5. Deterministic Posting via `post-review.sh`
 
-Posting is performed deterministically by `scripts/post-review.sh`:
+Posting is performed deterministically by `plugins/ci-review/scripts/post-review.sh`:
 
 ```bash
 sh plugins/ci-review/scripts/post-review.sh <PR#> "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"

--- a/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
+++ b/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
@@ -117,7 +117,7 @@ sh plugins/ci-review/scripts/post-review.sh <PR#> "${TMPDIR:-/tmp}/ci-review-pay
 The script automates the complete retry and fallback chain:
 
 1. **Primary Attempt**: Submits review via `gh api repos/<owner>/<repo>/pulls/<PR#>/reviews` with event `"COMMENT"`.
-2. **Retry 1 (Invalid comments)**: If the API rejects comments not in the diff, removes invalid comments and retries.
+2. **Retry 1 (Invalid comments)**: If the API rejects inline comments, prunes comments targeting files not in the PR diff and retries submission before falling back to body-only review.
 3. **Retry 2 (Body-only review)**: If inline comments still fail, moves inline comments to the review body and submits a body-only review (`POST .../reviews`).
 4. **Retry 3 (PR Comment fallback)**: If the reviews API fails (403, 401, permissions), falls back to `gh api repos/<owner>/<repo>/issues/<PR#>/comments` (or `gh pr comment`).
 5. **Verification**: Verifies that a valid URL was returned by GitHub, outputs `Review posted: <URL>`, and exits 0.


### PR DESCRIPTION
## Summary

Resolves #255 by replacing prompt-driven GitHub review posting with a deterministic shell script (`plugins/ci-review/scripts/post-review.sh`) and updating Step 6/7 of the `ci-review` skill.

### Background

On zero-findings / clean runs, prompt-level instructions to post a body-only review were repeatedly skipped by the model across consecutive CI runs (issue #255). While posting worked when findings were present, clean runs completed the session without submitting a review, violating the mandatory review postcontract.

### Changes

1. **`plugins/ci-review/scripts/post-review.sh`**:
   - Accepts PR number, payload JSON file (or stdin), and optional repository coordinates.
   - Parses review body and inline comments from structured JSON payload (handles empty/missing body with fallback "No actionable issues found" template).
   - Executes full retry and error-handling chain:
     - Primary POST to `repos/<owner>/<repo>/pulls/<PR#>/reviews` with event `"COMMENT"`.
     - Prunes invalid inline comments on 422 errors and retries.
     - Falls back to body-only review (`POST .../reviews` with inline comments appended to body).
     - Falls back to PR conversation issue comment (`POST .../issues/<PR#>/comments`).
   - Verifies valid HTML URL from GitHub and outputs `Review posted: <URL>` with exit code 0, or fails closed with exit code 1.

2. **`plugins/ci-review/skills/ci-review/SKILL.md`**:
   - Updated Step 6 to write the review payload JSON to `/tmp/ci-review-payload.json` (always including `"comments": []` when clean).
   - Rewrote Step 7 to execute `post-review.sh` deterministically in a single timing-measured invocation, eliminating superseded manual prompt-gate retry orchestration.
   - Updated inlined review posting rules and Timing Logs guidance.

3. **`plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md`**:
   - Documented structured JSON payload format and `post-review.sh` automated retry/fallback flow.

### Verification

- Validated plugins with `bun run validate` (marketplace schema, source paths, SKILL.md frontmatter all passing).
- Tested `post-review.sh` across all edge cases (zero findings, empty JSON, summary-only payload, inline comments payload, PR in JSON, missing file error handling, invalid JSON error handling).
- Self-verifying in CI: repository marketplace (`./`) ensures this PR is reviewed by its own updated `ci-review` plugin.

Closes #255.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull request review posting with summaries and inline comments.
  * Clean reviews can be submitted with an explicit empty comments list.
  * Successful submissions provide a direct link to the posted review.
  * Added checks to ensure a review is posted before completion.

* **Bug Fixes**
  * Added retries, comment filtering, and fallback posting when inline reviews fail.
  * Improved validation, authentication checks, and error reporting.

* **Documentation**
  * Updated review-posting guidance for automated submission and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->