### PR TITLE
fix(dlc): strip @-mentions from update-review-checklist worked examples and PR body

### DIFF
--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -320,12 +320,16 @@ git -c commit.gpgsign=false commit -m "chore(dlc): update review checklist (look
 git push -u origin "$BRANCH"
 ```
 
-Build the PR body per the template in [`references/checklist-schema.md`](references/checklist-schema.md). Include:
+Build the PR body per the template in [`references/checklist-schema.md`](references/checklist-schema.md).
+
+> **No GitHub mentions in posted PR body:** Any text this skill posts to GitHub — including the "Derived from" table, "Pending human review" section, and summary prose — MUST NOT contain an `@`-prefixed username or bot name. Write bare logins/names (e.g. `ana`, `ben`, `copilot`) without `@` prefixes to avoid triggering unintended mention notifications or bot actions. If quoting reviewer comments or technical content containing an `@` character (such as scoped packages or decorators), insert a space immediately after the `@` (e.g. `@ name`).
+
+Include:
 
 - A one-line summary of `ENTRIES_ADDED`
-- A **"Derived from"** table listing each new entry and the PRs it was clustered from (acceptance criterion #4)
+- A **"Derived from"** table listing each new entry and the PRs it was clustered from (acceptance criterion #4) — cite source PRs and bare reviewer names, never `@`-prefixed logins
 - The lookback window and threshold used
-- If `PENDING_HUMAN` is non-empty, a separate **"Pending human review"** section listing the held-back themes with their `source_prs` and `reason` — informational, so reviewers know these clusters were observed but not promoted
+- If `PENDING_HUMAN` is non-empty, a separate **"Pending human review"** section listing the held-back themes with their `source_prs` and `reason` — informational, so reviewers know these clusters were observed but not promoted (no `@`-mentions)
 - A "How this was generated" footer pointing at this skill
 
 ```bash

--- a/plugins/dlc/skills/update-review-checklist/SKILL.md
+++ b/plugins/dlc/skills/update-review-checklist/SKILL.md
@@ -327,12 +327,17 @@ Build the PR body per the template in [`references/checklist-schema.md`](referen
 Include:
 
 - A one-line summary of `ENTRIES_ADDED`
-- A **"Derived from"** table listing each new entry and the PRs it was clustered from (acceptance criterion #4) — cite source PRs and bare reviewer names, never `@`-prefixed logins
+- A **"Derived from"** table listing each new entry and the PRs it was clustered from (acceptance criterion #4)
 - The lookback window and threshold used
 - If `PENDING_HUMAN` is non-empty, a separate **"Pending human review"** section listing the held-back themes with their `source_prs` and `reason` — informational, so reviewers know these clusters were observed but not promoted (no `@`-mentions)
 - A "How this was generated" footer pointing at this skill
 
 ```bash
+if grep -qE '@[[:alnum:]_-]' "$WORKDIR/.pr-body.md"; then
+  echo "ERROR: PR body contains unneutralized @-mentions. Refusing to post." >&2
+  exit 1
+fi
+
 gh pr create \
   --repo "$REPO" \
   --title "chore(dlc): update review checklist (lookback $LOOKBACK)" \

--- a/plugins/dlc/skills/update-review-checklist/references/checklist-schema.md
+++ b/plugins/dlc/skills/update-review-checklist/references/checklist-schema.md
@@ -70,8 +70,9 @@ When in genuine doubt after all three questions, **keep** the candidate. The cos
 
 ## PR Body Structure (Step 7)
 
-The PR body the skill opens has this skeleton:
+> **No GitHub mentions in PR body:** Never use `@`-prefixed reviewer or bot names in the PR body, "Derived from" table, or "Pending human review" section — use bare names (e.g. `ana`, `ben`, `copilot`) to avoid triggering notifications or bot actions. For technical tokens containing `@` (e.g. scoped packages, decorators), insert a space after the `@`.
 
+The PR body the skill opens has this skeleton:
 ```markdown
 ## Summary
 

--- a/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
+++ b/plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md
@@ -78,9 +78,9 @@ Ambiguous clusters are not failures of the rubric — they are real cases where 
 **Good cluster** (3 PRs, weight 6):
 - Theme: "Form submissions disable the submit button while pending"
 - Members:
-  - PR #210, reviewer @ana, "this button stays active during submit — should be disabled"
-  - PR #214, reviewer @ben, severity:medium, "missing pending state on the submit button, double-submit possible"
-  - PR #221, reviewer @ana, "same issue as #210 — disable while loading"
+  - PR #210, reviewer ana, "this button stays active during submit — should be disabled"
+  - PR #214, reviewer ben, severity:medium, "missing pending state on the submit button, double-submit possible"
+  - PR #221, reviewer ana, "same issue as #210 — disable while loading"
 
 **Bad cluster** (overcoarse):
 - Theme: "Improve error handling"


### PR DESCRIPTION
## Summary

Fixes #242 by removing `@`-prefixed reviewer logins from `clustering-rubric.md`'s worked examples and explicitly prohibiting `@`-mentions in `update-review-checklist/SKILL.md` and `references/checklist-schema.md` when authoring the PR body.

## Context

While fixing #173 (PR #244), reviewers surfaced an adjacent instance in `dlc:update-review-checklist` where worked examples in `clustering-rubric.md` used `@ana` and `@ben`. This idiom could lead the skill to emit live `@`-mentions when generating the "Derived from" table or "Pending human review" section in the PR body.

## Changes

- `plugins/dlc/skills/update-review-checklist/references/clustering-rubric.md`: replaced `@ana` and `@ben` with bare names (`ana`, `ben`) in the Good cluster worked example.
- `plugins/dlc/skills/update-review-checklist/SKILL.md`: added explicit no-mentions rule for the posted PR body and updated the "Derived from" table instruction to use bare names.
- `plugins/dlc/skills/update-review-checklist/references/checklist-schema.md`: added a no-mentions rule to the PR body structure section.

## Verification

- Ran `bun run validate` — all marketplace and skill schema checks passed cleanly.
- Verified diff against acceptance criteria.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request checklist guidance to prohibit unintended GitHub mentions in generated and quoted content.
  * Added validation to detect unneutralized mentions before a pull request is created.
  * Clarified acceptable technical `@` tokens and updated examples to display names without `@` prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->