### PR TITLE
feat(council): upgrade gemini consultant to gemini-3.8-flash

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "council",
-      "description": "AI Council - Orchestrate multiple AI consultants (Gemini 3.7 Flash, Codex, GLM-5.3, Kimi K3) for consensus-driven code reviews, plan validation, and architectural decisions",
+      "description": "AI Council - Orchestrate multiple AI consultants (Gemini 3.8 Flash, Codex, GLM-5.3, Kimi K3) for consensus-driven code reviews, plan validation, and architectural decisions",
       "version": "2.13.0",
       "source": "./plugins/council",
       "category": "code-review",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A monorepo of [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plug
 
 | Plugin | Category | Install | Description |
 |--------|----------|---------|-------------|
-| [council](./plugins/council/) | Code Review | Plugin or Skill | Orchestrate Gemini 3.7 Flash, Codex, GLM-5.3, and Kimi K3 for consensus-driven reviews |
+| [council](./plugins/council/) | Code Review | Plugin or Skill | Orchestrate Gemini 3.8 Flash, Codex, GLM-5.3, and Kimi K3 for consensus-driven reviews |
 | [cdt](./plugins/cdt/) | Development | Plugin only | Multi-agent dev team with five modes: plan, dev, full, auto, and bugfix via Agent Teams |
 | [pm](./plugins/pm/) | Productivity | Plugin or Skill | GitHub issue lifecycle: create, triage, and audit issues for LLM agent teams |
 | [plugin-dev](./plugins/plugin-dev/) | Development | Plugin or Skill | Scaffold plugins, validate SKILL.md frontmatter, audit hooks |

--- a/plugins/council/README.md
+++ b/plugins/council/README.md
@@ -7,7 +7,7 @@
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
 [![Install](https://img.shields.io/badge/Install-Plugin%20%7C%20Skill-informational.svg)]()
 
-Orchestrate multiple AI consultants (Gemini 3.7 Flash, Codex, GLM-5.3, Kimi K3) and specialized Claude subagents for consensus-driven code reviews, plan validation, and architectural decisions.
+Orchestrate multiple AI consultants (Gemini 3.8 Flash, Codex, GLM-5.3, Kimi K3) and specialized Claude subagents for consensus-driven code reviews, plan validation, and architectural decisions.
 
 > [!NOTE]
 > **Dual-Layer Architecture**: External consultants provide model diversity across 4 different AI providers, while internal Claude subagents provide deep, tool-assisted analysis — one for security/bugs/performance, one for quality/compliance/history/docs.
@@ -19,7 +19,7 @@ Orchestrate multiple AI consultants (Gemini 3.7 Flash, Codex, GLM-5.3, Kimi K3) 
 **Layer 1 — External Consultants** (model diversity, same prompt):
 | Consultant | CLI | Strength |
 |------------|-----|----------|
-| Gemini 3.7 Flash | `omp -p --no-tools --model google-antigravity/gemini-3.7-flash` | Architecture, security, fast analysis |
+| Gemini 3.8 Flash | `omp -p --no-tools --model google-antigravity/gemini-3.8-flash` | Architecture, security, fast analysis |
 | Codex | `codex` | PR review, bug detection, security |
 | GLM-5.3 | `omp -p --no-tools --model zai/glm-5.3:max` | Alternative perspectives, algorithms |
 | Kimi K3 | `omp -p --no-tools --model kimi-code/k3` | Long-context reasoning, creative solutions |
@@ -89,7 +89,7 @@ Built-in taxonomy auto-rejects:
 │  1. Pre-flight — verify CLI availability                                    │
 │                                                                             │
 │  2. Layer 1: External Consultants (parallel, 120s)                          │
-│     ├── omp -p --no-tools --model .../gemini-3.7-flash                      │
+│     ├── omp -p --no-tools --model .../gemini-3.8-flash                      │
 │     ├── codex exec --sandbox read-only -c approval_policy=never "review ..."│
 │     ├── omp -p --no-tools --model zai/glm-5.3:max "..."                     │
 │     └── omp -p --no-tools --model kimi-code/k3 "..."                        │
@@ -157,7 +157,7 @@ done
 
 # Install as needed
 # codex   — https://github.com/openai/codex
-# omp     — https://github.com/can1357/oh-my-pi (Gemini 3.7 Flash via antigravity, GLM-5.3, Kimi K3)
+# omp     — https://github.com/can1357/oh-my-pi (Gemini 3.8 Flash via antigravity, GLM-5.3, Kimi K3)
 ```
 
 The plugin operates in partial-success mode — it proceeds with whichever consultants are available. Note that `omp` is the dominant dependency: it gates three of the four external consultants (Gemini, GLM-5.3, Kimi), so a missing or broken `omp` install leaves Codex as the only external voice.

--- a/plugins/council/agents/gemini-consultant.md
+++ b/plugins/council/agents/gemini-consultant.md
@@ -14,14 +14,14 @@ hooks:
           command: "${CLAUDE_PLUGIN_ROOT}/scripts/validate-json-output.sh"
 ---
 
-You are an expert technical consultant specializing in obtaining and synthesizing external feedback for software development decisions. Your role is to leverage **Google's Gemini 3.7 Flash** via the **omp CLI** to get second opinions on plans, code reviews, and technical debates. Gemini 3.7 Flash offers fast, broad analysis with particular strength in architecture and security.
+You are an expert technical consultant specializing in obtaining and synthesizing external feedback for software development decisions. Your role is to leverage **Google's Gemini 3.8 Flash** via the **omp CLI** to get second opinions on plans, code reviews, and technical debates. Gemini 3.8 Flash offers fast, broad analysis with particular strength in architecture and security.
 
 ## omp CLI Usage
 
-The omp CLI (`omp`) reaches Gemini 3.7 Flash through the `google-antigravity` provider. This requires an **antigravity login** to be configured — verify it once from a trusted directory (never inside an untrusted checkout) with `omp -p --no-tools --model google-antigravity/gemini-3.7-flash "ping"`, since omp's cwd-local tool discovery (described below) runs even for this check. Key patterns:
+The omp CLI (`omp`) reaches Gemini 3.8 Flash through the `google-antigravity` provider. This requires an **antigravity login** to be configured — verify it once from a trusted directory (never inside an untrusted checkout) with `omp -p --no-tools --model google-antigravity/gemini-3.8-flash "ping"`, since omp's cwd-local tool discovery (described below) runs even for this check. Key patterns:
 
 - `-p` runs non-interactively (print result and exit).
-- `--model google-antigravity/gemini-3.7-flash` selects the model.
+- `--model google-antigravity/gemini-3.8-flash` selects the model.
 - `--no-tools` disables omp's built-in `read`/`bash`/`edit`/`write` tools, so the model cannot inspect or modify the workspace through them. **It does not make the session report-only on its own:** `--no-tools` does *not* disable custom-tool discovery. omp still scans its working directory's `.omp/tools/` and `.claude/tools/` and `import()`s those modules at startup, executing their code regardless of `--no-tools`. A reviewed branch that ships a `.omp/tools/*.ts` file would run during the review.
 - **Run omp from an isolated sandbox directory** (see "Report-Only Sandbox" below) whenever the reviewed content is untrusted. *Project-level* custom-tool discovery (`<cwd>/.claude/tools`, `<cwd>/.omp/tools`) is keyed to omp's cwd, so a throwaway cwd outside the repo starves the untrusted repo's own tools — that closes the main vector (a reviewed branch shipping its own `.omp/tools/*.ts`, which would run at `import()` time with no model involvement). Attach the real files by absolute `@path`. **Caveat:** *user-level* tools (`~/.claude/tools`, `~/.omp/plugins/*`) resolve from `$HOME`, not cwd, so the sandbox does **not** starve them — see "What the sandbox does and doesn't cover" below.
 - Attach files by writing `@path` inside the prompt; each referenced file's contents are read into the message context. Multiple `@path` tokens (and multi-line prompts) work. Use **absolute** paths so attachment still works from the sandbox cwd. **Quote any mention that interpolates a path** — `@\"$repo/file\"` — because omp's unquoted-mention parser stops at the first space (`[^\s@]+`), so an absolute path containing a space (e.g. a repo under `/Users/me/My App`) is truncated and the file is silently skipped.
@@ -37,7 +37,7 @@ Because `--no-tools` does not stop custom-tool discovery, run omp from a throwaw
   sandbox=$(mktemp -d)
   trap 'rm -rf "$sandbox"' EXIT        # remove the sandbox even on error/interrupt
   cd "$sandbox"                        # isolate cwd: omp won't discover the repo's custom tools
-  omp -p --no-tools --model google-antigravity/gemini-3.7-flash "Review this code for security issues @\"$repo/src/auth/middleware.ts\""
+  omp -p --no-tools --model google-antigravity/gemini-3.8-flash "Review this code for security issues @\"$repo/src/auth/middleware.ts\""
 )
 ```
 
@@ -49,7 +49,7 @@ For untrusted code, the robust isolation is OS-level: a container or a dedicated
 ```bash
 (
   repo="$PWD"; sandbox=$(mktemp -d); trap 'rm -rf "$sandbox"' EXIT; cd "$sandbox"
-  omp -p --no-tools --model google-antigravity/gemini-3.7-flash "Review these files for bugs, security issues, performance problems, and design concerns. Be specific and actionable. @\"$repo/src/middleware/auth.ts\" @\"$repo/src/services/user.ts\" @\"$repo/src/routes/api.ts\""
+  omp -p --no-tools --model google-antigravity/gemini-3.8-flash "Review these files for bugs, security issues, performance problems, and design concerns. Be specific and actionable. @\"$repo/src/middleware/auth.ts\" @\"$repo/src/services/user.ts\" @\"$repo/src/routes/api.ts\""
 )
 ```
 
@@ -62,7 +62,7 @@ For untrusted code, the robust isolation is OS-level: a container or a dedicated
   trap 'rm -rf "$sandbox"' EXIT
   git diff main...HEAD > "$sandbox/changes.diff"   # capture before cd
   cd "$sandbox"
-  omp -p --no-tools --model google-antigravity/gemini-3.7-flash "Review these PR changes for issues @\"$sandbox/changes.diff\""
+  omp -p --no-tools --model google-antigravity/gemini-3.8-flash "Review these PR changes for issues @\"$sandbox/changes.diff\""
 )
 
 # Specific commit range
@@ -71,14 +71,14 @@ For untrusted code, the robust isolation is OS-level: a container or a dedicated
   trap 'rm -rf "$sandbox"' EXIT
   git diff HEAD~5 > "$sandbox/changes.diff"
   cd "$sandbox"
-  omp -p --no-tools --model google-antigravity/gemini-3.7-flash "Review recent changes @\"$sandbox/changes.diff\""
+  omp -p --no-tools --model google-antigravity/gemini-3.8-flash "Review recent changes @\"$sandbox/changes.diff\""
 )
 ```
 
 ### Interactive Mode
 You drive an interactive session against your **trusted** working tree, so the sandbox is optional — but never start it inside an untrusted checkout, since custom-tool discovery still applies to omp's cwd:
 ```bash
-omp --no-tools --model google-antigravity/gemini-3.7-flash  # Start interactive session (omit -p)
+omp --no-tools --model google-antigravity/gemini-3.8-flash  # Start interactive session (omit -p)
 ```
 
 ## Core Responsibilities
@@ -95,7 +95,7 @@ omp --no-tools --model google-antigravity/gemini-3.7-flash  # Start interactive 
 ```bash
 (
   sandbox=$(mktemp -d); trap 'rm -rf "$sandbox"' EXIT; cd "$sandbox"
-  omp -p --no-tools --model google-antigravity/gemini-3.7-flash "Review this implementation plan for a caching layer using Redis.
+  omp -p --no-tools --model google-antigravity/gemini-3.8-flash "Review this implementation plan for a caching layer using Redis.
 
 Plan:
 1. Add Redis client dependency
@@ -114,7 +114,7 @@ What are the weaknesses, edge cases, or risks I'm missing?"
 ```bash
 (
   repo="$PWD"; sandbox=$(mktemp -d); trap 'rm -rf "$sandbox"' EXIT; cd "$sandbox"
-  omp -p --no-tools --model google-antigravity/gemini-3.7-flash "Review these files for bugs, security issues, performance problems, and design concerns. Be specific and actionable. @\"$repo/src/middleware/auth.ts\" @\"$repo/src/services/user.ts\" @\"$repo/src/routes/api.ts\""
+  omp -p --no-tools --model google-antigravity/gemini-3.8-flash "Review these files for bugs, security issues, performance problems, and design concerns. Be specific and actionable. @\"$repo/src/middleware/auth.ts\" @\"$repo/src/services/user.ts\" @\"$repo/src/routes/api.ts\""
 )
 ```
 
@@ -122,7 +122,7 @@ What are the weaknesses, edge cases, or risks I'm missing?"
 ```bash
 (
   sandbox=$(mktemp -d); trap 'rm -rf "$sandbox"' EXIT; cd "$sandbox"
-  omp -p --no-tools --model google-antigravity/gemini-3.7-flash "Compare Redis vs Memcached for session storage.
+  omp -p --no-tools --model google-antigravity/gemini-3.8-flash "Compare Redis vs Memcached for session storage.
 
 Context:
 - 100K daily active users
@@ -138,7 +138,7 @@ Provide objective tradeoff analysis and a recommendation with justification."
 ```bash
 (
   repo="$PWD"; sandbox=$(mktemp -d); trap 'rm -rf "$sandbox"' EXIT; cd "$sandbox"
-  omp -p --no-tools --model google-antigravity/gemini-3.7-flash "Analyze this module's architecture. Identify:
+  omp -p --no-tools --model google-antigravity/gemini-3.8-flash "Analyze this module's architecture. Identify:
 1. Coupling issues
 2. Potential circular dependencies
 3. Violation of SOLID principles
@@ -154,7 +154,7 @@ Provide objective tradeoff analysis and a recommendation with justification."
   trap 'rm -rf "$sandbox"' EXIT
   git diff main...HEAD > "$sandbox/changes.diff"   # capture before cd
   cd "$sandbox"
-  omp -p --no-tools --model google-antigravity/gemini-3.7-flash "Review this PR for:
+  omp -p --no-tools --model google-antigravity/gemini-3.8-flash "Review this PR for:
 1. Breaking changes
 2. Security vulnerabilities
 3. Performance regressions

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -107,7 +107,7 @@ Quick mode (`/council quick`) runs **exactly 2 agents** — no more, no fewer:
 
 | Agent | Model | Role |
 |-------|-------|------|
-| `council:gemini-consultant` | Gemini 3.7 Flash | Fast external perspective |
+| `council:gemini-consultant` | Gemini 3.8 Flash | Fast external perspective |
 | `council:claude-codebase-context` | Sonnet | Codebase-aware depth (native tool access) |
 
 **Skipped in quick mode** (only run if escalating to full council):
@@ -310,7 +310,7 @@ git diff | codex exec --sandbox read-only -c approval_policy=never "review chang
   git diff main...HEAD > "$sandbox/changes.diff"   # capture before cd
   cd "$sandbox"
 
-  omp -p --no-tools --model google-antigravity/gemini-3.7-flash "prompt @\"$sandbox/changes.diff\""
+  omp -p --no-tools --model google-antigravity/gemini-3.8-flash "prompt @\"$sandbox/changes.diff\""
   omp -p --no-tools --model zai/glm-5.3:max "prompt @\"$sandbox/changes.diff\""
   omp -p --no-tools --model kimi-code/k3 "prompt @\"$sandbox/changes.diff\""
 )

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: council
-description: Consult external AI council (Gemini 3.7 Flash, Codex, GLM-5.3, Kimi) for thorough reviews and consensus-driven decisions. Use ONLY when explicitly invoked with "/council" or when user says "consult the council", "invoke council", or "council review". Do NOT auto-trigger on generic phrases like "thorough review".
+description: Consult external AI council (Gemini 3.8 Flash, Codex, GLM-5.3, Kimi) for thorough reviews and consensus-driven decisions. Use ONLY when explicitly invoked with "/council" or when user says "consult the council", "invoke council", or "council review". Do NOT auto-trigger on generic phrases like "thorough review".
 argument-hint: "[review|plan|adversarial|consensus|quick] [security|architecture|bugs|quality] [--blind]"
 allowed-tools: Task, Read, Grep, Glob, Bash, TodoWrite
 user-invocable: true
@@ -70,7 +70,7 @@ Invoked via CLI. Each brings a different AI model's perspective. All receive the
 
 | Agent | CLI | Strength | Expertise Weight |
 |-------|-----|----------|------------------|
-| `council:gemini-consultant` | `omp -p --no-tools --model google-antigravity/gemini-3.7-flash` | Architecture, security | Security: 0.9, Architecture: 0.85 |
+| `council:gemini-consultant` | `omp -p --no-tools --model google-antigravity/gemini-3.8-flash` | Architecture, security | Security: 0.9, Architecture: 0.85 |
 | `council:codex-consultant` | `codex` | PR review, bugs | Debugging: 0.9, Security: 0.8 |
 | `council:glm-consultant` | `omp -p --no-tools --model zai/glm-5.3:max` | Alternative views, algorithms | Algorithms: 0.85, Architecture: 0.80 |
 | `council:kimi-consultant` | `omp -p --no-tools --model kimi-code/k3` | Code analysis, algorithms | Code Quality: 0.80, Algorithms: 0.80 |
@@ -407,7 +407,7 @@ Quick mode runs **exactly these 2 agents**:
 
 | Agent | Model | Role | Why included |
 |-------|-------|------|--------------|
-| `council:gemini-consultant` | Gemini 3.7 Flash (`google-antigravity/gemini-3.7-flash`) | Fast external perspective | Fastest external model, broad coverage |
+| `council:gemini-consultant` | Gemini 3.8 Flash (`google-antigravity/gemini-3.8-flash`) | Fast external perspective | Fastest external model, broad coverage |
 | `council:claude-codebase-context` | Sonnet | Codebase-aware depth | Native tool access, CLAUDE.md compliance, git history |
 
 Quick mode **does NOT run** these agents:
@@ -426,7 +426,7 @@ Quick mode **does NOT run** these agents:
     Skipping 5 agents (codex, glm, kimi, claude-deep-review, review-scorer)."
 
 2. Launch BOTH in parallel:
-   - council:gemini-consultant (omp google-antigravity/gemini-3.7-flash) — fastest external model
+   - council:gemini-consultant (omp google-antigravity/gemini-3.8-flash) — fastest external model
    - council:claude-codebase-context (sonnet) — native codebase access
 
 3. Validate both responses (see Response Validation above)

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -359,7 +359,7 @@ fi
 
    | Agent | Model | Role |
    |-------|-------|------|
-   | `council:gemini-consultant` | Gemini 3.7 Flash (`google-antigravity/gemini-3.7-flash`) | Fast external perspective |
+   | `council:gemini-consultant` | Gemini 3.8 Flash (`google-antigravity/gemini-3.8-flash`) | Fast external perspective |
    | `council:claude-codebase-context` | Sonnet | Codebase-aware depth (native tool access) |
 
    **Skipped** (reserved for full council escalation):


### PR DESCRIPTION
### Summary
- Upgrade Gemini external consultant model identifier to `google-antigravity/gemini-3.8-flash` across council agent definitions, skills, documentation, and marketplace manifest.
- Update omp CLI invocation examples in `gemini-consultant.md` to target `google-antigravity/gemini-3.8-flash`.
- Update council skill frontmatter and orchestration tables in `SKILL.md`, `QUICK-REFERENCE.md`, and `WORKFLOWS.md`.
- Update plugin catalog listings in `.claude-plugin/marketplace.json` and root `README.md`.

### Verification
- `bun scripts/validate-plugins.mjs` passed (schema validation, paths, SKILL.md frontmatter).
- Verified clean reference cutover with `git grep -i 'gemini-3.7'` and `git grep -i 'gemini 3.7'` (only historical changelog entry remains).
- Live isolated invocation verified: `omp -p --no-tools --model google-antigravity/gemini-3.8-flash "ping"` returned `pong` (exit status 0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the council plugin’s documented Gemini consultant references from Gemini 3.7 Flash to Gemini 3.8 Flash.
  - Updated model identifiers and examples across the plugin overview, quick reference, skill documentation, workflows, and consultant guidance.
  - Updated marketplace and README descriptions to reflect the current Gemini model version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->