### PR TITLE
feat(ci-review): add Copilot-style verdict headings and sentinel verification

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -119,9 +119,9 @@ jobs:
             # a gh or jq failure nonzero so the caller can distinguish transport
             # errors from a verified zero.
             posted=$(gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" \
-              | jq --arg started "$STARTED" '[.[][] | select(.user.login == "github-actions[bot]" and .submitted_at > $started and ((.body // "") | startswith("## CI Review")))] | length') || return 2
+              | jq --arg started "$STARTED" '[.[][] | select(.user.login == "github-actions[bot]" and .submitted_at > $started and ((.body // "") | startswith("<!-- ci-review -->")))] | length') || return 2
             comments=$(gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/issues/$PR/comments" \
-              | jq --arg started "$STARTED" '[.[][] | select(.user.login == "github-actions[bot]" and .created_at > $started and ((.body // "") | startswith("## CI Review")))] | length') || return 2
+              | jq --arg started "$STARTED" '[.[][] | select(.user.login == "github-actions[bot]" and .created_at > $started and ((.body // "") | startswith("<!-- ci-review -->")))] | length') || return 2
             echo $((posted + comments))
           }
           API_FAILS=0

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -103,7 +103,6 @@ jobs:
           # builds review URLs from shell variables, which prefix patterns cannot match
           claude_args: >-
             --allowedTools "Read,Grep,Glob,Agent,Bash(gh auth status:*),Bash(gh pr:*),Bash(gh repo view:*),Bash(gh api:*),Bash(sh:*),Bash(git branch:*),Bash(git rev-parse:*),Bash(git blame:*),Bash(jq:*),Bash(echo:*),Bash(cat:*),Bash(date:*)"
-          show_full_output: true
 
       - name: Verify review posted
         env:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -103,6 +103,7 @@ jobs:
           # builds review URLs from shell variables, which prefix patterns cannot match
           claude_args: >-
             --allowedTools "Read,Grep,Glob,Agent,Bash(gh auth status:*),Bash(gh pr:*),Bash(gh repo view:*),Bash(gh api:*),Bash(sh:*),Bash(git branch:*),Bash(git rev-parse:*),Bash(git blame:*),Bash(jq:*),Bash(echo:*),Bash(cat:*),Bash(date:*)"
+          show_full_output: true
 
       - name: Verify review posted
         env:

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -147,11 +147,15 @@ fi
 # Extract or construct review body
 jq -r '
   ( if .body and (.body | type == "string") and (.body | length > 0) then
-      .body
+      if (.body | startswith("## CI Review\n\n")) then
+        "### ✅ Approval recommended\n\n" + (.body | sub("^## CI Review\n\n"; ""))
+      else
+        .body
+      end
     elif .summary and (.summary | type == "string") then
-      "## CI Review\n\n" + .summary
+      "### ✅ Approval recommended\n\n" + .summary
     else
-      "## CI Review\n\nNo actionable issues found."
+      "### ✅ Approval recommended\n\nNo actionable issues found."
     end ) as $b
   | if $b | startswith("<!-- ci-review -->") then $b else "<!-- ci-review -->\n" + $b end
 ' "$RAW_PAYLOAD_FILE" > "$_tmpdir/body.md"

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -153,7 +153,11 @@ jq -r '
     else
       "## CI Review\n\nNo actionable issues found."
     end ) as $b
-  | if $b | startswith("<!-- ci-review -->") then $b else "<!-- ci-review -->\n" + $b end
+  | if ($b | test("^[ \t\r\n]*<!-- ci-review -->")) then
+      ($b | sub("^[ \t\r\n]*"; ""))
+    else
+      "<!-- ci-review -->\n" + ($b | sub("^[ \t\r\n]*"; ""))
+    end
 ' "$RAW_PAYLOAD_FILE" > "$_tmpdir/body.md"
 
 # Extract comments array (ensuring valid structure and safe line parsing)

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -154,12 +154,10 @@ jq -r '
       "## CI Review"
     else
       "## CI Review\n\nNo actionable issues found."
-    end ) as $b
-  | if ($b | test("^[ \t\r\n]*<!-- ci-review -->")) then
-      ($b | sub("^[ \t\r\n]*"; ""))
-    else
-      "<!-- ci-review -->\n" + ($b | sub("^[ \t\r\n]*"; ""))
-    end
+    end )
+  | sub("^[ \t\r\n]*<!-- ci-review -->[ \t]*\n*"; "")
+  | sub("^[ \t\r\n]*"; "")
+  | "<!-- ci-review -->\n" + .
 ' "$RAW_PAYLOAD_FILE" > "$_tmpdir/body.md"
 
 # Extract comments array (ensuring valid structure and safe line parsing)

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -150,6 +150,8 @@ jq -r '
       .body
     elif .summary and (.summary | type == "string") then
       "## CI Review\n\n" + .summary
+    elif .comments and (.comments | type == "array") and (.comments | length > 0) then
+      "## CI Review"
     else
       "## CI Review\n\nNo actionable issues found."
     end ) as $b

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -147,15 +147,11 @@ fi
 # Extract or construct review body
 jq -r '
   ( if .body and (.body | type == "string") and (.body | length > 0) then
-      if (.body | startswith("## CI Review\n\n")) then
-        "### ✅ Approval recommended\n\n" + (.body | sub("^## CI Review\n\n"; ""))
-      else
-        .body
-      end
+      .body
     elif .summary and (.summary | type == "string") then
-      "### ✅ Approval recommended\n\n" + .summary
+      "## CI Review\n\n" + .summary
     else
-      "### ✅ Approval recommended\n\nNo actionable issues found."
+      "## CI Review\n\nNo actionable issues found."
     end ) as $b
   | if $b | startswith("<!-- ci-review -->") then $b else "<!-- ci-review -->\n" + $b end
 ' "$RAW_PAYLOAD_FILE" > "$_tmpdir/body.md"

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -149,7 +149,7 @@ jq -r '
   ( if .body and (.body | type == "string") and (.body | test("[^ \t\r\n]")) then
       .body
     elif .summary and (.summary | type == "string") and (.summary | test("[^ \t\r\n]")) then
-      "## CI Review\n\n" + .summary
+      .summary
     elif .comments and (.comments | type == "array") and (.comments | length > 0) then
       "## CI Review"
     else

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -146,9 +146,9 @@ fi
 
 # Extract or construct review body
 jq -r '
-  ( if .body and (.body | type == "string") and (.body | length > 0) then
+  ( if .body and (.body | type == "string") and (.body | test("[^ \t\r\n]")) then
       .body
-    elif .summary and (.summary | type == "string") then
+    elif .summary and (.summary | type == "string") and (.summary | test("[^ \t\r\n]")) then
       "## CI Review\n\n" + .summary
     elif .comments and (.comments | type == "array") and (.comments | length > 0) then
       "## CI Review"

--- a/plugins/ci-review/scripts/post-review.sh
+++ b/plugins/ci-review/scripts/post-review.sh
@@ -5,7 +5,7 @@
 #
 # Accepts a JSON payload containing:
 #   {
-#     "body": "## CI Review\n...",
+#     "body": "<!-- ci-review -->\n### ⚠️ Changes recommended\n...",
 #     "comments": [
 #       { "path": "src/foo.ts", "line": 10, "side": "RIGHT", "body": "..." }
 #     ]
@@ -146,13 +146,14 @@ fi
 
 # Extract or construct review body
 jq -r '
-  if .body and (.body | type == "string") and (.body | length > 0) then
-    .body
-  elif .summary and (.summary | type == "string") then
-    "## CI Review\n\n" + .summary
-  else
-    "## CI Review\n\nNo actionable issues found."
-  end
+  ( if .body and (.body | type == "string") and (.body | length > 0) then
+      .body
+    elif .summary and (.summary | type == "string") then
+      "## CI Review\n\n" + .summary
+    else
+      "## CI Review\n\nNo actionable issues found."
+    end ) as $b
+  | if $b | startswith("<!-- ci-review -->") then $b else "<!-- ci-review -->\n" + $b end
 ' "$RAW_PAYLOAD_FILE" > "$_tmpdir/body.md"
 
 # Extract comments array (ensuring valid structure and safe line parsing)

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -403,53 +403,53 @@ date +%s   # remember this epoch for the phase-end call
 You MUST execute the `Bash` tool to construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
 
 - **For clean runs with zero findings (VERDICT_COUNTS empty / no findings surviving confidence & severity filters)**, substitute the actual values into `<PR#>`, `<N>` (files), `<M>` (lines), and `<profile>`, and execute this Bash command:
-  ```bash
-  cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
-  <!-- ci-review -->
-  ### ✅ Approval recommended
+```bash
+cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
+<!-- ci-review -->
+### ✅ Approval recommended
 
-  No actionable issues found. Reviewed <N> files across <M> changed lines.
+No actionable issues found. Reviewed <N> files across <M> changed lines.
 
-  **CI Review** · **Profile**: <profile>
-  EOF
+**CI Review** · **Profile**: <profile>
+EOF
 
-  cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json"
-  []
-  EOF
+cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json"
+[]
+EOF
 
-  jq -n \
-    --rawfile body "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md" \
-    --slurpfile comments "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json" \
-    '{body: $body, comments: ($comments[0] // [])}' \
-    > "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
+jq -n \
+  --rawfile body "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md" \
+  --slurpfile comments "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json" \
+  '{body: $body, comments: ($comments[0] // [])}' \
+  > "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
 
-  echo "[ci-review] Step 6 done elapsed=$(( $(date +%s) - <STEP6_START_EPOCH> ))s"
-  echo "::endgroup::"
-  ```
+echo "[ci-review] Step 6 done elapsed=$(( $(date +%s) - <STEP6_START_EPOCH> ))s"
+echo "::endgroup::"
+```
 
 - **For runs with findings (VERDICT_COUNTS > 0)**:
   1. **Determine inline eligibility**: Check if each surviving finding (after dedup) appears in the PR diff and its `line` is in a changed hunk. If yes → inline comment. If no → body-only finding.
   2. **Build payload**:
      - **If all findings were excluded by dedup (posted findings == 0)**: construct `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md` per [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 edge case using the severity-derived verdict heading and the all-deduplicated verdict paragraph (`All <N> findings were already flagged in existing comments — nothing new posted.`), and set `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json` to `[]`.
      - **Otherwise (posted findings > 0)**: build inline comment objects in `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json` and review body per [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 — first line `<!-- ci-review -->`, then the verdict heading and verdict paragraph — in `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md`. Then encode with `jq`:
-     ```bash
-     cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
-     <REVIEW_BODY>
-     EOF
+```bash
+cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
+<REVIEW_BODY>
+EOF
 
-     cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json"
-     [ ...inline comments... ]
-     EOF
+cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json"
+[ ...inline comments... ]
+EOF
 
-     jq -n \
-       --rawfile body "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md" \
-       --slurpfile comments "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json" \
-       '{body: $body, comments: ($comments[0] // [])}' \
-       > "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
+jq -n \
+  --rawfile body "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md" \
+  --slurpfile comments "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json" \
+  '{body: $body, comments: ($comments[0] // [])}' \
+  > "${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json"
 
-     echo "[ci-review] Step 6 done elapsed=$(( $(date +%s) - <STEP6_START_EPOCH> ))s"
-     echo "::endgroup::"
-     ```
+echo "[ci-review] Step 6 done elapsed=$(( $(date +%s) - <STEP6_START_EPOCH> ))s"
+echo "::endgroup::"
+```
 
 ### Step 7: Post Review
 

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -402,7 +402,7 @@ date +%s   # remember this epoch for the phase-end call
 
 You MUST execute the `Bash` tool to construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
 
-- **For clean runs with zero findings (VERDICT_COUNTS empty / no findings surviving confidence & severity filters)**, substitute the actual values into `<PR#>`, `<N>` (files), `<M>` (lines), and `<profile>`, and execute this Bash command:
+- **For clean runs with zero findings (total findings surviving confidence & severity filters == 0 / all counts in `VERDICT_COUNTS` are 0)**, substitute the actual values into `<PR#>`, `<N>` (files), `<M>` (lines), and `<profile>`, and execute this Bash command:
 ```bash
 cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
 <!-- ci-review -->
@@ -427,7 +427,7 @@ echo "[ci-review] Step 6 done elapsed=$(( $(date +%s) - <STEP6_START_EPOCH> ))s"
 echo "::endgroup::"
 ```
 
-- **For runs with findings (VERDICT_COUNTS > 0)**:
+- **For runs with findings (total findings surviving confidence & severity filters > 0 / at least one severity count in `VERDICT_COUNTS` > 0)**:
   1. **Determine inline eligibility**: Check if each surviving finding (after dedup) appears in the PR diff and its `line` is in a changed hunk. If yes → inline comment. If no → body-only finding.
   2. **Build payload files and encode**:
      - **If all findings were excluded by dedup (posted findings == 0)**: write `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md` per [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 edge case using the severity-derived verdict heading and the all-deduplicated verdict paragraph (`All <N> findings were already flagged in existing comments — nothing new posted.`), and write `[]` to `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json`.

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -429,9 +429,10 @@ echo "::endgroup::"
 
 - **For runs with findings (VERDICT_COUNTS > 0)**:
   1. **Determine inline eligibility**: Check if each surviving finding (after dedup) appears in the PR diff and its `line` is in a changed hunk. If yes → inline comment. If no → body-only finding.
-  2. **Build payload**:
-     - **If all findings were excluded by dedup (posted findings == 0)**: construct `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md` per [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 edge case using the severity-derived verdict heading and the all-deduplicated verdict paragraph (`All <N> findings were already flagged in existing comments — nothing new posted.`), and set `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json` to `[]`.
-     - **Otherwise (posted findings > 0)**: build inline comment objects in `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json` and review body per [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 — first line `<!-- ci-review -->`, then the verdict heading and verdict paragraph — in `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md`. Then encode with `jq`:
+  2. **Build payload files and encode**:
+     - **If all findings were excluded by dedup (posted findings == 0)**: write `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md` per [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 edge case using the severity-derived verdict heading and the all-deduplicated verdict paragraph (`All <N> findings were already flagged in existing comments — nothing new posted.`), and write `[]` to `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json`.
+     - **Otherwise (posted findings > 0)**: write inline comment objects to `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json` and review body per [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 — first line `<!-- ci-review -->`, then the verdict heading and verdict paragraph — to `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md`.
+     - **Encode with jq** (required for both cases above before Step 7):
 ```bash
 cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
 <REVIEW_BODY>

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -399,6 +399,7 @@ date +%s   # remember this epoch for the phase-end call
 | ≥1 `high` | `### ⚠️ Changes recommended` |
 | ≥1 `medium` or `low` | `### 👀 Needs a closer look` |
 | none | `### ✅ Approval recommended` |
+
 You MUST execute the `Bash` tool to construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
 
 - **For clean runs with zero findings (findings == 0)**, substitute the actual values into `<PR#>`, `<N>` (files), `<M>` (lines), and `<profile>`, and execute this Bash command:

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -402,7 +402,7 @@ date +%s   # remember this epoch for the phase-end call
 
 You MUST execute the `Bash` tool to construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
 
-- **For clean runs with zero findings (findings == 0)**, substitute the actual values into `<PR#>`, `<N>` (files), `<M>` (lines), and `<profile>`, and execute this Bash command:
+- **For clean runs with zero findings (VERDICT_COUNTS empty / no findings surviving confidence & severity filters)**, substitute the actual values into `<PR#>`, `<N>` (files), `<M>` (lines), and `<profile>`, and execute this Bash command:
   ```bash
   cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
   <!-- ci-review -->
@@ -427,9 +427,11 @@ You MUST execute the `Bash` tool to construct the payload file `${TMPDIR:-/tmp}/
   echo "::endgroup::"
   ```
 
-- **For runs with surviving findings (findings > 0)**:
-  1. **Determine inline eligibility**: Check if the finding's `file` appears in the PR diff and the `line` is in a changed hunk. If yes → inline comment. If no → body-only finding.
-  2. **Build inline comment objects** in `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json` and review body per [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 — first line `<!-- ci-review -->`, then the verdict heading and verdict paragraph — in `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md`, then encode with `jq`:
+- **For runs with findings (VERDICT_COUNTS > 0)**:
+  1. **Determine inline eligibility**: Check if each surviving finding (after dedup) appears in the PR diff and its `line` is in a changed hunk. If yes → inline comment. If no → body-only finding.
+  2. **Build payload**:
+     - **If all findings were excluded by dedup (posted findings == 0)**: construct `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md` per [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 edge case using the severity-derived verdict heading and the all-deduplicated verdict paragraph (`All <N> findings were already flagged in existing comments — nothing new posted.`), and set `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json` to `[]`.
+     - **Otherwise (posted findings > 0)**: build inline comment objects in `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json` and review body per [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 — first line `<!-- ci-review -->`, then the verdict heading and verdict paragraph — in `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md`. Then encode with `jq`:
      ```bash
      cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
      <REVIEW_BODY>

--- a/plugins/ci-review/skills/ci-review/SKILL.md
+++ b/plugins/ci-review/skills/ci-review/SKILL.md
@@ -65,7 +65,7 @@ These rules are critical. They are also detailed in REVIEW-POSTING.md but inline
 - Only post **actionable** inline comments — no confirmations, no "looks good"
 - Do not repeat correctly addressed items
 - If no inline comments, write `"comments": []` in the Step 6 payload file
-- **Always post — even with zero findings.** A clean review still requires a body-only review using the exact "No Findings" template from [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 (`## CI Review` header, "No actionable issues found. Reviewed N files across M changed lines.", profile).
+- **Always post — even with zero findings.** A clean review still requires a body-only review using the exact "No Findings" template from [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 (first line `<!-- ci-review -->`, `### ✅ Approval recommended` heading, "No actionable issues found. Reviewed N files across M changed lines.", profile).
 - **Posting is deterministic via `post-review.sh`**: Step 6 writes `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`, and Step 7 executes `post-review.sh` to handle payload submission, retry logic, and fallback posting automatically. Never skip Step 7.
 ## Timing Logs
 
@@ -353,6 +353,8 @@ A single generic signal (severity tag alone or type keyword alone) is NOT suffic
 - String matching is case-insensitive
 
 Track the count of findings excluded by this pass as `EXISTING_DEDUP_COUNT`.
+
+Record the severity counts of findings that survived the confidence + severity filters **before** this dedup pass as `VERDICT_COUNTS` — Step 6 derives the review verdict from them, so dedup-suppressed findings still influence the verdict.
 After all scorers have returned and filtering/deduplication is complete, emit the Step-5 phase-end marker:
 
 ```bash
@@ -388,16 +390,26 @@ date +%s   # remember this epoch for the phase-end call
 | comment-analyzer | comment-accuracy |
 | type-analyzer | type-design |
 
+
+**Determine the verdict.** Derive the review verdict from `VERDICT_COUNTS` (post-confidence, post-severity-filter findings before dedup):
+
+| Condition (on `VERDICT_COUNTS`) | Verdict heading |
+|---|---|
+| ≥1 `critical` | `### 🚨 Blocker found` |
+| ≥1 `high` | `### ⚠️ Changes recommended` |
+| ≥1 `medium` or `low` | `### 👀 Needs a closer look` |
+| none | `### ✅ Approval recommended` |
 You MUST execute the `Bash` tool to construct the payload file `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`:
 
 - **For clean runs with zero findings (findings == 0)**, substitute the actual values into `<PR#>`, `<N>` (files), `<M>` (lines), and `<profile>`, and execute this Bash command:
   ```bash
   cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
-  ## CI Review
+  <!-- ci-review -->
+  ### ✅ Approval recommended
 
   No actionable issues found. Reviewed <N> files across <M> changed lines.
 
-  **Profile**: <profile>
+  **CI Review** · **Profile**: <profile>
   EOF
 
   cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json"
@@ -416,7 +428,7 @@ You MUST execute the `Bash` tool to construct the payload file `${TMPDIR:-/tmp}/
 
 - **For runs with surviving findings (findings > 0)**:
   1. **Determine inline eligibility**: Check if the finding's `file` appears in the PR diff and the `line` is in a changed hunk. If yes → inline comment. If no → body-only finding.
-  2. **Build inline comment objects** in `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json` and review body in `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md`, then encode with `jq`:
+  2. **Build inline comment objects** in `${TMPDIR:-/tmp}/ci-review-comments-<PR#>.json` and review body per [REVIEW-POSTING.md](references/REVIEW-POSTING.md) §3 — first line `<!-- ci-review -->`, then the verdict heading and verdict paragraph — in `${TMPDIR:-/tmp}/ci-review-body-<PR#>.md`, then encode with `jq`:
      ```bash
      cat << 'EOF' > "${TMPDIR:-/tmp}/ci-review-body-<PR#>.md"
      <REVIEW_BODY>
@@ -470,6 +482,7 @@ Print the summary for the CI log:
 ```
 CI Review complete for PR #N
 Profile: single|lean|full|agent
+Verdict: <emoji> <text>
 Agents: N launched, N completed [, N failed]
 Raw findings: N collected
 After confidence scoring (≥65): N survived

--- a/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
+++ b/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
@@ -49,16 +49,26 @@ Where:
 
 The review body is the summary posted at the top of the review.
 
+### Verdict Model
+
+The verdict is computed from findings that survive the **confidence filter (≥65) and severity filter**, i.e. **before** the existing-comment dedup pass. Dedup only suppresses duplicate comment posting; the verdict reflects the PR's actual state:
+
+| Condition (on post-filter findings) | Verdict heading |
+|---|---|
+| ≥1 `critical` | `### 🚨 Blocker found` |
+| ≥1 `high` | `### ⚠️ Changes recommended` |
+| ≥1 `medium` or `low` | `### 👀 Needs a closer look` |
+| none | `### ✅ Approval recommended` |
+
 ### With Findings
 
 ```markdown
-## CI Review
+<!-- ci-review -->
+### <verdict emoji> <verdict text>
 
-**Profile**: <single|lean|full|agent> | **Findings**: <total> (<N> critical, <N> high, <N> medium, <N> low)
+<1–2 sentence verdict paragraph: name the most important finding(s) and why they matter — not a generic "issues were found">
 
-### Summary
-
-<2-3 sentence overview of the review — what was checked, key themes>
+**CI Review** · **Profile**: <single|lean|full|agent> | **Findings**: <total> (<N> critical, <N> high, <N> medium, <N> low)<if EXISTING_DEDUP_COUNT > 0: append " | **Already flagged**: <EXISTING_DEDUP_COUNT> (not re-posted)">
 
 ### Findings Not in Diff
 
@@ -69,14 +79,19 @@ The review body is the summary posted at the top of the review.
   - `Found by: <agent-name>`
 ```
 
+*Note:* The `### Findings Not in Diff` section is omitted when there are no body-only findings.
+
+*Edge case (all findings already commented):* When all surviving findings are excluded by existing-comment dedup (posted findings == 0 but verdict ≠ ✅), keep the severity-derived verdict, set `"comments": []`, and use this verdict paragraph: `All <N> findings were already flagged in existing comments — nothing new posted.` (with no `### Findings Not in Diff` section).
+
 ### No Findings
 
 ```markdown
-## CI Review
+<!-- ci-review -->
+### ✅ Approval recommended
 
 No actionable issues found. Reviewed <N> files across <M> changed lines.
 
-**Profile**: <single|lean|full|agent>
+**CI Review** · **Profile**: <single|lean|full|agent>
 ```
 
 ## 4. Construct the JSON Payload
@@ -84,8 +99,7 @@ No actionable issues found. Reviewed <N> files across <M> changed lines.
 Write the review payload as a structured JSON file (e.g. `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`):
 
 ```json
-{
-  "body": "## CI Review\n\n**Profile**: lean | **Findings**: 2 (0 critical, 1 high, 1 medium, 0 low)\n\n### Summary\n...",
+  "body": "<!-- ci-review -->\n### ⚠️ Changes recommended\n\nPotential SQL injection in user query handler.\n\n**CI Review** · **Profile**: lean | **Findings**: 2 (0 critical, 1 high, 1 medium, 0 low)\n...",
   "comments": [
     {
       "path": "src/api.ts",
@@ -101,7 +115,7 @@ If there are no inline comments (or zero findings), set `"comments": []`:
 
 ```json
 {
-  "body": "## CI Review\n\nNo actionable issues found. Reviewed 3 files across 45 changed lines.\n\n**Profile**: lean",
+  "body": "<!-- ci-review -->\n### ✅ Approval recommended\n\nNo actionable issues found. Reviewed 3 files across 45 changed lines.\n\n**CI Review** · **Profile**: lean",
   "comments": []
 }
 ```

--- a/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
+++ b/plugins/ci-review/skills/ci-review/references/REVIEW-POSTING.md
@@ -99,6 +99,7 @@ No actionable issues found. Reviewed <N> files across <M> changed lines.
 Write the review payload as a structured JSON file (e.g. `${TMPDIR:-/tmp}/ci-review-payload-<PR#>.json`):
 
 ```json
+{
   "body": "<!-- ci-review -->\n### ⚠️ Changes recommended\n\nPotential SQL injection in user query handler.\n\n**CI Review** · **Profile**: lean | **Findings**: 2 (0 critical, 1 high, 1 medium, 0 low)\n...",
   "comments": [
     {


### PR DESCRIPTION
### Summary
- Add Copilot-style verdict headings (`### 🚨 Blocker found`, `### ⚠️ Changes recommended`, `### 👀 Needs a closer look`, `### ✅ Approval recommended`) based on pre-dedup severity counts.
- Add `<!-- ci-review -->` HTML sentinel on line 1 for deterministic machine verification.
- Update `post-review.sh` body normalization to guarantee sentinel injection.
- Update workflow verification in `.github/workflows/claude-code-review.yml` to check for sentinel marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standardized CI review format with a hidden marker, verdict heading, summary, and review metadata.
  * Review verdicts now reflect the highest-severity detected finding, including cases where duplicate findings are suppressed.
  * Added clearer handling for reviews with no findings or findings excluded as duplicates.

* **Bug Fixes**
  * Improved verification so posted CI reviews are reliably recognized.
  * Improved handling of empty or whitespace-only review content.

* **Documentation**
  * Updated CI review guidance, templates, payload examples, and edge-case handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->