### PR TITLE
feat(council): add consultant subscription config and dynamic dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | Plugin | Category | Skill Triggers |
 |--------|----------|----------------|
-| council | Code Review | `/council`, `/council:review-plan` |
+| council | Code Review | `/council`, `/council:config`, `/council:review-plan` |
 | cdt | Development | `/cdt` |
 | pm | Productivity | `/pm`, `/pm:brainstorm`, `/pm:next`, `/pm:update`, `/pm:review` |
 | plugin-dev | Development | `/plugin-dev`, `/plugin-dev:create`, `/plugin-dev:develop` |

--- a/README.md
+++ b/README.md
@@ -169,9 +169,10 @@ cc-skills/
 ├── plugins/
 │   ├── council/             # AI council code reviews
 │   │   ├── agents/          # Consultant agents + Claude subagents
+│   │   ├── commands/        # Configuration command (/council:config)
 │   │   ├── hooks/           # Pre/post tool-use hooks
-│   │   ├── scripts/         # Validation scripts
-│   │   └── skills/          # council, council-reference
+│   │   ├── scripts/         # Validation and config scripts
+│   │   └── skills/          # council, council-reference, review-plan
 │   ├── cdt/                 # Multi-agent dev team
 │   │   ├── agents/          # Researcher subagent
 │   │   ├── commands/        # Task workflow commands

--- a/plugins/council/README.md
+++ b/plugins/council/README.md
@@ -70,7 +70,7 @@ Built-in taxonomy auto-rejects:
 | `/council plan` | Implementation plan validation |
 | `/council adversarial` | Advocates vs critics comparison |
 | `/council consensus [topic]` | Multi-round consensus building |
-| `/council quick` | Parallel triage — Gemini Flash + Claude subagent in parallel, escalates to full council if needed |
+| `/council quick` | Parallel triage — configured quick consultant (default: fastest enabled) + Claude subagent in parallel, escalates to full council if needed |
 
 ## Hooks
 

--- a/plugins/council/README.md
+++ b/plugins/council/README.md
@@ -159,8 +159,8 @@ External consultants can be enabled or disabled based on your active subscriptio
 /council:config subagent model <m>    # Set deep review model (opus, sonnet)
 /council:config subagent enable <name># Enable subagent (claude-deep-review, claude-codebase-context, review-scorer)
 /council:config subagent disable <n>  # Disable subagent
-/council:config detect                # Probe installed CLIs & active subscriptions
-/council:config init [--auto]         # Initialize configuration (.dev/council/config.json)
+/council:config detect                     # Probe installed CLIs & active subscriptions
+/council:config init [--auto] [--force]    # Initialize configuration (.dev/council/config.json)
 ```
 
 Pass `--global` to any command to persist settings across all repositories in `~/.config/council/config.json`.

--- a/plugins/council/README.md
+++ b/plugins/council/README.md
@@ -1,9 +1,9 @@
 # council
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Skills](https://img.shields.io/badge/Skills-3-blue.svg)]()
-[![Agents](https://img.shields.io/badge/Agents-7-green.svg)]()
-[![Commands](https://img.shields.io/badge/Commands-1-purple.svg)]()
+[![Skills](https://img.shields.io/badge/Skills-3-blue.svg)](#skills--commands)
+[![Agents](https://img.shields.io/badge/Agents-7-green.svg)](#dual-layer-review-system)
+[![Commands](https://img.shields.io/badge/Commands-1-purple.svg)](#skills--commands)
 [![Hooks](https://img.shields.io/badge/Hooks-2-orange.svg)](#hooks)
 
 Orchestrate multiple AI consultants (Gemini 3.8 Flash, Codex, GLM-5.3, Kimi K3) and specialized Claude subagents for consensus-driven code reviews, plan validation, and architectural decisions.

--- a/plugins/council/README.md
+++ b/plugins/council/README.md
@@ -33,6 +33,7 @@ Orchestrate multiple AI consultants (Gemini 3.8 Flash, Codex, GLM-5.3, Kimi K3) 
 | Agent | Model | Role |
 |-------|-------|------|
 | review-scorer | Sonnet | Deduplicate, verify, score 0-100, filter to >= 80 |
+
 ### Weighted Synthesis
 
 Not simple voting — findings are weighted by expertise and confidence:

--- a/plugins/council/README.md
+++ b/plugins/council/README.md
@@ -154,6 +154,7 @@ External consultants can be enabled or disabled based on your active subscriptio
 /council:config show                  # Display current configuration & CLI status
 /council:config enable <consultant>   # Enable a consultant (gemini, codex, glm, kimi)
 /council:config disable <consultant>  # Disable a consultant
+/council:config quick <consultant>     # Set quick mode consultant, or use auto
 /council:config detect                # Probe installed CLIs & active subscriptions
 /council:config init [--auto]         # Initialize configuration (.dev/council/config.json)
 ```

--- a/plugins/council/README.md
+++ b/plugins/council/README.md
@@ -144,7 +144,7 @@ npx skills add rube-de/cc-skills --skill council
 > - `preflight.sh` — no automatic CLI availability check on session start
 > - `validate-json-output.sh` — no PostToolUse JSON validation for consultant output
 > - Agent `.md` definitions — subagent types (codex-consultant, gemini-consultant, etc.) won't be registered
-
+> - `/council:config` command & scripts — consultant enablement configuration and subscription management won't be available (council falls back to default consultants)
 ### Configuration & Subscriptions
 
 External consultants can be enabled or disabled based on your active subscriptions (`.dev/council/config.json`):

--- a/plugins/council/README.md
+++ b/plugins/council/README.md
@@ -1,7 +1,7 @@
 # council
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Skills](https://img.shields.io/badge/Skills-2-blue.svg)]()
+[![Skills](https://img.shields.io/badge/Skills-3-blue.svg)]()
 [![Agents](https://img.shields.io/badge/Agents-7-green.svg)]()
 [![Commands](https://img.shields.io/badge/Commands-1-purple.svg)]()
 [![Hooks](https://img.shields.io/badge/Hooks-2-orange.svg)](#hooks)
@@ -167,22 +167,21 @@ Pass `--global` to any command to persist settings across all repositories in `~
 
 ### Prerequisites
 
-At least one external CLI (or subscription) is recommended:
+`jq` (or `jaq`) is required for configuration parsing and JSON validation hooks. At least one external CLI (or subscription) is recommended:
 
 ```bash
 # Check capability detection
 ./plugins/council/scripts/council-config.sh detect
 ```
-
 The plugin operates in partial-success mode — it proceeds with whichever consultants are enabled and available. If all external consultants are disabled, Council seamlessly runs Layer 2 (Claude Opus and Sonnet subagents) for dual-depth analysis.
 ## Dependencies
 
 | Component | Required | Purpose |
 |-----------|----------|---------|
 | Claude Code | Yes | Plugin host |
+| jq | Yes | JSON configuration and validation hooks |
 | codex CLI | Recommended | Codex consultant |
 | omp CLI | Recommended | Gemini, GLM-5.3, and Kimi consultants (3 of 4) |
-
 ## Troubleshooting
 
 | Issue | Cause | Solution |

--- a/plugins/council/README.md
+++ b/plugins/council/README.md
@@ -3,9 +3,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Skills](https://img.shields.io/badge/Skills-2-blue.svg)]()
 [![Agents](https://img.shields.io/badge/Agents-7-green.svg)]()
+[![Commands](https://img.shields.io/badge/Commands-1-purple.svg)]()
 [![Hooks](https://img.shields.io/badge/Hooks-2-orange.svg)](#hooks)
-[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
-[![Install](https://img.shields.io/badge/Install-Plugin%20%7C%20Skill-informational.svg)]()
 
 Orchestrate multiple AI consultants (Gemini 3.8 Flash, Codex, GLM-5.3, Kimi K3) and specialized Claude subagents for consensus-driven code reviews, plan validation, and architectural decisions.
 
@@ -51,13 +50,14 @@ Built-in taxonomy auto-rejects:
 - Pedantic nitpicks senior engineers wouldn't flag
 - Issues on lines NOT modified in the review
 
-## Skills
+## Skills & Commands
 
-| Skill | Purpose | User-Invocable |
-|-------|---------|----------------|
-| **council** | Main orchestration — all review modes | Yes |
-| **council-reference** | Expertise matrix and response format data | No (background) |
-
+| Name | Type | Purpose | Invocable |
+|------|------|---------|-----------|
+| **council** | Skill | Main orchestration — all review modes | Yes (`/council`) |
+| **council:config** | Command | Configure consultant enablement & active subscriptions | Yes (`/council:config` or `/council config`) |
+| **council:review-plan** | Skill | Pre-execution implementation plan review | Yes (`/council:review-plan`) |
+| **council-reference** | Skill | Expertise matrix and response format data | No (background) |
 ## Review Modes
 
 | Command | Description |
@@ -76,7 +76,7 @@ Built-in taxonomy auto-rejects:
 
 | Hook | Trigger | Purpose |
 |------|---------|---------|
-| `preflight.sh` | SessionStart | Check CLI availability for all external consultant CLIs |
+| `preflight.sh` | SessionStart | Check configuration and CLI availability for enabled consultants |
 | `validate-json-output.sh` | PostToolUse (Bash) | Validate consultant output matches expected JSON schema |
 
 ## How It Works
@@ -145,23 +145,31 @@ npx skills add rube-de/cc-skills --skill council
 > - `validate-json-output.sh` — no PostToolUse JSON validation for consultant output
 > - Agent `.md` definitions — subagent types (codex-consultant, gemini-consultant, etc.) won't be registered
 
-### Prerequisites
+### Configuration & Subscriptions
 
-At least one external CLI must be installed:
+External consultants can be enabled or disabled based on your active subscriptions (`.dev/council/config.json`):
 
 ```bash
-# Check availability (prints ✓/✗ per CLI — omp covers 3 of 4 consultants, codex covers 1)
-for cli in codex omp; do
-  command -v "$cli" >/dev/null 2>&1 && echo "✓ $cli" || echo "✗ $cli"
-done
-
-# Install as needed
-# codex   — https://github.com/openai/codex
-# omp     — https://github.com/can1357/oh-my-pi (Gemini 3.8 Flash via antigravity, GLM-5.3, Kimi K3)
+/council:config                       # Interactive setup & detection wizard
+/council:config show                  # Display current configuration & CLI status
+/council:config enable <consultant>   # Enable a consultant (gemini, codex, glm, kimi)
+/council:config disable <consultant>  # Disable a consultant
+/council:config detect                # Probe installed CLIs & active subscriptions
+/council:config init [--auto]         # Initialize configuration (.dev/council/config.json)
 ```
 
-The plugin operates in partial-success mode — it proceeds with whichever consultants are available. Note that `omp` is the dominant dependency: it gates three of the four external consultants (Gemini, GLM-5.3, Kimi), so a missing or broken `omp` install leaves Codex as the only external voice.
+Pass `--global` to any command to persist settings across all repositories in `~/.config/council/config.json`.
 
+### Prerequisites
+
+At least one external CLI (or subscription) is recommended:
+
+```bash
+# Check capability detection
+./plugins/council/scripts/council-config.sh detect
+```
+
+The plugin operates in partial-success mode — it proceeds with whichever consultants are enabled and available. If all external consultants are disabled, Council seamlessly runs Layer 2 (Claude Opus and Sonnet subagents) for dual-depth analysis.
 ## Dependencies
 
 | Component | Required | Purpose |

--- a/plugins/council/README.md
+++ b/plugins/council/README.md
@@ -23,17 +23,16 @@ Orchestrate multiple AI consultants (Gemini 3.8 Flash, Codex, GLM-5.3, Kimi K3) 
 | GLM-5.3 | `omp -p --no-tools --model zai/glm-5.3:max` | Alternative perspectives, algorithms |
 | Kimi K3 | `omp -p --no-tools --model kimi-code/k3` | Long-context reasoning, creative solutions |
 
-**Layer 2 — Claude Subagents** (concern depth, tool access):
+**Layer 2 — Claude Subagents** (concern depth, tool access — backend and models configurable):
 | Subagent | Model | Focus |
 |----------|-------|-------|
-| claude-deep-review | Opus | Security, bugs, performance — traces input paths, follows call chains |
+| claude-deep-review | Opus (or Sonnet via config) | Security, bugs, performance — traces input paths, follows call chains |
 | claude-codebase-context | Sonnet | Quality, compliance, history, documentation — compares against project conventions |
 
-**Layer 3 — Scoring** (noise reduction):
+**Layer 3 — Scoring** (noise reduction — optional / conditional via config):
 | Agent | Model | Role |
 |-------|-------|------|
 | review-scorer | Sonnet | Deduplicate, verify, score 0-100, filter to >= 80 |
-
 ### Weighted Synthesis
 
 Not simple voting — findings are weighted by expertise and confidence:
@@ -152,9 +151,13 @@ External consultants can be enabled or disabled based on your active subscriptio
 ```bash
 /council:config                       # Interactive setup & detection wizard
 /council:config show                  # Display current configuration & CLI status
-/council:config enable <consultant>   # Enable a consultant (gemini, codex, glm, kimi)
-/council:config disable <consultant>  # Disable a consultant
-/council:config quick <consultant>     # Set quick mode consultant, or use auto
+/council:config enable <consultant>   # Enable an external consultant (gemini, codex, glm, kimi)
+/council:config disable <consultant>  # Disable an external consultant
+/council:config quick <consultant>    # Set quick mode consultant (gemini, codex, glm, kimi, auto)
+/council:config subagent backend <t>  # Set subagent execution backend (native, omp, claude-cli)
+/council:config subagent model <m>    # Set deep review model (opus, sonnet)
+/council:config subagent enable <name># Enable subagent (claude-deep-review, claude-codebase-context, review-scorer)
+/council:config subagent disable <n>  # Disable subagent
 /council:config detect                # Probe installed CLIs & active subscriptions
 /council:config init [--auto]         # Initialize configuration (.dev/council/config.json)
 ```

--- a/plugins/council/README.md
+++ b/plugins/council/README.md
@@ -179,7 +179,7 @@ The plugin operates in partial-success mode — it proceeds with whichever consu
 | Component | Required | Purpose |
 |-----------|----------|---------|
 | Claude Code | Yes | Plugin host |
-| jq | Yes | JSON configuration and validation hooks |
+| jq (or jaq) | Yes | JSON configuration and validation hooks |
 | codex CLI | Recommended | Codex consultant |
 | omp CLI | Recommended | Gemini, GLM-5.3, and Kimi consultants (3 of 4) |
 ## Troubleshooting

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -1,0 +1,114 @@
+---
+allowed-tools: [Bash, Read, Write, Edit, AskUserQuestion]
+description: "Configure Council external consultant enablement based on available subscriptions (Gemini, Codex, GLM, Kimi)"
+---
+
+# /council:config — Council Consultant Configuration
+
+Configure which external AI consultants are enabled for Council reviews and consultations based on your active subscriptions and installed CLIs.
+
+## Usage
+
+```text
+/council:config                       # Interactive setup & detection wizard
+/council:config show                  # Display current configuration & CLI status
+/council:config enable <consultant>   # Enable a consultant (gemini, codex, glm, kimi)
+/council:config disable <consultant>  # Disable a consultant
+/council:config detect                # Probe installed CLIs & active subscriptions
+/council:config init [--auto]         # Initialize configuration (.dev/council/config.json)
+```
+
+Add `--global` to any command to target `~/.config/council/config.json` instead of the project-local `.dev/council/config.json`.
+
+## Configuration Precedence
+
+1. **Project-local**: `.dev/council/config.json` (takes precedence; committed to gitignore)
+2. **User-global**: `~/.config/council/config.json` (fallback across all projects)
+3. **Default**: Gemini & Codex enabled, GLM & Kimi disabled
+
+## Workflow
+
+### 1. Parse Arguments
+
+Inspect `$ARGUMENTS`:
+
+- If `$ARGUMENTS` contains `show` or `status`:
+  Run:
+  ```bash
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" show "$ARGUMENTS"
+  ```
+  Present the formatted status table to the user.
+
+- If `$ARGUMENTS` starts with `enable `:
+  Extract the consultant name and optional flags:
+  ```bash
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write <consultant> true [flags]
+  ```
+  Confirm to user that the consultant was enabled.
+
+- If `$ARGUMENTS` starts with `disable `:
+  Extract the consultant name and optional flags:
+  ```bash
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write <consultant> false [flags]
+  ```
+  Confirm to user that the consultant was disabled.
+
+- If `$ARGUMENTS` contains `detect`:
+  Run:
+  ```bash
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" detect
+  ```
+  Present detection results and explain which subscriptions/CLIs were found.
+
+- If `$ARGUMENTS` contains `init`:
+  Run:
+  ```bash
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" init [flags]
+  ```
+  Confirm initialization path.
+
+### 2. Interactive Wizard (Default when no subcommands given)
+
+When invoked without subcommands (or during first-run setup):
+
+1. **Run Capability Detection**:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" detect --json
+   ```
+
+2. **Read Existing Config (or defaults)**:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" read
+   ```
+
+3. **Present Status**:
+   Display detected capabilities and current enablement state to the user:
+   - **Gemini 3.8 Flash**: omp CLI + Google Antigravity account / `GEMINI_API_KEY`
+   - **Codex**: codex CLI + ChatGPT login (`codex login status`) / `OPENAI_API_KEY`
+   - **GLM-5.3**: omp CLI + Z.AI account / `ZAI_API_KEY`
+   - **Kimi K3**: omp CLI + Kimi Code account / `KIMI_API_KEY`
+
+4. **Ask User for Consultant Selection**:
+   Prompt user with `AskUserQuestion`:
+   - "Which external consultants do you want to enable for Council reviews?"
+   - Multi-select options showing detected recommendation (e.g. `Gemini 3.8 Flash (Recommended: Active)`, `Codex (Recommended: Active)`, `GLM-5.3`, `Kimi K3`).
+
+5. **Ask Scope Preference**:
+   - Save to current project (`.dev/council/config.json`)
+   - Save globally (`~/.config/council/config.json`)
+
+6. **Save Configuration**:
+   Apply user choices using `council-config.sh write <consultant> <true|false>`:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write gemini <bool> [flags]
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write codex <bool> [flags]
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write glm <bool> [flags]
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write kimi <bool> [flags]
+   ```
+
+7. **Verify & Display Summary**:
+   Run:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" show
+   ```
+   Inform the user that `/council` will now dynamically dispatch only the enabled consultants.

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -27,7 +27,7 @@ Add `--global` to any command to target `~/.config/council/config.json` instead 
 
 ## Configuration Precedence
 
-1. **Project-local**: `.dev/council/config.json` (takes precedence; committed to gitignore)
+1. **Project-local**: `.dev/council/config.json` (takes precedence; should be added to `.gitignore`)
 2. **User-global**: `~/.config/council/config.json` (fallback across all projects)
 3. **Default**: Gemini & Codex enabled, GLM & Kimi disabled
 

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -35,6 +35,11 @@ Add `--global` to any command to target `~/.config/council/config.json` instead 
 
 ### 1. Parse Arguments
 
+Resolve the config utility path with a fallback when `CLAUDE_PLUGIN_ROOT` is unset:
+```bash
+CONFIG_SCRIPT="${CLAUDE_PLUGIN_ROOT:-plugins/council}/scripts/council-config.sh"
+```
+
 Check if `$ARGUMENTS` contains the standalone flag token `--global` (not as part of another argument like `--globalfoo`). If present, pass `--global` as an explicit, separate flag argument to script commands (e.g. `show --global`).
 
 Inspect `$ARGUMENTS`:
@@ -42,70 +47,70 @@ Inspect `$ARGUMENTS`:
 - If `$ARGUMENTS` contains `show` or `status`:
   Run:
   ```bash
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" show [flags]
+  "$CONFIG_SCRIPT" show [flags]
   ```
   Present the formatted status table to the user.
 
 - If `$ARGUMENTS` starts with `enable `:
   Extract the consultant name:
   ```bash
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write <consultant> true [flags]
+  "$CONFIG_SCRIPT" write <consultant> true [flags]
   ```
   Confirm to user that the consultant was enabled.
 
 - If `$ARGUMENTS` starts with `disable `:
   Extract the consultant name:
   ```bash
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write <consultant> false [flags]
+  "$CONFIG_SCRIPT" write <consultant> false [flags]
   ```
   Confirm to user that the consultant was disabled.
 
 - If `$ARGUMENTS` starts with `quick `:
   Extract the consultant name (or `auto`):
   ```bash
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-quick <consultant|auto> [flags]
+  "$CONFIG_SCRIPT" set-quick <consultant|auto> [flags]
   ```
   Confirm to user that the quick mode consultant was updated.
 
 - If `$ARGUMENTS` starts with `subagent backend `:
   Extract the backend value (`native`, `omp`, `claude-cli`):
   ```bash
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-subagent-backend <type> [flags]
+  "$CONFIG_SCRIPT" set-subagent-backend <type> [flags]
   ```
   Confirm to user that the subagent backend was updated.
 
 - If `$ARGUMENTS` starts with `subagent model `:
   Extract the model value (`opus`, `sonnet`):
   ```bash
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-deep-model <model> [flags]
+  "$CONFIG_SCRIPT" set-deep-model <model> [flags]
   ```
   Confirm to user that the deep review model was updated.
 
 - If `$ARGUMENTS` starts with `subagent enable `:
   Extract the subagent name:
   ```bash
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write-subagent <name> true [flags]
+  "$CONFIG_SCRIPT" write-subagent <name> true [flags]
   ```
   Confirm to user that the subagent was enabled.
 
 - If `$ARGUMENTS` starts with `subagent disable `:
   Extract the subagent name:
   ```bash
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write-subagent <name> false [flags]
+  "$CONFIG_SCRIPT" write-subagent <name> false [flags]
   ```
   Confirm to user that the subagent was disabled.
 
 - If `$ARGUMENTS` contains `detect`:
   Run:
   ```bash
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" detect
+  "$CONFIG_SCRIPT" detect
   ```
   Present detection results and explain which subscriptions/CLIs were found.
 
 - If `$ARGUMENTS` contains `init`:
   Run:
   ```bash
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" init [flags]
+  "$CONFIG_SCRIPT" init [flags]
   ```
   Confirm initialization path.
 
@@ -119,12 +124,12 @@ When invoked without subcommands (or during first-run setup):
 
 1. **Run Capability Detection**:
    ```bash
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" detect --json
+   "$CONFIG_SCRIPT" detect --json
    ```
 
 2. **Read Existing Config (or defaults)**:
    ```bash
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" read $SCOPE_FLAG
+   "$CONFIG_SCRIPT" read $SCOPE_FLAG
    ```
 
 3. **Present Status**:
@@ -151,16 +156,16 @@ When invoked without subcommands (or during first-run setup):
 7. **Save Configuration**:
    Apply user choices using `council-config.sh write <consultant> <true|false>`:
    ```bash
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write gemini <bool> $SCOPE_FLAG
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write codex <bool> $SCOPE_FLAG
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write glm <bool> $SCOPE_FLAG
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write kimi <bool> $SCOPE_FLAG
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-quick <quick_choice> $SCOPE_FLAG
+   "$CONFIG_SCRIPT" write gemini <bool> $SCOPE_FLAG
+   "$CONFIG_SCRIPT" write codex <bool> $SCOPE_FLAG
+   "$CONFIG_SCRIPT" write glm <bool> $SCOPE_FLAG
+   "$CONFIG_SCRIPT" write kimi <bool> $SCOPE_FLAG
+   "$CONFIG_SCRIPT" set-quick <quick_choice> $SCOPE_FLAG
    ```
 
 8. **Verify & Display Summary**:
    Run:
    ```bash
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" show $SCOPE_FLAG
+   "$CONFIG_SCRIPT" show $SCOPE_FLAG
    ```
    Inform the user that `/council` will now dynamically dispatch only the enabled consultants.

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -108,6 +108,8 @@ When invoked without subcommands (or during first-run setup):
 6. **Ask Scope Preference**:
    - Save to current project (`.dev/council/config.json`)
    - Save globally (`~/.config/council/config.json`)
+
+7. **Save Configuration**:
    Apply user choices using `council-config.sh write <consultant> <true|false>`:
    ```bash
    "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write gemini <bool> [flags]
@@ -116,7 +118,8 @@ When invoked without subcommands (or during first-run setup):
    "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write kimi <bool> [flags]
    "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-quick <quick_choice> [flags]
    ```
-7. **Verify & Display Summary**:
+
+8. **Verify & Display Summary**:
    Run:
    ```bash
    "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" show

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -15,6 +15,10 @@ Configure which external AI consultants are enabled for Council reviews and cons
 /council:config enable <consultant>        # Enable a consultant (gemini, codex, glm, kimi)
 /council:config disable <consultant>       # Disable a consultant
 /council:config quick <consultant|auto>    # Set preferred quick mode external consultant
+/council:config subagent backend <type>    # Set Claude subagent backend (native, omp, claude-cli)
+/council:config subagent model <model>     # Set deep review model (opus, sonnet)
+/council:config subagent enable <name>     # Enable subagent (claude-deep-review, claude-codebase-context, review-scorer)
+/council:config subagent disable <name>    # Disable subagent
 /council:config detect                     # Probe installed CLIs & active subscriptions
 /council:config init [--auto]              # Initialize configuration (.dev/council/config.json)
 ```
@@ -60,6 +64,35 @@ Inspect `$ARGUMENTS`:
   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-quick <consultant|auto> [flags]
   ```
   Confirm to user that the quick mode consultant was updated.
+
+- If `$ARGUMENTS` starts with `subagent backend `:
+  Extract the backend value (`native`, `omp`, `claude-cli`) and optional flags:
+  ```bash
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-subagent-backend <type> [flags]
+  ```
+  Confirm to user that the subagent backend was updated.
+
+- If `$ARGUMENTS` starts with `subagent model `:
+  Extract the model value (`opus`, `sonnet`) and optional flags:
+  ```bash
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-deep-model <model> [flags]
+  ```
+  Confirm to user that the deep review model was updated.
+
+- If `$ARGUMENTS` starts with `subagent enable `:
+  Extract the subagent name and optional flags:
+  ```bash
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write-subagent <name> true [flags]
+  ```
+  Confirm to user that the subagent was enabled.
+
+- If `$ARGUMENTS` starts with `subagent disable `:
+  Extract the subagent name and optional flags:
+  ```bash
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write-subagent <name> false [flags]
+  ```
+  Confirm to user that the subagent was disabled.
+
 - If `$ARGUMENTS` contains `detect`:
   Run:
   ```bash

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -35,7 +35,7 @@ Add `--global` to any command to target `~/.config/council/config.json` instead 
 
 ### 1. Parse Arguments
 
-Check if `$ARGUMENTS` contains `--global`. If present, pass `--global` as an explicit, separate flag argument to script commands (e.g. `show --global`).
+Check if `$ARGUMENTS` contains the standalone flag token `--global` (not as part of another argument like `--globalfoo`). If present, pass `--global` as an explicit, separate flag argument to script commands (e.g. `show --global`).
 
 Inspect `$ARGUMENTS`:
 
@@ -114,7 +114,7 @@ Inspect `$ARGUMENTS`:
 When invoked without subcommands (or during first-run setup):
 
 **Scope Handling**:
-- If `$ARGUMENTS` contains `--global`: set `SCOPE_FLAG="--global"` and skip Step 6.
+- If `$ARGUMENTS` contains the standalone token `--global`: set `SCOPE_FLAG="--global"` and skip Step 6.
 - Otherwise: prompt user for scope in Step 6 (set `SCOPE_FLAG="--global"` if user chooses global scope, or leave empty for project scope).
 
 1. **Run Capability Detection**:

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -10,12 +10,13 @@ Configure which external AI consultants are enabled for Council reviews and cons
 ## Usage
 
 ```text
-/council:config                       # Interactive setup & detection wizard
-/council:config show                  # Display current configuration & CLI status
-/council:config enable <consultant>   # Enable a consultant (gemini, codex, glm, kimi)
-/council:config disable <consultant>  # Disable a consultant
-/council:config detect                # Probe installed CLIs & active subscriptions
-/council:config init [--auto]         # Initialize configuration (.dev/council/config.json)
+/council:config                            # Interactive setup & detection wizard
+/council:config show                       # Display current configuration & CLI status
+/council:config enable <consultant>        # Enable a consultant (gemini, codex, glm, kimi)
+/council:config disable <consultant>       # Disable a consultant
+/council:config quick <consultant|auto>    # Set preferred quick mode external consultant
+/council:config detect                     # Probe installed CLIs & active subscriptions
+/council:config init [--auto]              # Initialize configuration (.dev/council/config.json)
 ```
 
 Add `--global` to any command to target `~/.config/council/config.json` instead of the project-local `.dev/council/config.json`.
@@ -53,6 +54,12 @@ Inspect `$ARGUMENTS`:
   ```
   Confirm to user that the consultant was disabled.
 
+- If `$ARGUMENTS` starts with `quick `:
+  Extract the consultant name (or `auto`) and optional flags:
+  ```bash
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-quick <consultant|auto> [flags]
+  ```
+  Confirm to user that the quick mode consultant was updated.
 - If `$ARGUMENTS` contains `detect`:
   Run:
   ```bash
@@ -93,19 +100,22 @@ When invoked without subcommands (or during first-run setup):
    - "Which external consultants do you want to enable for Council reviews?"
    - Multi-select options showing detected recommendation (e.g. `Gemini 3.8 Flash (Recommended: Active)`, `Codex (Recommended: Active)`, `GLM-5.3`, `Kimi K3`).
 
-5. **Ask Scope Preference**:
+5. **Ask Preferred Quick Mode Consultant**:
+   Prompt user with `AskUserQuestion`:
+   - "Which consultant should be used for quick triage reviews (/council quick)?"
+   - Options: `auto (Recommended: First enabled)`, `gemini`, `codex`, `glm`, `kimi`
+
+6. **Ask Scope Preference**:
    - Save to current project (`.dev/council/config.json`)
    - Save globally (`~/.config/council/config.json`)
-
-6. **Save Configuration**:
    Apply user choices using `council-config.sh write <consultant> <true|false>`:
    ```bash
    "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write gemini <bool> [flags]
    "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write codex <bool> [flags]
    "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write glm <bool> [flags]
    "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write kimi <bool> [flags]
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-quick <quick_choice> [flags]
    ```
-
 7. **Verify & Display Summary**:
    Run:
    ```bash

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -113,6 +113,10 @@ Inspect `$ARGUMENTS`:
 
 When invoked without subcommands (or during first-run setup):
 
+**Scope Handling**:
+- If `$ARGUMENTS` contains `--global`: set `SCOPE_FLAG="--global"` and skip Step 6.
+- Otherwise: prompt user for scope in Step 6 (set `SCOPE_FLAG="--global"` if user chooses global scope, or leave empty for project scope).
+
 1. **Run Capability Detection**:
    ```bash
    "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" detect --json
@@ -120,7 +124,7 @@ When invoked without subcommands (or during first-run setup):
 
 2. **Read Existing Config (or defaults)**:
    ```bash
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" read
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" read $SCOPE_FLAG
    ```
 
 3. **Present Status**:
@@ -140,23 +144,23 @@ When invoked without subcommands (or during first-run setup):
    - "Which consultant should be used for quick triage reviews (/council quick)?"
    - Options: `auto (Recommended: First enabled)`, `gemini`, `codex`, `glm`, `kimi`
 
-6. **Ask Scope Preference**:
+6. **Ask Scope Preference** (skipped if `--global` was already passed):
    - Save to current project (`.dev/council/config.json`)
    - Save globally (`~/.config/council/config.json`)
 
 7. **Save Configuration**:
    Apply user choices using `council-config.sh write <consultant> <true|false>`:
    ```bash
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write gemini <bool> [flags]
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write codex <bool> [flags]
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write glm <bool> [flags]
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write kimi <bool> [flags]
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-quick <quick_choice> [flags]
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write gemini <bool> $SCOPE_FLAG
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write codex <bool> $SCOPE_FLAG
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write glm <bool> $SCOPE_FLAG
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write kimi <bool> $SCOPE_FLAG
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-quick <quick_choice> $SCOPE_FLAG
    ```
 
 8. **Verify & Display Summary**:
    Run:
    ```bash
-   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" show
+   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" show $SCOPE_FLAG
    ```
    Inform the user that `/council` will now dynamically dispatch only the enabled consultants.

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -20,7 +20,7 @@ Configure which external AI consultants are enabled for Council reviews and cons
 /council:config subagent enable <name>     # Enable subagent (claude-deep-review, claude-codebase-context, review-scorer)
 /council:config subagent disable <name>    # Disable subagent
 /council:config detect                     # Probe installed CLIs & active subscriptions
-/council:config init [--auto]              # Initialize configuration (.dev/council/config.json)
+/council:config init [--auto] [--force]    # Initialize configuration (.dev/council/config.json)
 ```
 
 Add `--global` to any command to target `~/.config/council/config.json` instead of the project-local `.dev/council/config.json`.

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -35,59 +35,61 @@ Add `--global` to any command to target `~/.config/council/config.json` instead 
 
 ### 1. Parse Arguments
 
+Check if `$ARGUMENTS` contains `--global`. If present, pass `--global` as an explicit, separate flag argument to script commands (e.g. `show --global`).
+
 Inspect `$ARGUMENTS`:
 
 - If `$ARGUMENTS` contains `show` or `status`:
   Run:
   ```bash
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" show "$ARGUMENTS"
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" show [flags]
   ```
   Present the formatted status table to the user.
 
 - If `$ARGUMENTS` starts with `enable `:
-  Extract the consultant name and optional flags:
+  Extract the consultant name:
   ```bash
   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write <consultant> true [flags]
   ```
   Confirm to user that the consultant was enabled.
 
 - If `$ARGUMENTS` starts with `disable `:
-  Extract the consultant name and optional flags:
+  Extract the consultant name:
   ```bash
   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write <consultant> false [flags]
   ```
   Confirm to user that the consultant was disabled.
 
 - If `$ARGUMENTS` starts with `quick `:
-  Extract the consultant name (or `auto`) and optional flags:
+  Extract the consultant name (or `auto`):
   ```bash
   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-quick <consultant|auto> [flags]
   ```
   Confirm to user that the quick mode consultant was updated.
 
 - If `$ARGUMENTS` starts with `subagent backend `:
-  Extract the backend value (`native`, `omp`, `claude-cli`) and optional flags:
+  Extract the backend value (`native`, `omp`, `claude-cli`):
   ```bash
   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-subagent-backend <type> [flags]
   ```
   Confirm to user that the subagent backend was updated.
 
 - If `$ARGUMENTS` starts with `subagent model `:
-  Extract the model value (`opus`, `sonnet`) and optional flags:
+  Extract the model value (`opus`, `sonnet`):
   ```bash
   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" set-deep-model <model> [flags]
   ```
   Confirm to user that the deep review model was updated.
 
 - If `$ARGUMENTS` starts with `subagent enable `:
-  Extract the subagent name and optional flags:
+  Extract the subagent name:
   ```bash
   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write-subagent <name> true [flags]
   ```
   Confirm to user that the subagent was enabled.
 
 - If `$ARGUMENTS` starts with `subagent disable `:
-  Extract the subagent name and optional flags:
+  Extract the subagent name:
   ```bash
   "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" write-subagent <name> false [flags]
   ```

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -37,7 +37,7 @@ Add `--global` to any command to target `~/.config/council/config.json` instead 
 
 Resolve the config utility path with a fallback when `CLAUDE_PLUGIN_ROOT` is unset:
 ```bash
-CONFIG_SCRIPT="${CLAUDE_PLUGIN_ROOT:-plugins/council}/scripts/council-config.sh"
+CONFIG_SCRIPT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/plugins/council}/scripts/council-config.sh"
 ```
 
 Check if `$ARGUMENTS` contains the standalone flag token `--global` (not as part of another argument like `--globalfoo`). If present, pass `--global` as an explicit, separate flag argument to script commands (e.g. `show --global`).

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -19,6 +19,7 @@ Configure which external AI consultants are enabled for Council reviews and cons
 /council:config subagent model <model>     # Set deep review model (opus, sonnet)
 /council:config subagent enable <name>     # Enable subagent (claude-deep-review, claude-codebase-context, review-scorer)
 /council:config subagent disable <name>    # Disable subagent
+/council:config timeout <seconds>          # Set per-consultant timeout in seconds
 /council:config detect                     # Probe installed CLIs & active subscriptions
 /council:config init [--auto] [--force]    # Initialize configuration (.dev/council/config.json)
 ```
@@ -72,6 +73,12 @@ Inspect `$ARGUMENTS`:
   ```
   Confirm to user that the quick mode consultant was updated.
 
+- If `$ARGUMENTS` starts with `timeout `:
+  Extract the timeout value in seconds:
+  ```bash
+  "$CONFIG_SCRIPT" set-timeout <seconds> [flags]
+  ```
+  Confirm to user that the operational timeout was updated.
 - If `$ARGUMENTS` starts with `subagent backend `:
   Extract the backend value (`native`, `omp`, `claude-cli`):
   ```bash

--- a/plugins/council/commands/config.md
+++ b/plugins/council/commands/config.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: [Bash, Read, Write, Edit, AskUserQuestion]
+allowed-tools: [Bash, Read, AskUserQuestion]
 description: "Configure Council external consultant enablement based on available subscriptions (Gemini, Codex, GLM, Kimi)"
 ---
 

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -34,9 +34,10 @@ get_project_path() {
 resolve_read_path() {
   target_global=false
   for arg in "$@"; do
-    case "$arg" in
-      *--global*) target_global=true; break ;;
-    esac
+    if [ "$arg" = "--global" ]; then
+      target_global=true
+      break
+    fi
   done
 
   if [ "$target_global" = "true" ]; then
@@ -75,9 +76,10 @@ resolve_read_path() {
 
 resolve_write_path() {
   for arg in "$@"; do
-    case "$arg" in
-      *--global*) echo "$DEFAULT_GLOBAL_PATH"; return 0 ;;
-    esac
+    if [ "$arg" = "--global" ]; then
+      echo "$DEFAULT_GLOBAL_PATH"
+      return 0
+    fi
   done
 
   repo_root="$(get_repo_root)"
@@ -614,12 +616,16 @@ cmd_check_cli() {
     command -v omp >/dev/null 2>&1 || missing+=("omp")
   fi
 
-  sub_backend="$(cmd_get_subagent_backend "$@")"
-  if [ "$sub_backend" = "omp" ]; then
-    command -v omp >/dev/null 2>&1 || missing+=("omp (subagent backend)")
-  elif [ "$sub_backend" = "claude-cli" ]; then
-    command -v claude >/dev/null 2>&1 || missing+=("claude CLI (subagent backend)")
+  enabled_subagents="$(cmd_get_enabled_subagents "$@")"
+  if [ -n "$enabled_subagents" ]; then
+    sub_backend="$(cmd_get_subagent_backend "$@")"
+    if [ "$sub_backend" = "omp" ]; then
+      command -v omp >/dev/null 2>&1 || missing+=("omp (subagent backend)")
+    elif [ "$sub_backend" = "claude-cli" ]; then
+      command -v claude >/dev/null 2>&1 || missing+=("claude CLI (subagent backend)")
+    fi
   fi
+
   if [ ${#missing[@]} -gt 0 ]; then
     echo "Council plugin: missing CLIs for enabled consultants (${enabled_consultants}): ${missing[*]}"
     return 1

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -99,9 +99,9 @@ resolve_write_path() {
   repo_root="$(get_repo_root)"
   proj_path="$(get_project_path)"
 
-  # Security check: refuse to write to a tracked repo file
-  if [ -f "$proj_path" ] && command -v git >/dev/null 2>&1 && git -C "$repo_root" ls-files --error-unmatch -- .dev/council/config.json >/dev/null 2>&1; then
-    echo "Security error: $proj_path is tracked in git repository. Refusing to overwrite tracked file. Use --global or remove from git tracking." >&2
+  # Security check: refuse to write to a tracked repo file (checks git index regardless of working tree existence)
+  if command -v git >/dev/null 2>&1 && git -C "$repo_root" ls-files --error-unmatch -- .dev/council/config.json >/dev/null 2>&1; then
+    echo "Security error: $proj_path is tracked in git repository. Refusing to write to tracked repo file. Use --global or remove from git tracking." >&2
     exit 1
   fi
 
@@ -225,7 +225,7 @@ cmd_detect() {
     has_codex_cli=true
     if [ -n "$OPENAI_API_KEY" ]; then
       has_codex_auth=true
-    elif codex login status 2>&1 | grep -qi "Logged in"; then
+    elif codex login status 2>&1 | grep -qi "Logged in" && ! codex login status 2>&1 | grep -qi "Not logged in"; then
       has_codex_auth=true
     fi
   fi
@@ -631,7 +631,6 @@ cmd_set_timeout() {
 }
 
 cmd_check_cli() {
-  data="$(cmd_read "$@")"
   enabled_consultants="$(cmd_get_enabled "$@")"
 
   need_codex=false

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -16,14 +16,18 @@ set -e
 DEFAULT_GLOBAL_PATH="${HOME}/.config/council/config.json"
 
 get_repo_root() {
-  git rev-parse --show-toplevel 2>/dev/null || pwd
+  if command -v git >/dev/null 2>&1; then
+    git rev-parse --show-toplevel 2>/dev/null || pwd
+  else
+    pwd
+  fi
 }
 
 get_project_path() {
   echo "$(get_repo_root)/.dev/council/config.json"
 }
 
-resolve_config_path() {
+resolve_read_path() {
   target_global=false
   for arg in "$@"; do
     if [ "$arg" = "--global" ]; then
@@ -49,6 +53,20 @@ resolve_config_path() {
   fi
 
   echo "$proj_path"
+}
+
+resolve_write_path() {
+  for arg in "$@"; do
+    if [ "$arg" = "--global" ]; then
+      echo "$DEFAULT_GLOBAL_PATH"
+      return 0
+    fi
+  done
+  get_project_path
+}
+
+resolve_config_path() {
+  resolve_read_path "$@"
 }
 
 default_config() {
@@ -91,11 +109,11 @@ EOF
 }
 
 cmd_path() {
-  resolve_config_path "$@"
+  resolve_read_path "$@"
 }
 
 cmd_exists() {
-  cfg="$(resolve_config_path "$@")"
+  cfg="$(resolve_read_path "$@")"
   if [ -f "$cfg" ]; then
     exit 0
   else
@@ -104,7 +122,7 @@ cmd_exists() {
 }
 
 cmd_read() {
-  cfg="$(resolve_config_path "$@")"
+  cfg="$(resolve_read_path "$@")"
   if [ -f "$cfg" ]; then
     cat "$cfg"
   else
@@ -134,7 +152,7 @@ cmd_write() {
       ;;
   esac
 
-  cfg="$(resolve_config_path "$@")"
+  cfg="$(resolve_write_path "$@")"
   cfg_dir="$(dirname "$cfg")"
   mkdir -p "$cfg_dir"
 
@@ -250,7 +268,7 @@ cmd_init() {
     fi
   done
 
-  cfg="$(resolve_config_path "$@")"
+  cfg="$(resolve_write_path "$@")"
   cfg_dir="$(dirname "$cfg")"
   mkdir -p "$cfg_dir"
 
@@ -290,7 +308,7 @@ cmd_init() {
 }
 
 cmd_show() {
-  cfg="$(resolve_config_path "$@")"
+  cfg="$(resolve_read_path "$@")"
   data="$(cmd_read "$@")"
 
   echo "Council Consultant Configuration"
@@ -379,7 +397,7 @@ cmd_set_quick() {
       ;;
   esac
 
-  cfg="$(resolve_config_path "$@")"
+  cfg="$(resolve_write_path "$@")"
   cfg_dir="$(dirname "$cfg")"
   mkdir -p "$cfg_dir"
 
@@ -442,7 +460,7 @@ cmd_set_subagent_backend() {
       ;;
   esac
 
-  cfg="$(resolve_config_path "$@")"
+  cfg="$(resolve_write_path "$@")"
   cfg_dir="$(dirname "$cfg")"
   mkdir -p "$cfg_dir"
 
@@ -471,7 +489,7 @@ cmd_set_deep_model() {
       ;;
   esac
 
-  cfg="$(resolve_config_path "$@")"
+  cfg="$(resolve_write_path "$@")"
   cfg_dir="$(dirname "$cfg")"
   mkdir -p "$cfg_dir"
 
@@ -510,7 +528,7 @@ cmd_write_subagent() {
       ;;
   esac
 
-  cfg="$(resolve_config_path "$@")"
+  cfg="$(resolve_write_path "$@")"
   cfg_dir="$(dirname "$cfg")"
   mkdir -p "$cfg_dir"
 

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -615,7 +615,7 @@ cmd_set_timeout() {
   val="$1"
   shift || true
   case "$val" in
-    ''|*[!0-9]*)
+    ''|*[!0-9]*|0*)
       echo "Error: timeout must be a positive integer" >&2
       exit 1
       ;;

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -1,0 +1,400 @@
+#!/bin/bash
+# council-config.sh — Manage Council consultant enablement and configuration
+# Usage:
+#   council-config.sh path [--global]
+#   council-config.sh exists [--global]
+#   council-config.sh read [--global]
+#   council-config.sh write <consultant> <true|false> [--global]
+#   council-config.sh detect [--json]
+#   council-config.sh init [--auto] [--global]
+#   council-config.sh show
+#   council-config.sh check-cli
+#   council-config.sh get-enabled
+
+set -e
+
+DEFAULT_GLOBAL_PATH="${HOME}/.config/council/config.json"
+
+get_repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+get_project_path() {
+  echo "$(get_repo_root)/.dev/council/config.json"
+}
+
+resolve_config_path() {
+  target_global=false
+  for arg in "$@"; do
+    if [ "$arg" = "--global" ]; then
+      target_global=true
+      break
+    fi
+  done
+
+  if [ "$target_global" = "true" ]; then
+    echo "$DEFAULT_GLOBAL_PATH"
+    return 0
+  fi
+
+  proj_path="$(get_project_path)"
+  if [ -f "$proj_path" ]; then
+    echo "$proj_path"
+    return 0
+  fi
+
+  if [ -f "$DEFAULT_GLOBAL_PATH" ]; then
+    echo "$DEFAULT_GLOBAL_PATH"
+    return 0
+  fi
+
+  echo "$proj_path"
+}
+
+default_config() {
+  cat <<'EOF'
+{
+  "version": 1,
+  "consultants": {
+    "gemini": {
+      "enabled": true
+    },
+    "codex": {
+      "enabled": true
+    },
+    "glm": {
+      "enabled": false
+    },
+    "kimi": {
+      "enabled": false
+    }
+  },
+  "settings": {
+    "timeout_seconds": 120
+  }
+}
+EOF
+}
+
+cmd_path() {
+  resolve_config_path "$@"
+}
+
+cmd_exists() {
+  cfg="$(resolve_config_path "$@")"
+  if [ -f "$cfg" ]; then
+    exit 0
+  else
+    exit 1
+  fi
+}
+
+cmd_read() {
+  cfg="$(resolve_config_path "$@")"
+  if [ -f "$cfg" ]; then
+    cat "$cfg"
+  else
+    default_config
+  fi
+}
+
+cmd_write() {
+  consultant="$1"
+  state="$2"
+  shift 2 || true
+
+  case "$consultant" in
+    gemini|codex|glm|kimi) ;;
+    *)
+      echo "Error: Unknown consultant '$consultant'. Valid: gemini, codex, glm, kimi" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$state" in
+    true|on|enable|enabled) bool_val="true" ;;
+    false|off|disable|disabled) bool_val="false" ;;
+    *)
+      echo "Error: Invalid state '$state'. Valid: true, false, on, off, enable, disable" >&2
+      exit 1
+      ;;
+  esac
+
+  cfg="$(resolve_config_path "$@")"
+  cfg_dir="$(dirname "$cfg")"
+  mkdir -p "$cfg_dir"
+
+  current="$(cmd_read "$@")"
+  tmp_file="$(mktemp "${cfg_dir}/.config.tmp.XXXXXX")"
+  echo "$current" | jq --arg c "$consultant" --argjson v "$bool_val" \
+    '.consultants[$c].enabled = $v' > "$tmp_file"
+  mv "$tmp_file" "$cfg"
+
+  echo "Updated $consultant enabled=$bool_val in $cfg"
+}
+
+cmd_detect() {
+  json_mode=false
+  if [ "$1" = "--json" ]; then
+    json_mode=true
+  fi
+
+  # Check codex CLI and auth
+  has_codex_cli=false
+  has_codex_auth=false
+  if command -v codex >/dev/null 2>&1; then
+    has_codex_cli=true
+    if [ -n "$OPENAI_API_KEY" ]; then
+      has_codex_auth=true
+    elif codex login status 2>&1 | grep -qi "Logged in"; then
+      has_codex_auth=true
+    fi
+  fi
+
+  # Check omp CLI and providers
+  has_omp_cli=false
+  omp_usage=""
+  if command -v omp >/dev/null 2>&1; then
+    has_omp_cli=true
+    omp_usage="$(omp usage 2>/dev/null || true)"
+  fi
+
+  # Check gemini
+  has_gemini_cli="$has_omp_cli"
+  has_gemini_auth=false
+  if [ "$has_omp_cli" = "true" ]; then
+    if [ -n "$GEMINI_API_KEY" ]; then
+      has_gemini_auth=true
+    elif echo "$omp_usage" | grep -qi "Google Antigravity"; then
+      has_gemini_auth=true
+    fi
+  fi
+
+  # Check glm
+  has_glm_cli="$has_omp_cli"
+  has_glm_auth=false
+  if [ "$has_omp_cli" = "true" ]; then
+    if [ -n "$ZAI_API_KEY" ]; then
+      has_glm_auth=true
+    elif echo "$omp_usage" | grep -qi "Zai"; then
+      has_glm_auth=true
+    fi
+  fi
+
+  # Check kimi
+  has_kimi_cli="$has_omp_cli"
+  has_kimi_auth=false
+  if [ "$has_omp_cli" = "true" ]; then
+    if [ -n "$KIMI_API_KEY" ]; then
+      has_kimi_auth=true
+    elif echo "$omp_usage" | grep -qi "Kimi Code"; then
+      has_kimi_auth=true
+    fi
+  fi
+
+  if [ "$json_mode" = "true" ]; then
+    jq -n \
+      --argjson codex_cli "$has_codex_cli" --argjson codex_auth "$has_codex_auth" \
+      --argjson gemini_cli "$has_gemini_cli" --argjson gemini_auth "$has_gemini_auth" \
+      --argjson glm_cli "$has_glm_cli" --argjson glm_auth "$has_glm_auth" \
+      --argjson kimi_cli "$has_kimi_cli" --argjson kimi_auth "$has_kimi_auth" \
+      '{
+        gemini: { cli: $gemini_cli, auth: $gemini_auth, recommended: ($gemini_cli and $gemini_auth) },
+        codex:  { cli: $codex_cli,  auth: $codex_auth,  recommended: ($codex_cli and $codex_auth) },
+        glm:    { cli: $glm_cli,    auth: $glm_auth,    recommended: ($glm_cli and $glm_auth) },
+        kimi:   { cli: $kimi_cli,   auth: $kimi_auth,   recommended: ($kimi_cli and $kimi_auth) }
+      }'
+  else
+    echo "Detected Consultant Capabilities:"
+    printf "  %-8s | CLI: %-5s | Auth: %-5s | Recommended: %s\n" \
+      "gemini" "$([ "$has_gemini_cli" = "true" ] && echo "yes" || echo "no")" \
+      "$([ "$has_gemini_auth" = "true" ] && echo "yes" || echo "no")" \
+      "$([ "$has_gemini_cli" = "true" ] && [ "$has_gemini_auth" = "true" ] && echo "YES" || echo "no")"
+    printf "  %-8s | CLI: %-5s | Auth: %-5s | Recommended: %s\n" \
+      "codex" "$([ "$has_codex_cli" = "true" ] && echo "yes" || echo "no")" \
+      "$([ "$has_codex_auth" = "true" ] && echo "yes" || echo "no")" \
+      "$([ "$has_codex_cli" = "true" ] && [ "$has_codex_auth" = "true" ] && echo "YES" || echo "no")"
+    printf "  %-8s | CLI: %-5s | Auth: %-5s | Recommended: %s\n" \
+      "glm" "$([ "$has_glm_cli" = "true" ] && echo "yes" || echo "no")" \
+      "$([ "$has_glm_auth" = "true" ] && echo "yes" || echo "no")" \
+      "$([ "$has_glm_cli" = "true" ] && [ "$has_glm_auth" = "true" ] && echo "YES" || echo "no")"
+    printf "  %-8s | CLI: %-5s | Auth: %-5s | Recommended: %s\n" \
+      "kimi" "$([ "$has_kimi_cli" = "true" ] && echo "yes" || echo "no")" \
+      "$([ "$has_kimi_auth" = "true" ] && echo "yes" || echo "no")" \
+      "$([ "$has_kimi_cli" = "true" ] && [ "$has_kimi_auth" = "true" ] && echo "YES" || echo "no")"
+  fi
+}
+
+cmd_init() {
+  auto_mode=false
+  target_global=false
+  for arg in "$@"; do
+    if [ "$arg" = "--auto" ]; then
+      auto_mode=true
+    elif [ "$arg" = "--global" ]; then
+      target_global=true
+    fi
+  done
+
+  cfg="$(resolve_config_path "$@")"
+  cfg_dir="$(dirname "$cfg")"
+  mkdir -p "$cfg_dir"
+
+  if [ "$auto_mode" = "true" ]; then
+    detected="$(cmd_detect --json)"
+    gemini_rec="$(echo "$detected" | jq -r '.gemini.recommended')"
+    codex_rec="$(echo "$detected" | jq -r '.codex.recommended')"
+    glm_rec="$(echo "$detected" | jq -r '.glm.recommended')"
+    kimi_rec="$(echo "$detected" | jq -r '.kimi.recommended')"
+
+    # If none recommended, fallback to gemini & codex default
+    if [ "$gemini_rec" = "false" ] && [ "$codex_rec" = "false" ] && [ "$glm_rec" = "false" ] && [ "$kimi_rec" = "false" ]; then
+      gemini_rec="true"
+      codex_rec="true"
+    fi
+
+    tmp_file="$(mktemp "${cfg_dir}/.config.tmp.XXXXXX")"
+    default_config | jq \
+      --argjson g "$gemini_rec" \
+      --argjson c "$codex_rec" \
+      --argjson gl "$glm_rec" \
+      --argjson k "$kimi_rec" \
+      '.consultants.gemini.enabled = $g |
+       .consultants.codex.enabled = $c |
+       .consultants.glm.enabled = $gl |
+       .consultants.kimi.enabled = $k' > "$tmp_file"
+    mv "$tmp_file" "$cfg"
+    echo "Initialized configuration with auto-detected consultants at $cfg"
+  else
+    if [ ! -f "$cfg" ]; then
+      default_config > "$cfg"
+      echo "Initialized default configuration at $cfg"
+    else
+      echo "Configuration already exists at $cfg"
+    fi
+  fi
+}
+
+cmd_show() {
+  cfg="$(resolve_config_path "$@")"
+  data="$(cmd_read "$@")"
+
+  echo "Council Consultant Configuration"
+  echo "Active config: $cfg"
+  if [ -f "$cfg" ]; then
+    echo "Status: Saved on disk"
+  else
+    echo "Status: Unsaved defaults (run 'council-config.sh init' to save)"
+  fi
+  echo ""
+
+  for c in gemini codex glm kimi; do
+    en="$(echo "$data" | jq -r ".consultants.${c}.enabled // false")"
+    cli_type="omp"
+    model_info=""
+    case "$c" in
+      gemini)
+        model_info="google-antigravity/gemini-3.8-flash"
+        ;;
+      codex)
+        cli_type="codex"
+        model_info="codex CLI"
+        ;;
+      glm)
+        model_info="zai/glm-5.3:max"
+        ;;
+      kimi)
+        model_info="kimi-code/k3"
+        ;;
+    esac
+
+    if [ "$en" = "true" ]; then
+      status_tag="[ENABLED] "
+    else
+      status_tag="[DISABLED]"
+    fi
+    printf "  %-8s %s (via %s: %s)\n" "$c" "$status_tag" "$cli_type" "$model_info"
+  done
+}
+
+cmd_get_enabled() {
+  data="$(cmd_read "$@")"
+  echo "$data" | jq -r '
+    .consultants
+    | to_entries
+    | map(select(.value.enabled == true) | .key)
+    | join(" ")
+  '
+}
+
+cmd_check_cli() {
+  data="$(cmd_read "$@")"
+  enabled_consultants="$(cmd_get_enabled "$@")"
+
+  need_codex=false
+  need_omp=false
+
+  for c in $enabled_consultants; do
+    case "$c" in
+      codex) need_codex=true ;;
+      gemini|glm|kimi) need_omp=true ;;
+    esac
+  done
+
+  missing=()
+  if [ "$need_codex" = "true" ]; then
+    command -v codex >/dev/null 2>&1 || missing+=("codex")
+  fi
+  if [ "$need_omp" = "true" ]; then
+    command -v omp >/dev/null 2>&1 || missing+=("omp")
+  fi
+
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "Council plugin: missing CLIs for enabled consultants (${enabled_consultants}): ${missing[*]}"
+    return 1
+  fi
+  return 0
+}
+
+case "$1" in
+  path)
+    shift
+    cmd_path "$@"
+    ;;
+  exists)
+    shift
+    cmd_exists "$@"
+    ;;
+  read)
+    shift
+    cmd_read "$@"
+    ;;
+  write)
+    shift
+    cmd_write "$@"
+    ;;
+  detect)
+    shift
+    cmd_detect "$@"
+    ;;
+  init)
+    shift
+    cmd_init "$@"
+    ;;
+  show)
+    shift
+    cmd_show "$@"
+    ;;
+  check-cli)
+    shift
+    cmd_check_cli "$@"
+    ;;
+  get-enabled)
+    shift
+    cmd_get_enabled "$@"
+    ;;
+  *)
+    echo "Usage: $0 {path|exists|read|write|detect|init|show|check-cli|get-enabled} [args...]" >&2
+    exit 1
+    ;;
+esac

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -45,19 +45,29 @@ resolve_read_path() {
     return 0
   fi
 
+  repo_root="$(get_repo_root)"
   proj_path="$(get_project_path)"
+  proj_is_tracked=false
+
   if [ -f "$proj_path" ]; then
     # Security check (CWE-15): verify .dev/council/config.json is not tracked in git
     # Only local, untracked runtime configuration is honored from repository trees
-    if command -v git >/dev/null 2>&1 && git ls-files --error-unmatch "$proj_path" >/dev/null 2>&1; then
-      echo "Security warning: $proj_path is tracked in git repository. Ignoring untrusted repo config." >&2
+    if command -v git >/dev/null 2>&1 && git -C "$repo_root" ls-files --error-unmatch -- .dev/council/config.json >/dev/null 2>&1; then
+      proj_is_tracked=true
+      echo "Security warning: .dev/council/config.json is tracked in git repository. Ignoring untrusted repo config." >&2
     else
       echo "$proj_path"
       return 0
     fi
   fi
+
   if [ -f "$DEFAULT_GLOBAL_PATH" ]; then
     echo "$DEFAULT_GLOBAL_PATH"
+    return 0
+  fi
+
+  if [ "$proj_is_tracked" = "true" ]; then
+    echo ""
     return 0
   fi
 
@@ -123,7 +133,7 @@ cmd_path() {
 
 cmd_exists() {
   cfg="$(resolve_read_path "$@")"
-  if [ -f "$cfg" ]; then
+  if [ -n "$cfg" ] && [ -f "$cfg" ]; then
     exit 0
   else
     exit 1
@@ -132,7 +142,7 @@ cmd_exists() {
 
 cmd_read() {
   cfg="$(resolve_read_path "$@")"
-  if [ -f "$cfg" ]; then
+  if [ -n "$cfg" ] && [ -f "$cfg" ]; then
     cat "$cfg"
   else
     default_config

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -70,7 +70,8 @@ default_config() {
     }
   },
   "settings": {
-    "timeout_seconds": 120
+    "timeout_seconds": 120,
+    "quick_consultant": "auto"
   }
 }
 EOF
@@ -315,6 +316,11 @@ cmd_show() {
     fi
     printf "  %-8s %s (via %s: %s)\n" "$c" "$status_tag" "$cli_type" "$model_info"
   done
+
+  quick_cfg="$(echo "$data" | jq -r '.settings.quick_consultant // "auto"')"
+  quick_resolved="$(cmd_get_quick "$@")"
+  echo ""
+  echo "Quick Mode Consultant: $quick_resolved (setting: $quick_cfg)"
 }
 
 cmd_get_enabled() {
@@ -325,6 +331,69 @@ cmd_get_enabled() {
     | map(select(.value.enabled == true) | .key)
     | join(" ")
   '
+}
+cmd_set_quick() {
+  val="$1"
+  shift || true
+
+  case "$val" in
+    auto|gemini|codex|glm|kimi) ;;
+    *)
+      echo "Error: Unknown quick consultant '$val'. Valid: auto, gemini, codex, glm, kimi" >&2
+      exit 1
+      ;;
+  esac
+
+  cfg="$(resolve_config_path "$@")"
+  cfg_dir="$(dirname "$cfg")"
+  mkdir -p "$cfg_dir"
+
+  current="$(cmd_read "$@")"
+  tmp_file="$(mktemp "${cfg_dir}/.config.tmp.XXXXXX")"
+  echo "$current" | jq --arg q "$val" '.settings.quick_consultant = $q' > "$tmp_file"
+  mv "$tmp_file" "$cfg"
+
+  echo "Updated quick_consultant=$val in $cfg"
+}
+
+cmd_get_quick() {
+  data="$(cmd_read "$@")"
+  configured="$(echo "$data" | jq -r '.settings.quick_consultant // "auto"')"
+
+  # Check if explicitly configured consultant is enabled and CLI available
+  if [ "$configured" != "auto" ] && [ -n "$configured" ]; then
+    en="$(echo "$data" | jq -r ".consultants.${configured}.enabled // false")"
+    if [ "$en" = "true" ]; then
+      has_cli=false
+      case "$configured" in
+        codex) command -v codex >/dev/null 2>&1 && has_cli=true ;;
+        gemini|glm|kimi) command -v omp >/dev/null 2>&1 && has_cli=true ;;
+      esac
+      if [ "$has_cli" = "true" ]; then
+        echo "$configured"
+        return 0
+      fi
+    fi
+  fi
+
+  # Auto resolution: iterate enabled consultants in priority order
+  for c in gemini codex glm kimi; do
+    en="$(echo "$data" | jq -r ".consultants.${c}.enabled // false")"
+    if [ "$en" = "true" ]; then
+      has_cli=false
+      case "$c" in
+        codex) command -v codex >/dev/null 2>&1 && has_cli=true ;;
+        gemini|glm|kimi) command -v omp >/dev/null 2>&1 && has_cli=true ;;
+      esac
+      if [ "$has_cli" = "true" ]; then
+        echo "$c"
+        return 0
+      fi
+    fi
+  done
+
+  echo "none"
+  return 0
 }
 
 cmd_check_cli() {
@@ -393,8 +462,16 @@ case "$1" in
     shift
     cmd_get_enabled "$@"
     ;;
+  set-quick)
+    shift
+    cmd_set_quick "$@"
+    ;;
+  get-quick)
+    shift
+    cmd_get_quick "$@"
+    ;;
   *)
-    echo "Usage: $0 {path|exists|read|write|detect|init|show|check-cli|get-enabled} [args...]" >&2
+    echo "Usage: $0 {path|exists|read|write|detect|init|show|check-cli|get-enabled|set-quick|get-quick} [args...]" >&2
     exit 1
     ;;
 esac

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -69,6 +69,19 @@ default_config() {
       "enabled": false
     }
   },
+  "subagents": {
+    "backend": "native",
+    "deep_review_model": "opus",
+    "claude-deep-review": {
+      "enabled": true
+    },
+    "claude-codebase-context": {
+      "enabled": true
+    },
+    "review-scorer": {
+      "enabled": true
+    }
+  },
   "settings": {
     "timeout_seconds": 120,
     "quick_consultant": "auto"
@@ -321,6 +334,28 @@ cmd_show() {
   quick_resolved="$(cmd_get_quick "$@")"
   echo ""
   echo "Quick Mode Consultant: $quick_resolved (setting: $quick_cfg)"
+
+  sub_backend="$(cmd_get_subagent_backend "$@")"
+  deep_mod="$(cmd_get_deep_model "$@")"
+  echo ""
+  echo "Claude Subagent Configuration:"
+  echo "  Backend:           $sub_backend (options: native, omp, claude-cli)"
+  echo "  Deep Review Model: $deep_mod (options: opus, sonnet)"
+  for s in claude-deep-review claude-codebase-context review-scorer; do
+    en="$(echo "$data" | jq -r --arg s "$s" '((.subagents // {})[$s] // {}).enabled as $v | if $v != null then $v else true end')"
+    if [ "$en" = "true" ]; then
+      status_tag="[ENABLED] "
+    else
+      status_tag="[DISABLED]"
+    fi
+    role_desc=""
+    case "$s" in
+      claude-deep-review) role_desc="Layer 2: security, bugs, performance" ;;
+      claude-codebase-context) role_desc="Layer 2: quality, compliance, docs" ;;
+      review-scorer) role_desc="Layer 3: confidence scoring" ;;
+    esac
+    printf "  %-24s %s (%s)\n" "$s" "$status_tag" "$role_desc"
+  done
 }
 
 cmd_get_enabled() {
@@ -395,6 +430,108 @@ cmd_get_quick() {
   echo "none"
   return 0
 }
+cmd_set_subagent_backend() {
+  val="$1"
+  shift || true
+
+  case "$val" in
+    native|omp|claude-cli) ;;
+    *)
+      echo "Error: Unknown subagent backend '$val'. Valid: native, omp, claude-cli" >&2
+      exit 1
+      ;;
+  esac
+
+  cfg="$(resolve_config_path "$@")"
+  cfg_dir="$(dirname "$cfg")"
+  mkdir -p "$cfg_dir"
+
+  current="$(cmd_read "$@")"
+  tmp_file="$(mktemp "${cfg_dir}/.config.tmp.XXXXXX")"
+  echo "$current" | jq --arg b "$val" '.subagents.backend = $b' > "$tmp_file"
+  mv "$tmp_file" "$cfg"
+
+  echo "Updated subagents.backend=$val in $cfg"
+}
+
+cmd_get_subagent_backend() {
+  data="$(cmd_read "$@")"
+  echo "$data" | jq -r '.subagents.backend // "native"'
+}
+
+cmd_set_deep_model() {
+  val="$1"
+  shift || true
+
+  case "$val" in
+    opus|sonnet) ;;
+    *)
+      echo "Error: Unknown deep review model '$val'. Valid: opus, sonnet" >&2
+      exit 1
+      ;;
+  esac
+
+  cfg="$(resolve_config_path "$@")"
+  cfg_dir="$(dirname "$cfg")"
+  mkdir -p "$cfg_dir"
+
+  current="$(cmd_read "$@")"
+  tmp_file="$(mktemp "${cfg_dir}/.config.tmp.XXXXXX")"
+  echo "$current" | jq --arg m "$val" '.subagents.deep_review_model = $m' > "$tmp_file"
+  mv "$tmp_file" "$cfg"
+
+  echo "Updated subagents.deep_review_model=$val in $cfg"
+}
+
+cmd_get_deep_model() {
+  data="$(cmd_read "$@")"
+  echo "$data" | jq -r '.subagents.deep_review_model // "opus"'
+}
+
+cmd_write_subagent() {
+  agent="$1"
+  state="$2"
+  shift 2 || true
+
+  case "$agent" in
+    claude-deep-review|claude-codebase-context|review-scorer) ;;
+    *)
+      echo "Error: Unknown subagent '$agent'. Valid: claude-deep-review, claude-codebase-context, review-scorer" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$state" in
+    true|on|enable|enabled) bool_val="true" ;;
+    false|off|disable|disabled) bool_val="false" ;;
+    *)
+      echo "Error: Invalid state '$state'. Valid: true, false, on, off, enable, disable" >&2
+      exit 1
+      ;;
+  esac
+
+  cfg="$(resolve_config_path "$@")"
+  cfg_dir="$(dirname "$cfg")"
+  mkdir -p "$cfg_dir"
+
+  current="$(cmd_read "$@")"
+  tmp_file="$(mktemp "${cfg_dir}/.config.tmp.XXXXXX")"
+  echo "$current" | jq --arg a "$agent" --argjson v "$bool_val" \
+    '.subagents[$a].enabled = $v' > "$tmp_file"
+  mv "$tmp_file" "$cfg"
+
+  echo "Updated subagent $agent enabled=$bool_val in $cfg"
+}
+
+cmd_get_enabled_subagents() {
+  data="$(cmd_read "$@")"
+  echo "$data" | jq -r '
+    .subagents // {}
+    | to_entries
+    | map(select(.key != "backend" and .key != "deep_review_model" and .value.enabled == true) | .key)
+    | join(" ")
+  '
+}
 
 cmd_check_cli() {
   data="$(cmd_read "$@")"
@@ -418,6 +555,12 @@ cmd_check_cli() {
     command -v omp >/dev/null 2>&1 || missing+=("omp")
   fi
 
+  sub_backend="$(cmd_get_subagent_backend "$@")"
+  if [ "$sub_backend" = "omp" ]; then
+    command -v omp >/dev/null 2>&1 || missing+=("omp (subagent backend)")
+  elif [ "$sub_backend" = "claude-cli" ]; then
+    command -v claude >/dev/null 2>&1 || missing+=("claude CLI (subagent backend)")
+  fi
   if [ ${#missing[@]} -gt 0 ]; then
     echo "Council plugin: missing CLIs for enabled consultants (${enabled_consultants}): ${missing[*]}"
     return 1
@@ -470,8 +613,32 @@ case "$1" in
     shift
     cmd_get_quick "$@"
     ;;
+  set-subagent-backend)
+    shift
+    cmd_set_subagent_backend "$@"
+    ;;
+  get-subagent-backend)
+    shift
+    cmd_get_subagent_backend "$@"
+    ;;
+  set-deep-model)
+    shift
+    cmd_set_deep_model "$@"
+    ;;
+  get-deep-model)
+    shift
+    cmd_get_deep_model "$@"
+    ;;
+  write-subagent)
+    shift
+    cmd_write_subagent "$@"
+    ;;
+  get-enabled-subagents)
+    shift
+    cmd_get_enabled_subagents "$@"
+    ;;
   *)
-    echo "Usage: $0 {path|exists|read|write|detect|init|show|check-cli|get-enabled|set-quick|get-quick} [args...]" >&2
+    echo "Usage: $0 {path|exists|read|write|detect|init|show|check-cli|get-enabled|set-quick|get-quick|set-subagent-backend|get-subagent-backend|set-deep-model|get-deep-model|write-subagent|get-enabled-subagents} [args...]" >&2
     exit 1
     ;;
 esac

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -7,10 +7,18 @@
 #   council-config.sh write <consultant> <true|false> [--global]
 #   council-config.sh detect [--json]
 #   council-config.sh init [--auto] [--global]
-#   council-config.sh show
+#   council-config.sh show [--global]
 #   council-config.sh check-cli
-#   council-config.sh get-enabled
-
+#   council-config.sh get-enabled [--global]
+#   council-config.sh get-available [--global]
+#   council-config.sh get-quick [--global]
+#   council-config.sh set-quick <consultant|auto> [--global]
+#   council-config.sh get-subagent-backend [--global]
+#   council-config.sh set-subagent-backend <native|omp|claude-cli> [--global]
+#   council-config.sh get-deep-model [--global]
+#   council-config.sh set-deep-model <opus|sonnet> [--global]
+#   council-config.sh get-enabled-subagents [--global]
+#   council-config.sh write-subagent <subagent> <true|false> [--global]
 set -e
 
 if ! command -v jq >/dev/null 2>&1; then
@@ -707,7 +715,7 @@ case "$1" in
     cmd_get_enabled_subagents "$@"
     ;;
   *)
-    echo "Usage: $0 {path|exists|read|write|detect|init|show|check-cli|get-enabled|set-quick|get-quick|set-subagent-backend|get-subagent-backend|set-deep-model|get-deep-model|write-subagent|get-enabled-subagents} [args...]" >&2
+    echo "Usage: $0 {path|exists|read|write|detect|init|show|check-cli|get-enabled|get-available|get-quick|set-quick|get-subagent-backend|set-subagent-backend|get-deep-model|set-deep-model|get-enabled-subagents|write-subagent} [args...]" >&2
     exit 1
     ;;
 esac

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -470,37 +470,26 @@ cmd_set_quick() {
 
 cmd_get_quick() {
   data="$(cmd_read "$@")"
+  detected="$(cmd_detect --json)"
   configured="$(echo "$data" | jq -r '.settings.quick_consultant // "auto"')"
 
-  # Check if explicitly configured consultant is enabled and CLI available
+  # Check if explicitly configured consultant is enabled and recommended (CLI + auth)
   if [ "$configured" != "auto" ] && [ -n "$configured" ]; then
     en="$(echo "$data" | jq -r ".consultants.${configured}.enabled // false")"
-    if [ "$en" = "true" ]; then
-      has_cli=false
-      case "$configured" in
-        codex) command -v codex >/dev/null 2>&1 && has_cli=true ;;
-        gemini|glm|kimi) command -v omp >/dev/null 2>&1 && has_cli=true ;;
-      esac
-      if [ "$has_cli" = "true" ]; then
-        echo "$configured"
-        return 0
-      fi
+    rec="$(echo "$detected" | jq -r ".${configured}.recommended // false")"
+    if [ "$en" = "true" ] && [ "$rec" = "true" ]; then
+      echo "$configured"
+      return 0
     fi
   fi
 
-  # Auto resolution: iterate enabled consultants in priority order
+  # Auto resolution: iterate enabled consultants in priority order, checking recommended
   for c in gemini codex glm kimi; do
     en="$(echo "$data" | jq -r ".consultants.${c}.enabled // false")"
-    if [ "$en" = "true" ]; then
-      has_cli=false
-      case "$c" in
-        codex) command -v codex >/dev/null 2>&1 && has_cli=true ;;
-        gemini|glm|kimi) command -v omp >/dev/null 2>&1 && has_cli=true ;;
-      esac
-      if [ "$has_cli" = "true" ]; then
-        echo "$c"
-        return 0
-      fi
+    rec="$(echo "$detected" | jq -r ".${c}.recommended // false")"
+    if [ "$en" = "true" ] && [ "$rec" = "true" ]; then
+      echo "$c"
+      return 0
     fi
   done
 

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -6,7 +6,7 @@
 #   council-config.sh read [--global]
 #   council-config.sh write <consultant> <true|false> [--global]
 #   council-config.sh detect [--json]
-#   council-config.sh init [--auto] [--global]
+#   council-config.sh init [--auto] [--force] [--global]
 #   council-config.sh show [--global]
 #   council-config.sh check-cli
 #   council-config.sh get-enabled [--global]
@@ -161,7 +161,11 @@ cmd_exists() {
 cmd_read() {
   cfg="$(resolve_read_path "$@")"
   if [ -n "$cfg" ] && [ -f "$cfg" ]; then
-    cat "$cfg"
+    def_tmp="$(mktemp "${TMPDIR:-/tmp}/council-def.XXXXXX")"
+    default_config > "$def_tmp"
+    merged="$(jq -n --slurpfile def "$def_tmp" --slurpfile custom "$cfg" '$def[0] * $custom[0]')"
+    rm -f "$def_tmp"
+    echo "$merged"
   else
     default_config
   fi
@@ -296,18 +300,22 @@ cmd_detect() {
 
 cmd_init() {
   auto_mode=false
-  target_global=false
+  force_mode=false
   for arg in "$@"; do
-    if [ "$arg" = "--auto" ]; then
-      auto_mode=true
-    elif [ "$arg" = "--global" ]; then
-      target_global=true
-    fi
+    case "$arg" in
+      --auto) auto_mode=true ;;
+      --force) force_mode=true ;;
+    esac
   done
 
   cfg="$(resolve_write_path "$@")"
   cfg_dir="$(dirname "$cfg")"
   mkdir -p "$cfg_dir"
+
+  if [ -f "$cfg" ] && [ "$force_mode" = "false" ]; then
+    echo "Configuration already exists at $cfg (use --force to overwrite)"
+    return 0
+  fi
 
   if [ "$auto_mode" = "true" ]; then
     detected="$(cmd_detect --json)"
@@ -335,12 +343,8 @@ cmd_init() {
     mv "$tmp_file" "$cfg"
     echo "Initialized configuration with auto-detected consultants at $cfg"
   else
-    if [ ! -f "$cfg" ]; then
-      default_config > "$cfg"
-      echo "Initialized default configuration at $cfg"
-    else
-      echo "Configuration already exists at $cfg"
-    fi
+    default_config > "$cfg"
+    echo "Initialized default configuration at $cfg"
   fi
 }
 

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -34,10 +34,9 @@ get_project_path() {
 resolve_read_path() {
   target_global=false
   for arg in "$@"; do
-    if [ "$arg" = "--global" ]; then
-      target_global=true
-      break
-    fi
+    case "$arg" in
+      *--global*) target_global=true; break ;;
+    esac
   done
 
   if [ "$target_global" = "true" ]; then
@@ -76,12 +75,21 @@ resolve_read_path() {
 
 resolve_write_path() {
   for arg in "$@"; do
-    if [ "$arg" = "--global" ]; then
-      echo "$DEFAULT_GLOBAL_PATH"
-      return 0
-    fi
+    case "$arg" in
+      *--global*) echo "$DEFAULT_GLOBAL_PATH"; return 0 ;;
+    esac
   done
-  get_project_path
+
+  repo_root="$(get_repo_root)"
+  proj_path="$(get_project_path)"
+
+  # Security check: refuse to write to a tracked repo file
+  if [ -f "$proj_path" ] && command -v git >/dev/null 2>&1 && git -C "$repo_root" ls-files --error-unmatch -- .dev/council/config.json >/dev/null 2>&1; then
+    echo "Security error: $proj_path is tracked in git repository. Refusing to overwrite tracked file. Use --global or remove from git tracking." >&2
+    exit 1
+  fi
+
+  echo "$proj_path"
 }
 
 resolve_config_path() {

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -167,7 +167,7 @@ cmd_read() {
   if [ -n "$cfg" ] && [ -f "$cfg" ]; then
     def_tmp="$(mktemp "${TMPDIR:-/tmp}/council-def.XXXXXX")"
     default_config > "$def_tmp"
-    merged="$(jq -n --slurpfile def "$def_tmp" --slurpfile custom "$cfg" '$def[0] * $custom[0]')"
+    merged="$(jq -n --slurpfile def "$def_tmp" --slurpfile custom "$cfg" '$def[0] * ($custom[0] // {})')"
     rm -f "$def_tmp"
     echo "$merged"
   else

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -19,6 +19,8 @@
 #   council-config.sh set-deep-model <opus|sonnet> [--global]
 #   council-config.sh get-enabled-subagents [--global]
 #   council-config.sh write-subagent <subagent> <true|false> [--global]
+#   council-config.sh get-timeout [--global]
+#   council-config.sh set-timeout <seconds> [--global]
 set -e
 
 if ! command -v jq >/dev/null 2>&1; then
@@ -253,7 +255,7 @@ cmd_detect() {
   if [ "$has_omp_cli" = "true" ]; then
     if [ -n "$ZAI_API_KEY" ]; then
       has_glm_auth=true
-    elif echo "$omp_usage" | grep -qi "Zai"; then
+    elif echo "$omp_usage" | grep -Eiq "Zai|Z\.AI"; then
       has_glm_auth=true
     fi
   fi
@@ -419,6 +421,11 @@ cmd_show() {
     esac
     printf "  %-24s %s (%s)\n" "$s" "$status_tag" "$role_desc"
   done
+
+  timeout="$(cmd_get_timeout "$@")"
+  echo ""
+  echo "Operational Settings:"
+  echo "  Timeout:                 ${timeout}s"
 }
 
 cmd_get_enabled() {
@@ -599,6 +606,30 @@ cmd_get_enabled_subagents() {
   '
 }
 
+cmd_get_timeout() {
+  data="$(cmd_read "$@")"
+  echo "$data" | jq -r '.settings.timeout_seconds // 120'
+}
+
+cmd_set_timeout() {
+  val="$1"
+  shift || true
+  case "$val" in
+    ''|*[!0-9]*)
+      echo "Error: timeout must be a positive integer" >&2
+      exit 1
+      ;;
+  esac
+  cfg="$(resolve_write_path "$@")"
+  cfg_dir="$(dirname "$cfg")"
+  mkdir -p "$cfg_dir"
+  current="$(cmd_read "$@")"
+  tmp_file="$(mktemp "${cfg_dir}/.config.tmp.XXXXXX")"
+  echo "$current" | jq --argjson t "$val" '.settings.timeout_seconds = $t' > "$tmp_file"
+  mv "$tmp_file" "$cfg"
+  echo "Updated timeout_seconds=$val in $cfg"
+}
+
 cmd_check_cli() {
   data="$(cmd_read "$@")"
   enabled_consultants="$(cmd_get_enabled "$@")"
@@ -632,7 +663,7 @@ cmd_check_cli() {
   fi
 
   if [ ${#missing[@]} -gt 0 ]; then
-    echo "Council plugin: missing CLIs for enabled consultants (${enabled_consultants}): ${missing[*]}"
+    echo "Council plugin: missing required CLIs: ${missing[*]}"
     return 1
   fi
   return 0
@@ -711,8 +742,16 @@ case "$1" in
     shift
     cmd_get_enabled_subagents "$@"
     ;;
+  get-timeout)
+    shift
+    cmd_get_timeout "$@"
+    ;;
+  set-timeout)
+    shift
+    cmd_set_timeout "$@"
+    ;;
   *)
-    echo "Usage: $0 {path|exists|read|write|detect|init|show|check-cli|get-enabled|get-available|get-quick|set-quick|get-subagent-backend|set-subagent-backend|get-deep-model|set-deep-model|get-enabled-subagents|write-subagent} [args...]" >&2
+    echo "Usage: $0 {path|exists|read|write|detect|init|show|check-cli|get-enabled|get-available|get-quick|set-quick|get-subagent-backend|set-subagent-backend|get-deep-model|set-deep-model|get-enabled-subagents|write-subagent|get-timeout|set-timeout} [args...]" >&2
     exit 1
     ;;
 esac

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -13,6 +13,10 @@
 
 set -e
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: 'jq' is required by council-config.sh but was not found in PATH." >&2
+  exit 1
+fi
 DEFAULT_GLOBAL_PATH="${HOME}/.config/council/config.json"
 
 get_repo_root() {
@@ -43,10 +47,15 @@ resolve_read_path() {
 
   proj_path="$(get_project_path)"
   if [ -f "$proj_path" ]; then
-    echo "$proj_path"
-    return 0
+    # Security check (CWE-15): verify .dev/council/config.json is not tracked in git
+    # Only local, untracked runtime configuration is honored from repository trees
+    if command -v git >/dev/null 2>&1 && git ls-files --error-unmatch "$proj_path" >/dev/null 2>&1; then
+      echo "Security warning: $proj_path is tracked in git repository. Ignoring untrusted repo config." >&2
+    else
+      echo "$proj_path"
+      return 0
+    fi
   fi
-
   if [ -f "$DEFAULT_GLOBAL_PATH" ]; then
     echo "$DEFAULT_GLOBAL_PATH"
     return 0
@@ -385,6 +394,20 @@ cmd_get_enabled() {
     | join(" ")
   '
 }
+
+cmd_get_available() {
+  detected="$(cmd_detect --json)"
+  data="$(cmd_read "$@")"
+  available=()
+  for c in gemini codex glm kimi; do
+    en="$(echo "$data" | jq -r ".consultants.${c}.enabled // false")"
+    rec="$(echo "$detected" | jq -r ".${c}.recommended // false")"
+    if [ "$en" = "true" ] && [ "$rec" = "true" ]; then
+      available+=("$c")
+    fi
+  done
+  echo "${available[*]}"
+}
 cmd_set_quick() {
   val="$1"
   shift || true
@@ -630,6 +653,10 @@ case "$1" in
   get-quick)
     shift
     cmd_get_quick "$@"
+    ;;
+  get-available)
+    shift
+    cmd_get_available "$@"
     ;;
   set-subagent-backend)
     shift

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -225,8 +225,11 @@ cmd_detect() {
     has_codex_cli=true
     if [ -n "$OPENAI_API_KEY" ]; then
       has_codex_auth=true
-    elif codex login status 2>&1 | grep -qi "Logged in" && ! codex login status 2>&1 | grep -qi "Not logged in"; then
-      has_codex_auth=true
+    else
+      codex_status="$(codex login status 2>&1 || true)"
+      if echo "$codex_status" | grep -qi "Logged in" && ! echo "$codex_status" | grep -qi "Not logged in"; then
+        has_codex_auth=true
+      fi
     fi
   fi
 

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -22,8 +22,12 @@
 set -e
 
 if ! command -v jq >/dev/null 2>&1; then
-  echo "Error: 'jq' is required by council-config.sh but was not found in PATH." >&2
-  exit 1
+  if command -v jaq >/dev/null 2>&1; then
+    jq() { jaq "$@"; }
+  else
+    echo "Error: 'jq' (or 'jaq') is required by council-config.sh but was not found in PATH." >&2
+    exit 1
+  fi
 fi
 DEFAULT_GLOBAL_PATH="${HOME}/.config/council/config.json"
 

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -370,10 +370,14 @@ cmd_show() {
   data="$(cmd_read "$@")"
 
   echo "Council Consultant Configuration"
-  echo "Active config: $cfg"
-  if [ -f "$cfg" ]; then
+  if [ -n "$cfg" ] && [ -f "$cfg" ]; then
+    echo "Active config: $cfg"
     echo "Status: Saved on disk"
+  elif [ -z "$cfg" ]; then
+    echo "Active config: None (repo config is git-tracked and ignored for security)"
+    echo "Status: Unsaved defaults (use /council:config --global to configure globally)"
   else
+    echo "Active config: $cfg"
     echo "Status: Unsaved defaults (run 'council-config.sh init' to save)"
   fi
   echo ""

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -637,7 +637,10 @@ cmd_get_enabled_subagents() {
 
 cmd_get_timeout() {
   data="$(cmd_read "$@")"
-  echo "$data" | jq -r '.settings.timeout_seconds // 120'
+  echo "$data" | jq -r '
+    (.settings // {}).timeout_seconds as $t |
+    if ($t | type) == "number" and $t > 0 and ($t | floor) == $t then $t else 120 end
+  '
 }
 
 cmd_set_timeout() {

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -169,9 +169,17 @@ cmd_read() {
   if [ -n "$cfg" ] && [ -f "$cfg" ]; then
     def_tmp="$(mktemp "${TMPDIR:-/tmp}/council-def.XXXXXX")"
     default_config > "$def_tmp"
-    merged="$(jq -n --slurpfile def "$def_tmp" --slurpfile custom "$cfg" '$def[0] * ($custom[0] // {})')"
+    set +e
+    merged="$(jq -n --slurpfile def "$def_tmp" --slurpfile custom "$cfg" '$def[0] * ($custom[0] // {})' 2>/dev/null)"
+    status=$?
+    set -e
     rm -f "$def_tmp"
-    echo "$merged"
+    if [ $status -eq 0 ] && [ -n "$merged" ]; then
+      echo "$merged"
+    else
+      echo "Warning: Failed to parse configuration at $cfg (invalid JSON). Falling back to default settings." >&2
+      default_config
+    fi
   else
     default_config
   fi
@@ -658,7 +666,9 @@ cmd_check_cli() {
   if [ -n "$enabled_subagents" ]; then
     sub_backend="$(cmd_get_subagent_backend "$@")"
     if [ "$sub_backend" = "omp" ]; then
-      command -v omp >/dev/null 2>&1 || missing+=("omp (subagent backend)")
+      if [ "$need_omp" != "true" ]; then
+        command -v omp >/dev/null 2>&1 || missing+=("omp (subagent backend)")
+      fi
     elif [ "$sub_backend" = "claude-cli" ]; then
       command -v claude >/dev/null 2>&1 || missing+=("claude CLI (subagent backend)")
     fi

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -381,20 +381,25 @@ cmd_show() {
   for c in gemini codex glm kimi; do
     en="$(echo "$data" | jq -r ".consultants.${c}.enabled // false")"
     cli_type="omp"
+    has_cli="missing"
     model_info=""
     case "$c" in
       gemini)
         model_info="google-antigravity/gemini-3.8-flash"
+        command -v omp >/dev/null 2>&1 && has_cli="installed"
         ;;
       codex)
         cli_type="codex"
         model_info="codex CLI"
+        command -v codex >/dev/null 2>&1 && has_cli="installed"
         ;;
       glm)
         model_info="zai/glm-5.3:max"
+        command -v omp >/dev/null 2>&1 && has_cli="installed"
         ;;
       kimi)
         model_info="kimi-code/k3"
+        command -v omp >/dev/null 2>&1 && has_cli="installed"
         ;;
     esac
 
@@ -403,7 +408,7 @@ cmd_show() {
     else
       status_tag="[DISABLED]"
     fi
-    printf "  %-8s %s (via %s: %s)\n" "$c" "$status_tag" "$cli_type" "$model_info"
+    printf "  %-8s %s (via %s: %s | CLI: %s)\n" "$c" "$status_tag" "$cli_type" "$model_info" "$has_cli"
   done
 
   quick_cfg="$(echo "$data" | jq -r '.settings.quick_consultant // "auto"')"
@@ -418,7 +423,7 @@ cmd_show() {
   echo "  Backend:           $sub_backend (options: native, omp, claude-cli)"
   echo "  Deep Review Model: $deep_mod (options: opus, sonnet)"
   for s in claude-deep-review claude-codebase-context review-scorer; do
-    en="$(echo "$data" | jq -r --arg s "$s" '((.subagents // {})[$s] // {}).enabled as $v | if $v != null then $v else true end')"
+    en="$(echo "$data" | jq -r --arg s "$s" '((.subagents // {})[$s] // {}).enabled == true')"
     if [ "$en" = "true" ]; then
       status_tag="[ENABLED] "
     else
@@ -437,6 +442,8 @@ cmd_show() {
   echo ""
   echo "Operational Settings:"
   echo "  Timeout:                 ${timeout}s"
+  echo ""
+  echo "Tip: Run 'council-config.sh detect' (or /council:config detect) to verify provider authentication."
 }
 
 cmd_get_enabled() {

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -634,10 +634,11 @@ cmd_get_timeout() {
 }
 
 cmd_set_timeout() {
-  val="$1"
+  raw="$1"
   shift || true
+  val="$(echo "$raw" | sed 's/^0*//')"
   case "$val" in
-    ''|*[!0-9]*|0*)
+    ''|*[!0-9]*)
       echo "Error: timeout must be a positive integer" >&2
       exit 1
       ;;

--- a/plugins/council/scripts/council-config.sh
+++ b/plugins/council/scripts/council-config.sh
@@ -156,7 +156,7 @@ cmd_path() {
 }
 
 cmd_exists() {
-  cfg="$(resolve_read_path "$@")"
+  cfg="$(resolve_read_path "$@" 2>/dev/null)"
   if [ -n "$cfg" ] && [ -f "$cfg" ]; then
     exit 0
   else
@@ -176,8 +176,15 @@ cmd_read() {
     rm -f "$def_tmp"
     if [ $status -eq 0 ] && [ -n "$merged" ]; then
       echo "$merged"
+      return 0
     else
-      echo "Warning: Failed to parse configuration at $cfg (invalid JSON). Falling back to default settings." >&2
+      echo "Warning: Failed to parse configuration at $cfg (invalid JSON)." >&2
+      proj_path="$(get_project_path)"
+      if [ "$cfg" = "$proj_path" ] && [ -f "$DEFAULT_GLOBAL_PATH" ]; then
+        echo "Notice: Falling back to global configuration at $DEFAULT_GLOBAL_PATH." >&2
+        cmd_read --global
+        return 0
+      fi
       default_config
     fi
   else

--- a/plugins/council/scripts/preflight.sh
+++ b/plugins/council/scripts/preflight.sh
@@ -19,7 +19,7 @@ fi
 
 if [ -x "$CONFIG_UTIL" ]; then
   if ! "$CONFIG_UTIL" exists; then
-    echo "Council plugin: no config found. Run /council:config to set active consultants."
+    echo "Council plugin: no active config found (or git-tracked config ignored). Run /council:config to set active consultants."
   fi
   # Check CLIs solely for enabled consultants
   "$CONFIG_UTIL" check-cli || true

--- a/plugins/council/scripts/preflight.sh
+++ b/plugins/council/scripts/preflight.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONFIG_UTIL="${SCRIPT_DIR}/council-config.sh"
 
 if ! command -v jq >/dev/null 2>&1 && ! command -v jaq >/dev/null 2>&1; then
-  echo "Council plugin: missing 'jq' or 'jaq' (required for configuration). Cannot verify configured backend."
+  echo "Council plugin: missing 'jq' or 'jaq' (required for configuration and dynamic dispatch). Skipping config-aware checks."
   missing=()
   for cli in codex omp claude; do
     command -v "$cli" >/dev/null 2>&1 || missing+=("$cli")

--- a/plugins/council/scripts/preflight.sh
+++ b/plugins/council/scripts/preflight.sh
@@ -6,9 +6,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONFIG_UTIL="${SCRIPT_DIR}/council-config.sh"
 
 if ! command -v jq >/dev/null 2>&1; then
-  echo "Council plugin: missing 'jq' (required for configuration). Some consultants may be unavailable."
+  echo "Council plugin: missing 'jq' (required for configuration). Cannot verify configured backend."
   missing=()
-  for cli in codex omp; do
+  for cli in codex omp claude; do
     command -v "$cli" >/dev/null 2>&1 || missing+=("$cli")
   done
   if [ ${#missing[@]} -gt 0 ]; then

--- a/plugins/council/scripts/preflight.sh
+++ b/plugins/council/scripts/preflight.sh
@@ -6,7 +6,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONFIG_UTIL="${SCRIPT_DIR}/council-config.sh"
 
 if ! command -v jq >/dev/null 2>&1 && ! command -v jaq >/dev/null 2>&1; then
-  echo "Council plugin: missing 'jq' or 'jaq' (required for configuration and dynamic dispatch). Configuration-aware checks unavailable."
+  echo "Council plugin: missing 'jq' or 'jaq' (required for configuration and dynamic dispatch). Falling back to basic CLI checks."
+  missing=()
+  for cli in codex omp; do
+    command -v "$cli" >/dev/null 2>&1 || missing+=("$cli")
+  done
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "Council plugin: missing CLIs: ${missing[*]}."
+  fi
   exit 0
 fi
 

--- a/plugins/council/scripts/preflight.sh
+++ b/plugins/council/scripts/preflight.sh
@@ -1,12 +1,25 @@
 #!/bin/bash
 # Council plugin pre-flight check — runs on SessionStart
-# Verifies external CLI tools are available for council consultants
+# Verifies external CLI tools are available for enabled council consultants
 
-missing=()
-for cli in codex omp; do
-  command -v "$cli" >/dev/null 2>&1 || missing+=("$cli")
-done
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_UTIL="${SCRIPT_DIR}/council-config.sh"
 
-if [ ${#missing[@]} -gt 0 ]; then
-  echo "Council plugin: missing CLIs: ${missing[*]}. Some consultants will be unavailable."
+if [ -x "$CONFIG_UTIL" ]; then
+  if ! "$CONFIG_UTIL" exists; then
+    echo "Council plugin: no config found. Run /council:config to set active consultants."
+  fi
+  # Check CLIs solely for enabled consultants
+  "$CONFIG_UTIL" check-cli || true
+else
+  # Fallback if config utility unavailable
+  missing=()
+  for cli in codex omp; do
+    command -v "$cli" >/dev/null 2>&1 || missing+=("$cli")
+  done
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "Council plugin: missing CLIs: ${missing[*]}. Some consultants will be unavailable."
+  fi
 fi
+
+exit 0

--- a/plugins/council/scripts/preflight.sh
+++ b/plugins/council/scripts/preflight.sh
@@ -5,8 +5,8 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONFIG_UTIL="${SCRIPT_DIR}/council-config.sh"
 
-if ! command -v jq >/dev/null 2>&1; then
-  echo "Council plugin: missing 'jq' (required for configuration). Cannot verify configured backend."
+if ! command -v jq >/dev/null 2>&1 && ! command -v jaq >/dev/null 2>&1; then
+  echo "Council plugin: missing 'jq' or 'jaq' (required for configuration). Cannot verify configured backend."
   missing=()
   for cli in codex omp claude; do
     command -v "$cli" >/dev/null 2>&1 || missing+=("$cli")

--- a/plugins/council/scripts/preflight.sh
+++ b/plugins/council/scripts/preflight.sh
@@ -5,6 +5,18 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONFIG_UTIL="${SCRIPT_DIR}/council-config.sh"
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Council plugin: missing 'jq' (required for configuration). Some consultants may be unavailable."
+  missing=()
+  for cli in codex omp; do
+    command -v "$cli" >/dev/null 2>&1 || missing+=("$cli")
+  done
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "Council plugin: missing CLIs: ${missing[*]}."
+  fi
+  exit 0
+fi
+
 if [ -x "$CONFIG_UTIL" ]; then
   if ! "$CONFIG_UTIL" exists; then
     echo "Council plugin: no config found. Run /council:config to set active consultants."

--- a/plugins/council/scripts/preflight.sh
+++ b/plugins/council/scripts/preflight.sh
@@ -6,14 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONFIG_UTIL="${SCRIPT_DIR}/council-config.sh"
 
 if ! command -v jq >/dev/null 2>&1 && ! command -v jaq >/dev/null 2>&1; then
-  echo "Council plugin: missing 'jq' or 'jaq' (required for configuration and dynamic dispatch). Skipping config-aware checks."
-  missing=()
-  for cli in codex omp claude; do
-    command -v "$cli" >/dev/null 2>&1 || missing+=("$cli")
-  done
-  if [ ${#missing[@]} -gt 0 ]; then
-    echo "Council plugin: missing CLIs: ${missing[*]}."
-  fi
+  echo "Council plugin: missing 'jq' or 'jaq' (required for configuration and dynamic dispatch). Configuration-aware checks unavailable."
   exit 0
 fi
 

--- a/plugins/council/scripts/preflight.sh
+++ b/plugins/council/scripts/preflight.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONFIG_UTIL="${SCRIPT_DIR}/council-config.sh"
 
 if ! command -v jq >/dev/null 2>&1 && ! command -v jaq >/dev/null 2>&1; then
-  echo "Council plugin: missing 'jq' or 'jaq' (required for configuration and dynamic dispatch). Falling back to basic CLI checks."
+  echo "Council plugin: missing both 'jq' and 'jaq' (required for configuration and dynamic dispatch). Falling back to basic CLI checks."
   missing=()
   for cli in codex omp; do
     command -v "$cli" >/dev/null 2>&1 || missing+=("$cli")

--- a/plugins/council/scripts/validate-json-output.sh
+++ b/plugins/council/scripts/validate-json-output.sh
@@ -3,6 +3,12 @@
 # Used as a PostToolUse hook on Bash calls from consultant agents
 # Reads hook input JSON from stdin (Claude Code hook protocol)
 
+if ! command -v jq >/dev/null 2>&1; then
+  if command -v jaq >/dev/null 2>&1; then
+    jq() { jaq "$@"; }
+  fi
+fi
+
 INPUT=$(cat)
 TOOL_OUTPUT=$(echo "$INPUT" | jq -r '.tool_output // empty' 2>/dev/null)
 

--- a/plugins/council/scripts/validate-json-output.sh
+++ b/plugins/council/scripts/validate-json-output.sh
@@ -6,6 +6,9 @@
 if ! command -v jq >/dev/null 2>&1; then
   if command -v jaq >/dev/null 2>&1; then
     jq() { jaq "$@"; }
+  else
+    echo "Warning: Neither 'jq' nor 'jaq' found in PATH. Skipping JSON validation hook." >&2
+    exit 0
   fi
 fi
 

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -53,7 +53,7 @@ Backend: native (Task), omp, or claude-cli (configured via /council:config)
 if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
   "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" init --auto
 fi
-"${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" check-cli
+"${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" check-cli || true
 ```
 
 Configure active consultants anytime with `/council:config` (or `/council config`).

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -33,7 +33,7 @@ Layer 1: External Consultants                    Layer 2: Claude Subagents
 (model diversity, same prompt)                   (concern depth, tool access)
 ┌────────┬────────┬────────┬────────┐            ┌──────────────┬──────────────┐
 │ Gemini │ Codex  │ GLM    │ Kimi   │            │ Deep Review  │  Codebase    │
-│  CLI   │  CLI   │  CLI   │  CLI   │            │ (opus)       │  Context     │
+│  CLI   │  CLI   │  CLI   │  CLI   │            │ (opus/sonnet)│  Context     │
 └────────┴────────┴────────┴────────┘            │ Security +   │  (sonnet)    │
          ↓ consensus                              │ Bugs + Perf  │  Quality +   │
                                                   │              │  Compliance +│
@@ -41,8 +41,9 @@ Layer 1: External Consultants                    Layer 2: Claude Subagents
                     ↓                             │              │  Docs        │
               ┌───────────┐                       └──────────────┴──────────────┘
               │  Scorer   │ ← merges + scores all findings   ↓ depth
-              │ (sonnet)  │
+              │ (sonnet)  │   (optional / conditional)
               └───────────┘
+Backend: native (Task), omp, or claude-cli (configured via /council:config)
 ```
 
 ## Pre-Flight & Configuration Check

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -50,10 +50,10 @@ Backend: native (Task), omp, or claude-cli (configured via /council:config)
 
 ```bash
 # Check/initialize config and verify CLIs for enabled consultants
-if ! "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" exists; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" init --auto
+if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
+  "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" init --auto
 fi
-"${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" check-cli
+"${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" check-cli
 ```
 
 Configure active consultants anytime with `/council:config` (or `/council config`).

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -173,14 +173,16 @@ Escalation to full council launches **all enabled** external consultants + enabl
 
 ## Partial Success Modes
 
-| Available | Action |
-|-----------|--------|
-| 4/4 | Full synthesis |
-| 3/4 | Proceed + note |
-| 2/4 | Proceed + warning |
-| 1/4 | Proceed (single consultant) + strong warning |
-| 0/4 | Abort with error |
+Evaluated dynamically against $N_{\text{enabled}}$:
 
+| Condition | Action |
+|-----------|--------|
+| $N_{\text{enabled}} = 0$ | External layer skipped by config. Proceed with Layer 2 (Claude subagents) only |
+| $k = N_{\text{enabled}}$ ($k > 0$) | Full synthesis |
+| $k = 1$ ($N_{\text{enabled}} > 1$) | Proceed in single-consultant mode with strong warning |
+| $k / N_{\text{enabled}} \ge 0.66$ ($k > 1$) | Proceed + note |
+| $k / N_{\text{enabled}} \ge 0.50$ ($k > 1$) | Proceed + warning |
+| $k = 0$ ($N_{\text{enabled}} > 0$) | Abort with error (or Layer 2 fallback if available) |
 ## Structured Response Schema
 
 ```json

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -45,17 +45,17 @@ Layer 1: External Consultants                    Layer 2: Claude Subagents
               └───────────┘
 ```
 
-## Pre-Flight Check
+## Pre-Flight & Configuration Check
 
 ```bash
-# Run before ANY council invocation
-for cli in codex omp; do
-  command -v "$cli" >/dev/null 2>&1 && echo "✓ $cli" || echo "✗ $cli"
-done
+# Check/initialize config and verify CLIs for enabled consultants
+if ! "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" exists; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" init --auto
+fi
+"${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" check-cli
 ```
 
-**Note**: `omp` gates 3 of the 4 external consultants (Gemini, GLM, Kimi). A missing `omp` is not a minor, single-consultant degradation — it drops you straight to 1/4 (Codex only).
-
+Configure active consultants anytime with `/council:config` (or `/council config`).
 ## Expertise Weights
 
 ```
@@ -105,18 +105,15 @@ done
 
 Quick mode (`/council quick`) runs **exactly 2 agents** — no more, no fewer:
 
-| Agent | Model | Role |
-|-------|-------|------|
-| `council:gemini-consultant` | Gemini 3.8 Flash | Fast external perspective |
-| `council:claude-codebase-context` | Sonnet | Codebase-aware depth (native tool access) |
+1. **External Slot**: First enabled external consultant in priority order (`gemini` $\to$ `codex` $\to$ `glm` $\to$ `kimi`). Falls back to `claude-deep-review` (opus) if all external consultants are disabled.
+2. **Codebase Depth Slot**: Always `council:claude-codebase-context` (sonnet) with native tool access.
 
 **Skipped in quick mode** (only run if escalating to full council):
-- `council:codex-consultant`, `council:glm-consultant`, `council:kimi-consultant`
-- `council:claude-deep-review` (opus — reserved for full review)
+- Remaining external consultants
+- `council:claude-deep-review` (unless external slot fell back to it)
 - `council:review-scorer` (not needed unless escalating)
 
-Escalation to full council launches **all** agents (4 external + 2 Claude subagents + scorer).
-
+Escalation to full council launches **all enabled** external consultants + 2 Claude subagents + scorer.
 ## Review Workflow Flow
 
 ```

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -175,16 +175,16 @@ Escalation to full council launches **all enabled** external consultants + enabl
 
 ## Partial Success Modes
 
-Evaluated dynamically against $N_{\text{enabled}}$:
+Evaluated dynamically against `N_enabled`:
 
 | Condition | Action |
 |-----------|--------|
-| $N_{\text{enabled}} = 0$ | External layer skipped by config. Proceed with Layer 2 (Claude subagents) only |
-| $k = N_{\text{enabled}}$ ($k > 0$) | Full synthesis |
-| $k = 1$ ($N_{\text{enabled}} > 1$) | Proceed in single-consultant mode with strong warning |
-| $k / N_{\text{enabled}} \ge 0.66$ ($k > 1$) | Proceed + note |
-| $k / N_{\text{enabled}} \ge 0.50$ ($k > 1$) | Proceed + warning |
-| $k = 0$ ($N_{\text{enabled}} > 0$) | Abort with error (or Layer 2 fallback if available) |
+| N_enabled == 0 | External layer skipped by config. Proceed with Layer 2 (Claude subagents) only |
+| k == N_enabled (k > 0) | Full synthesis |
+| k == 1 (N_enabled > 1) | Proceed in single-consultant mode with strong warning |
+| k / N_enabled >= 0.66 (k > 1) | Proceed + note |
+| k / N_enabled >= 0.50 (k > 1) | Proceed + warning |
+| k == 0 (N_enabled > 0) | Abort with error (or Layer 2 fallback if available) |
 ## Structured Response Schema
 
 ```json

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -49,9 +49,9 @@ Backend: native (Task), omp, or claude-cli (configured via /council:config)
 ## Pre-Flight & Configuration Check
 
 ```bash
-# Check/initialize config and verify CLIs for enabled consultants
+# Check config and verify CLIs for enabled consultants (falls back to defaults if unconfigured)
 if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
-  "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" init --auto
+  echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
 fi
 "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" check-cli || true
 ```

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -103,20 +103,19 @@ Configure active consultants anytime with `/council:config` (or `/council config
 ```
 
 ### Quick Mode Agent Boundary
+Quick mode (`/council quick`) runs **up to 2 agents** — gated by your configuration:
 
-Quick mode (`/council quick`) runs **exactly 2 agents** — no more, no fewer:
+1. **External Slot**: Resolved by `council-config.sh get-quick`, using `settings.quick_consultant`. Set it with `/council:config quick <auto|gemini|codex|glm|kimi>`. Falls back to `council:claude-deep-review` (if enabled in `$ENABLED_SUBAGENTS`) when no external consultant is available.
+2. **Codebase Depth Slot**: `council:claude-codebase-context` (sonnet) with native tool access, launched only if enabled in `$ENABLED_SUBAGENTS`.
 
-1. **External Slot**: Resolved by `council-config.sh get-quick`, using `settings.quick_consultant`. Set it with `/council:config quick <auto|gemini|codex|glm|kimi>`.
-2. **Codebase Depth Slot**: Always `council:claude-codebase-context` (sonnet) with native tool access.
-
-`auto` chooses the first enabled and CLI-available consultant in priority order (`gemini` → `codex` → `glm` → `kimi`). An unavailable explicit choice falls back to `auto`; if none are available, use `council:claude-deep-review`.
+`auto` chooses the first enabled and CLI-available consultant in priority order (`gemini` → `codex` → `glm` → `kimi`). An unavailable explicit choice falls back to `auto`; if none are available, use `council:claude-deep-review` (if enabled).
 
 **Skipped in quick mode** (only run if escalating to full council):
 - Remaining external consultants
-- `council:claude-deep-review` (unless no external slot is available)
+- `council:claude-deep-review` (unless used as external slot substitute)
 - `council:review-scorer` (not needed unless escalating)
 
-Escalation to full council launches **all enabled** external consultants + 2 Claude subagents + scorer.
+Escalation to full council launches **all enabled** external consultants + enabled Claude subagents + scorer (if enabled).
 ## Review Workflow Flow
 
 ```

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -105,12 +105,14 @@ Configure active consultants anytime with `/council:config` (or `/council config
 
 Quick mode (`/council quick`) runs **exactly 2 agents** — no more, no fewer:
 
-1. **External Slot**: First enabled external consultant in priority order (`gemini` $\to$ `codex` $\to$ `glm` $\to$ `kimi`). Falls back to `claude-deep-review` (opus) if all external consultants are disabled.
+1. **External Slot**: Resolved by `council-config.sh get-quick`, using `settings.quick_consultant`. Set it with `/council:config quick <auto|gemini|codex|glm|kimi>`.
 2. **Codebase Depth Slot**: Always `council:claude-codebase-context` (sonnet) with native tool access.
+
+`auto` chooses the first enabled and CLI-available consultant in priority order (`gemini` → `codex` → `glm` → `kimi`). An unavailable explicit choice falls back to `auto`; if none are available, use `council:claude-deep-review`.
 
 **Skipped in quick mode** (only run if escalating to full council):
 - Remaining external consultants
-- `council:claude-deep-review` (unless external slot fell back to it)
+- `council:claude-deep-review` (unless no external slot is available)
 - `council:review-scorer` (not needed unless escalating)
 
 Escalation to full council launches **all enabled** external consultants + 2 Claude subagents + scorer.

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -49,11 +49,13 @@ Backend: native (Task), omp, or claude-cli (configured via /council:config)
 ## Pre-Flight & Configuration Check
 
 ```bash
-# Check config and verify CLIs for enabled consultants (falls back to defaults if unconfigured)
-if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
-  echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
+CONFIG_SCRIPT="${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh"
+if [ -x "$CONFIG_SCRIPT" ]; then
+  if ! "$CONFIG_SCRIPT" exists; then
+    echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
+  fi
+  "$CONFIG_SCRIPT" check-cli || true
 fi
-"${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" check-cli || true
 ```
 
 Configure active consultants anytime with `/council:config` (or `/council config`).

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -33,7 +33,7 @@ Layer 1: External Consultants                    Layer 2: Claude Subagents
 (model diversity, same prompt)                   (concern depth, tool access)
 ┌────────┬────────┬────────┬────────┐            ┌──────────────┬──────────────┐
 │ Gemini │ Codex  │ GLM    │ Kimi   │            │ Deep Review  │  Codebase    │
-│  CLI   │  CLI   │  CLI   │  CLI   │            │ (opus/sonnet)│  Context     │
+│  CLI   │  CLI   │  CLI   │  CLI   │            │ opus/sonnet  │  Context     │
 └────────┴────────┴────────┴────────┘            │ Security +   │  (sonnet)    │
          ↓ consensus                              │ Bugs + Perf  │  Quality +   │
                                                   │              │  Compliance +│

--- a/plugins/council/skills/council/QUICK-REFERENCE.md
+++ b/plugins/council/skills/council/QUICK-REFERENCE.md
@@ -50,7 +50,7 @@ Backend: native (Task), omp, or claude-cli (configured via /council:config)
 
 ```bash
 CONFIG_SCRIPT="${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh"
-if [ -x "$CONFIG_SCRIPT" ]; then
+if [ -x "$CONFIG_SCRIPT" ] && (command -v jq >/dev/null 2>&1 || command -v jaq >/dev/null 2>&1); then
   if ! "$CONFIG_SCRIPT" exists; then
     echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
   fi
@@ -175,16 +175,16 @@ Escalation to full council launches **all enabled** external consultants + enabl
 
 ## Partial Success Modes
 
-Evaluated dynamically against `N_enabled`:
+Evaluated dynamically against `N_available`:
 
 | Condition | Action |
 |-----------|--------|
-| N_enabled == 0 | External layer skipped by config. Proceed with Layer 2 (Claude subagents) only |
-| k == N_enabled (k > 0) | Full synthesis |
-| k == 1 (N_enabled > 1) | Proceed in single-consultant mode with strong warning |
-| k / N_enabled >= 0.66 (k > 1) | Proceed + note |
-| k / N_enabled >= 0.50 (k > 1) | Proceed + warning |
-| k == 0 (N_enabled > 0) | Abort with error (or Layer 2 fallback if available) |
+| N_available == 0 | External layer skipped (or no external tools available). Proceed with Layer 2 (Claude subagents) only |
+| k == N_available (k > 0) | Full synthesis |
+| k == 1 (N_available > 1) | Proceed in single-consultant mode with strong warning |
+| k / N_available >= 0.66 (k > 1) | Proceed + note |
+| k / N_available >= 0.50 (k > 1) | Proceed + warning |
+| k == 0 (N_available > 0) | Abort with error (or Layer 2 fallback if available) |
 ## Structured Response Schema
 
 ```json

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -168,16 +168,16 @@ Use `--blind` when you want to compare Claude's blind opinion against its tool-a
 
 ### Partial Success Modes
 
-Evaluated dynamically against `N_enabled` (the count of enabled external consultants):
+Evaluated dynamically against `N_available` (the count of available external consultants):
 
 | Condition | Action |
 |-----------|--------|
-| N_enabled == 0 | External layer skipped by config. Proceed with Layer 2 (Claude subagents) only |
-| k == N_enabled (k > 0) | Full synthesis |
-| k == 1 (N_enabled > 1) | Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation" |
-| k / N_enabled >= 0.66 (k > 1) | Proceed with note: "[X] consultant unavailable" |
-| k / N_enabled >= 0.50 (k > 1) | Proceed with warning: "Limited council - only k/N_enabled responses" |
-| k == 0 (N_enabled > 0) | Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error |
+| N_available == 0 | External layer skipped by config (or no external tools available). Proceed with Layer 2 (Claude subagents) only |
+| k == N_available (k > 0) | Full synthesis |
+| k == 1 (N_available > 1) | Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation" |
+| k / N_available >= 0.66 (k > 1) | Proceed with note: "[X] consultant unavailable" |
+| k / N_available >= 0.50 (k > 1) | Proceed with warning: "Limited council - only k/N_available responses" |
+| k == 0 (N_available > 0) | Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error |
 ### Structured Response Format
 
 Each consultant MUST return structured output:
@@ -260,7 +260,7 @@ IF layer2_success == 0 AND mode == "full" (Pattern B):
   → Proceed with Layer 1 findings only
 
 IF layer1_success == 0 AND layer2_success > 0 AND mode == "full" (Pattern B):
-  IF N_enabled > 0:
+  IF N_available > 0:
     WARN: "Layer 1 (external consultants) returned no valid results — review lacks model diversity"
   ELSE:
     NOTE: "Layer 1 skipped (all external consultants disabled in config) — review conducted via Layer 2 Claude subagents"
@@ -453,7 +453,7 @@ Quick mode runs **up to 2 agents** — one external consultant (for fast externa
 
 ```text
 1. Log agent selection:
-   "Quick mode: running [selected participants from ENABLED_SUBAGENTS].
+   "Quick mode: running [selected participants from config].
     Skipping remaining consultants and deep-review/scorer."
 
 2. Launch enabled participants in parallel:
@@ -476,7 +476,7 @@ Quick mode runs **up to 2 agents** — one external consultant (for fast externa
 
 ### Pattern D: Adversarial Review (Thorough)
 
-Dynamic team assignment based on enabled external consultants ($N_{\text{enabled}}$):
+Dynamic team assignment based on available external consultants (N_available):
 
 ```text
 1. Assign roles:
@@ -484,11 +484,11 @@ Dynamic team assignment based on enabled external consultants ($N_{\text{enabled
    - Critic: "Find every reason this SHOULD NOT be approved"
 
 2. Team pairing:
-   - If N_enabled >= 4: Split enabled list evenly (first half Advocates, second half Critics)
-   - If N_enabled == 3: Consultant 1 and 2 as Advocates, Consultant 3 as Critic
-   - If N_enabled == 2 (e.g. Gemini + Codex): Consultant 1 as Advocate, Consultant 2 as Critic
-   - If N_enabled == 1: Single external consultant as Advocate, claude-deep-review as Critic
-   - If N_enabled == 0: claude-codebase-context as Advocate, claude-deep-review as Critic
+   - If N_available >= 4: Split available list evenly (first half Advocates, second half Critics)
+   - If N_available == 3: Consultant 1 and 2 as Advocates, Consultant 3 as Critic
+   - If N_available == 2 (e.g. Gemini + Codex): Consultant 1 as Advocate, Consultant 2 as Critic
+   - If N_available == 1: Single external consultant as Advocate, claude-deep-review as Critic
+   - If N_available == 0: claude-codebase-context as Advocate, claude-deep-review as Critic
 3. Present both perspectives
 4. User decides based on trade-offs
 ```

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -39,7 +39,7 @@ If the user explicitly invoked `/council config`, execute the configuration mana
 
 ```bash
 # Verifies required CLIs (codex, omp) only for consultants that are currently enabled
-"${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" check-cli
+"${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" check-cli || true
 ```
 
 If any required CLI is missing, inform the user and proceed with available enabled consultants only.

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -2,7 +2,7 @@
 name: council
 description: Consult external AI council (Gemini 3.8 Flash, Codex, GLM-5.3, Kimi) for thorough reviews and consensus-driven decisions. Use ONLY when explicitly invoked with "/council" or when user says "consult the council", "invoke council", or "council review". Do NOT auto-trigger on generic phrases like "thorough review".
 argument-hint: "[review|plan|adversarial|consensus|quick|config] [security|architecture|bugs|quality] [--blind]"
-allowed-tools: Task, Read, Grep, Glob, Bash, TodoWrite
+allowed-tools: Task, Read, Grep, Glob, Bash, TodoWrite, AskUserQuestion
 user-invocable: true
 context: fork
 agent: general-purpose
@@ -34,7 +34,7 @@ DEEP_MODEL=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-deep-mode
 ENABLED_SUBAGENTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled-subagents)
 ```
 
-If the user explicitly invoked `/council config`, execute the `/council:config` management workflow instead of a review.
+If the user explicitly invoked `/council config`, execute the configuration management commands using `council-config.sh` (via Bash) and `AskUserQuestion` for interactive selections (matching the `/council:config` workflow) instead of running a review.
 ### Step 1: Check CLI Availability for Enabled Consultants
 
 ```bash

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -27,6 +27,11 @@ fi
 
 # Retrieve enabled external consultants (e.g. "gemini codex")
 ENABLED_CONSULTANTS=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-enabled)
+
+# Retrieve subagent settings
+SUBAGENT_BACKEND=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-subagent-backend)
+DEEP_MODEL=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-deep-model)
+ENABLED_SUBAGENTS=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-enabled-subagents)
 ```
 
 If the user explicitly invoked `/council config`, execute the `/council:config` management workflow instead of a review.
@@ -93,13 +98,13 @@ Invoked via CLI. Each brings a different AI model's perspective. All receive the
 
 ### Claude Subagents (Concern Depth — Review Workflows Only)
 
-Invoked via Task tool. Each has a **different concern** and **native codebase access** (Read, Grep, Glob, Bash).
+Each subagent brings deep analysis with configurable execution backends (`native` Task, `omp`, or `claude-cli`) and model selection:
 
-| Agent | Model | Concern | Unique Capability |
-|-------|-------|---------|-------------------|
-| `council:claude-deep-review` | opus | Security, bugs, performance | Traces input paths, follows call chains, profiles hot paths |
-| `council:claude-codebase-context` | sonnet | Quality, compliance, history, documentation | Reads CLAUDE.md rules, greps codebase patterns, runs git blame |
-
+| Agent | Default Model | Configurable Model | Concern | Unique Capability |
+|-------|---------------|-------------------|---------|-------------------|
+| `council:claude-deep-review` | opus | `opus` or `sonnet` | Security, bugs, performance | Traces input paths, follows call chains, profiles hot paths |
+| `council:claude-codebase-context` | sonnet | sonnet | Quality, compliance, history, docs | Reads CLAUDE.md rules, greps codebase patterns, runs git blame |
+| `council:review-scorer` | sonnet | sonnet | Confidence scoring | Uniform 0-100 evaluation across all findings |
 ### Dual-Layer Architecture (Review Workflows)
 
 ```
@@ -135,17 +140,18 @@ Invoked via Task tool. Each has a **different concern** and **native codebase ac
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-Both layers launch **simultaneously** — external consultants (4) and Claude subagents (2) run in parallel.
+Both layers launch **simultaneously** — active external consultants and enabled Claude subagents run in parallel.
+
+### Subagent Execution Backends
+
+Configured via `/council:config subagent backend <type>`:
+- **`native`** (default): Runs via host `Task` tool with full native tool access (`Read`, `Grep`, `Glob`, `Bash`).
+- **`omp`**: Runs via `omp -p --model anthropic/<model>` (with tool access or report sandbox), utilizing your OMP Anthropic quota or profile.
+- **`claude-cli`**: Runs via `claude -p --model <model>` (CLI blind mode, no tool access).
 
 ### Blind Mode (`--blind`)
 
-By default, Claude subagents use native tool access. With the `--blind` flag, they run via `claude -p` CLI instead — losing tool access but reviewing under the same constraints as external consultants.
-
-```
-/council review --blind    → Claude subagents invoked via CLI, no tool access
-/council review            → Claude subagents invoked via Task, full tool access (default)
-```
-
+With the `--blind` flag (or `claude-cli` backend), subagents run without tool access, reviewing under the same constraints as external consultants.
 Use `--blind` when you want to compare Claude's blind opinion against its tool-assisted findings, or when you want all reviewers on equal footing.
 
 ## Timeout and Failure Handling
@@ -348,13 +354,14 @@ Phase 2: Auto-Escalation
   - If all findings are medium/low:
     → No escalation, proceed to scoring
 
-Phase 3: Confidence Scoring
-  - Sonnet scoring agent evaluates all findings (see below)
+Phase 3: Confidence Scoring (Conditional)
+  - If `review-scorer` is enabled in config: Sonnet scoring agent evaluates all findings (see below)
+  - If `review-scorer` is disabled: Skip separate scoring pass; synthesize findings directly using consultant confidence
 ```
 
 ## Confidence Scoring Agent
 
-After consultants return findings (in any `/council review` workflow), a **Sonnet scoring agent** evaluates every finding uniformly.
+After consultants return findings (in any `/council review` workflow), if `review-scorer` is enabled, a **Sonnet scoring agent** evaluates every finding uniformly.
 
 ### Scoring Process
 
@@ -362,7 +369,6 @@ After consultants return findings (in any `/council review` workflow), a **Sonne
 1. Collect ALL findings from ALL consultants
 2. Deduplicate findings that refer to the same issue (merge consultant attributions)
 3. Launch a Sonnet agent (model: sonnet) with the full code context + all findings
-4. The scorer evaluates each finding on a 0-100 confidence scale:
 
    0:   False positive. Does not stand up to scrutiny, or is pre-existing.
    25:  Might be real, but could also be a false positive. Not verified.

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -24,9 +24,9 @@ if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
   echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
 fi
 
-# Retrieve enabled external consultants (e.g. "gemini codex")
+# Retrieve enabled and available external consultants (e.g. "gemini codex")
 ENABLED_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled)
-
+AVAILABLE_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-available)
 # Retrieve subagent settings
 SUBAGENT_BACKEND=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-subagent-backend)
 DEEP_MODEL=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-deep-model)

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -19,28 +19,37 @@ Orchestrate multiple external AI consultants to provide thorough, consensus-driv
 Before invoking any consultant, resolve the active consultant set:
 
 ```bash
-# Check if council config exists (council-config.sh automatically falls back to defaults if unconfigured)
-if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
-  echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
+CONFIG_SCRIPT="${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh"
+if [ -x "$CONFIG_SCRIPT" ] && (command -v jq >/dev/null 2>&1 || command -v jaq >/dev/null 2>&1); then
+  if ! "$CONFIG_SCRIPT" exists; then
+    echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
+  fi
+  ENABLED_CONSULTANTS=$("$CONFIG_SCRIPT" get-enabled)
+  AVAILABLE_CONSULTANTS=$("$CONFIG_SCRIPT" get-available)
+  SUBAGENT_BACKEND=$("$CONFIG_SCRIPT" get-subagent-backend)
+  DEEP_MODEL=$("$CONFIG_SCRIPT" get-deep-model)
+  ENABLED_SUBAGENTS=$("$CONFIG_SCRIPT" get-enabled-subagents)
+else
+  echo "Notice: council-config.sh or jq/jaq unavailable (skill-only install). Using default consultants and models."
+  ENABLED_CONSULTANTS="gemini codex"
+  AVAILABLE_CONSULTANTS=""
+  command -v omp >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} gemini"
+  command -v codex >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} codex"
+  SUBAGENT_BACKEND="native"
+  DEEP_MODEL="opus"
+  ENABLED_SUBAGENTS="claude-deep-review claude-codebase-context review-scorer"
 fi
-
-# Retrieve enabled and available external consultants (e.g. "gemini codex")
-ENABLED_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled)
-AVAILABLE_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-available)
-# Retrieve subagent settings
-SUBAGENT_BACKEND=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-subagent-backend)
-DEEP_MODEL=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-deep-model)
-ENABLED_SUBAGENTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled-subagents)
 ```
 
 If the user explicitly invoked `/council config`, execute the configuration management commands using `council-config.sh` (via Bash) and `AskUserQuestion` for interactive selections (matching the `/council:config` workflow) instead of running a review.
+
 ### Step 1: Check CLI Availability for Enabled Consultants
 
 ```bash
-# Verifies required CLIs (codex, omp) only for consultants that are currently enabled
-"${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" check-cli || true
+if [ -x "$CONFIG_SCRIPT" ]; then
+  "$CONFIG_SCRIPT" check-cli || true
+fi
 ```
-
 If any required CLI is missing, inform the user and proceed with available enabled consultants only.
 
 ## Rate Limit Handling

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -19,10 +19,9 @@ Orchestrate multiple external AI consultants to provide thorough, consensus-driv
 Before invoking any consultant, resolve the active consultant set:
 
 ```bash
-# Check if council config exists (.dev/council/config.json or ~/.config/council/config.json)
+# Check if council config exists (council-config.sh automatically falls back to defaults if unconfigured)
 if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
-  # First-run setup: auto-detect available subscriptions and initialize config
-  "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" init --auto
+  echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
 fi
 
 # Retrieve enabled external consultants (e.g. "gemini codex")

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -495,7 +495,7 @@ Round 2: Cross-examination (share Round 1, ask for critique)
 Round 3: Final synthesis (if still split)
 
 Abort criteria:
-- After Round 2 if 3/4 agree
+- After Round 2 if ≥ 2/3 of available consultants agree
 - After Round 3 regardless of consensus
 - If disagreement is on preferences, not facts
 ```

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -465,7 +465,7 @@ Quick mode runs **up to 2 agents** — one external consultant (for fast externa
 ```
 
 **Use for**: Quick validations, cost-sensitive reviews, time-critical decisions
-**API calls**: Always 2, escalates to full council only if needed
+**API calls**: Up to 2, escalates to full council only if needed
 
 ### Pattern D: Adversarial Review (Thorough)
 

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -168,17 +168,16 @@ Use `--blind` when you want to compare Claude's blind opinion against its tool-a
 
 ### Partial Success Modes
 
-Evaluated dynamically against $N_{\text{enabled}}$ (the count of enabled external consultants):
+Evaluated dynamically against `N_enabled` (the count of enabled external consultants):
 
 | Condition | Action |
 |-----------|--------|
-| $N_{\text{enabled}} = 0$ | External layer skipped by config. Proceed with Layer 2 (Claude subagents) only |
-| $k = N_{\text{enabled}}$ ($k > 0$) | Full synthesis |
-| $k = 1$ ($N_{\text{enabled}} > 1$) | Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation" |
-| $k / N_{\text{enabled}} \ge 0.66$ ($k > 1$) | Proceed with note: "[X] consultant unavailable" |
-| $k / N_{\text{enabled}} \ge 0.50$ ($k > 1$) | Proceed with warning: "Limited council - only $k/$N responses" |
-| $k = 0$ ($N_{\text{enabled}} > 0$) | Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error |
-
+| N_enabled == 0 | External layer skipped by config. Proceed with Layer 2 (Claude subagents) only |
+| k == N_enabled (k > 0) | Full synthesis |
+| k == 1 (N_enabled > 1) | Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation" |
+| k / N_enabled >= 0.66 (k > 1) | Proceed with note: "[X] consultant unavailable" |
+| k / N_enabled >= 0.50 (k > 1) | Proceed with warning: "Limited council - only k/N_enabled responses" |
+| k == 0 (N_enabled > 0) | Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error |
 ### Structured Response Format
 
 Each consultant MUST return structured output:

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -20,31 +20,29 @@ Before invoking any consultant, resolve the active consultant set:
 
 ```bash
 # Check if council config exists (.dev/council/config.json or ~/.config/council/config.json)
-if ! "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" exists; then
+if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
   # First-run setup: auto-detect available subscriptions and initialize config
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" init --auto
+  "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" init --auto
 fi
 
 # Retrieve enabled external consultants (e.g. "gemini codex")
-ENABLED_CONSULTANTS=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-enabled)
+ENABLED_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled)
 
 # Retrieve subagent settings
-SUBAGENT_BACKEND=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-subagent-backend)
-DEEP_MODEL=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-deep-model)
-ENABLED_SUBAGENTS=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-enabled-subagents)
+SUBAGENT_BACKEND=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-subagent-backend)
+DEEP_MODEL=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-deep-model)
+ENABLED_SUBAGENTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled-subagents)
 ```
 
 If the user explicitly invoked `/council config`, execute the `/council:config` management workflow instead of a review.
-
 ### Step 1: Check CLI Availability for Enabled Consultants
 
 ```bash
 # Verifies required CLIs (codex, omp) only for consultants that are currently enabled
-"${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" check-cli
+"${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" check-cli
 ```
 
 If any required CLI is missing, inform the user and proceed with available enabled consultants only.
-
 
 ## Rate Limit Handling
 
@@ -166,12 +164,12 @@ Evaluated dynamically against $N_{\text{enabled}}$ (the count of enabled externa
 
 | Condition | Action |
 |-----------|--------|
-| $k = N_{\text{enabled}}$ ($k > 0$) | Full synthesis |
-| $k / N_{\text{enabled}} \ge 0.66$ | Proceed with note: "[X] consultant unavailable" |
-| $k / N_{\text{enabled}} \ge 0.50$ | Proceed with warning: "Limited council - only $k/$N responses" |
-| $k = 1$ ($N_{\text{enabled}} > 1$) | Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation" |
-| $k = 0$ ($N_{\text{enabled}} > 0$) | Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error |
 | $N_{\text{enabled}} = 0$ | External layer skipped by config. Proceed with Layer 2 (Claude subagents) only |
+| $k = N_{\text{enabled}}$ ($k > 0$) | Full synthesis |
+| $k = 1$ ($N_{\text{enabled}} > 1$) | Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation" |
+| $k / N_{\text{enabled}} \ge 0.66$ ($k > 1$) | Proceed with note: "[X] consultant unavailable" |
+| $k / N_{\text{enabled}} \ge 0.50$ ($k > 1$) | Proceed with warning: "Limited council - only $k/$N responses" |
+| $k = 0$ ($N_{\text{enabled}} > 0$) | Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error |
 
 ### Structured Response Format
 
@@ -431,36 +429,39 @@ See "Dual-Layer Architecture" section above and WORKFLOWS.md Workflow B for deta
 
 ### Pattern C: Parallel Triage (Efficient)
 
-Quick mode runs **exactly 2 agents** — one external consultant (for fast external perspective) and one Claude subagent (for codebase depth):
+Quick mode runs **up to 2 agents** — one external consultant (for fast external perspective) and one Claude subagent (for codebase depth), gated by your configuration:
 
 1. **External Slot Selection** (dynamic based on config):
-   - Run `"${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-quick`.
+   - Run `"${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-quick`.
    - The command resolves the configured `settings.quick_consultant` (`auto`, `gemini`, `codex`, `glm`, or `kimi`) against enabled consultants and installed CLIs.
    - `auto` selects the first enabled consultant in priority order: `gemini` → `codex` → `glm` → `kimi`.
    - An explicit consultant that is disabled or unavailable falls back to the same `auto` resolution.
-   - If resolution returns `none`, use `council:claude-deep-review` (opus) + `council:claude-codebase-context` (sonnet) for all-internal dual-perspective triage.
+   - If resolution returns `none`:
+     - If `claude-deep-review` is enabled in `$ENABLED_SUBAGENTS`: launch `council:claude-deep-review` (model: `$DEEP_MODEL`) as the external substitute.
+     - Otherwise, leave the external slot unassigned.
 
 2. **Codebase Depth Slot**:
-   - Always `council:claude-codebase-context` (sonnet) with native tool access.
+   - Launch `council:claude-codebase-context` (sonnet) only if enabled in `$ENABLED_SUBAGENTS`.
+   - If neither participant is enabled, abort: "No external consultants or Claude subagents enabled for quick triage."
 
 ```text
 1. Log agent selection:
-   "Quick mode: running [selected-external-consultant] + council:claude-codebase-context only.
-    Skipping other consultants and deep-review/scorer."
+   "Quick mode: running [selected participants from ENABLED_SUBAGENTS].
+    Skipping remaining consultants and deep-review/scorer."
 
-2. Launch BOTH in parallel:
-   - [selected external consultant]
-   - council:claude-codebase-context (sonnet)
+2. Launch enabled participants in parallel:
+   - [selected external consultant or claude-deep-review]
+   - council:claude-codebase-context (sonnet, if enabled)
 
-3. Validate both responses (see Response Validation above)
+3. Validate responses (see Response Validation above)
    - Mark invalid responses as failed
    - Drop invalid individual findings
 
-4. If BOTH valid AND confident (>= 0.7) AND no critical findings:
-   → DONE (synthesize dual-perspective report)
+4. If valid AND confident (>= 0.7) AND no critical findings:
+   → DONE (synthesize triage report)
 
-5. If either invalid, confidence < 0.7, disagreement, OR severity == "critical":
-   → Escalate to full council (all enabled external consultants + 2 Claude subagents + scoring)
+5. If invalid, confidence < 0.7, disagreement, OR severity == "critical":
+   → Escalate to full council (all enabled external consultants + enabled Claude subagents + scoring if enabled)
 ```
 
 **Use for**: Quick validations, cost-sensitive reviews, time-critical decisions
@@ -477,10 +478,10 @@ Dynamic team assignment based on enabled external consultants ($N_{\text{enabled
 
 2. Team pairing:
    - If N_enabled >= 4: Split enabled list evenly (first half Advocates, second half Critics)
+   - If N_enabled == 3: Consultant 1 and 2 as Advocates, Consultant 3 as Critic
    - If N_enabled == 2 (e.g. Gemini + Codex): Consultant 1 as Advocate, Consultant 2 as Critic
    - If N_enabled == 1: Single external consultant as Advocate, claude-deep-review as Critic
    - If N_enabled == 0: claude-codebase-context as Advocate, claude-deep-review as Critic
-
 3. Present both perspectives
 4. User decides based on trade-offs
 ```

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: council
 description: Consult external AI council (Gemini 3.8 Flash, Codex, GLM-5.3, Kimi) for thorough reviews and consensus-driven decisions. Use ONLY when explicitly invoked with "/council" or when user says "consult the council", "invoke council", or "council review". Do NOT auto-trigger on generic phrases like "thorough review".
-argument-hint: "[review|plan|adversarial|consensus|quick] [security|architecture|bugs|quality] [--blind]"
+argument-hint: "[review|plan|adversarial|consensus|quick|config] [security|architecture|bugs|quality] [--blind]"
 allowed-tools: Task, Read, Grep, Glob, Bash, TodoWrite
 user-invocable: true
 context: fork
@@ -12,18 +12,34 @@ agent: general-purpose
 
 Orchestrate multiple external AI consultants to provide thorough, consensus-driven feedback on plans, code, and architectural decisions.
 
-## Pre-Flight Checks (MANDATORY)
+## Configuration & Pre-Flight Checks (MANDATORY)
 
-Before invoking any consultant, verify:
+### Step 0: Read Configuration & Active Consultants
+
+Before invoking any consultant, resolve the active consultant set:
 
 ```bash
-# Check CLI availability — codex is independent, but omp now gates 3 of the 4
-# external consultants (Gemini, GLM, Kimi), not just one
-command -v codex >/dev/null 2>&1 || echo "WARN: codex CLI not found"
-command -v omp >/dev/null 2>&1 || echo "WARN: omp CLI not found (needed for Gemini, GLM, and Kimi)"
+# Check if council config exists (.dev/council/config.json or ~/.config/council/config.json)
+if ! "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" exists; then
+  # First-run setup: auto-detect available subscriptions and initialize config
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" init --auto
+fi
+
+# Retrieve enabled external consultants (e.g. "gemini codex")
+ENABLED_CONSULTANTS=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-enabled)
 ```
 
-If any CLI is missing, inform user and proceed with available consultants only.
+If the user explicitly invoked `/council config`, execute the `/council:config` management workflow instead of a review.
+
+### Step 1: Check CLI Availability for Enabled Consultants
+
+```bash
+# Verifies required CLIs (codex, omp) only for consultants that are currently enabled
+"${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" check-cli
+```
+
+If any required CLI is missing, inform the user and proceed with available enabled consultants only.
+
 
 ## Rate Limit Handling
 
@@ -54,12 +70,12 @@ retry_with_backoff() {
 
 ### Staggered Launch (if rate limits frequent)
 
-Instead of all 4 simultaneously, stagger by 5 seconds:
+Instead of launching all active consultants simultaneously, stagger by 5 seconds:
 ```
-t=0s:  Launch Gemini
-t=5s:  Launch Codex
-t=10s: Launch GLM
-t=15s: Launch Kimi
+t=0s:  Launch Consultant 1
+t=5s:  Launch Consultant 2
+t=10s: Launch Consultant 3 (if enabled)
+t=15s: Launch Consultant 4 (if enabled)
 ```
 
 ## Available Consultants
@@ -140,13 +156,16 @@ Use `--blind` when you want to compare Claude's blind opinion against its tool-a
 
 ### Partial Success Modes
 
-| Available | Action |
+Evaluated dynamically against $N_{\text{enabled}}$ (the count of enabled external consultants):
+
+| Condition | Action |
 |-----------|--------|
-| 4/4 | Full synthesis |
-| 3/4 | Proceed with note: "[X] consultant unavailable" |
-| 2/4 | Proceed with warning: "Limited council - only 2 responses" |
-| 1/4 | Proceed in single-consultant mode with strong warning: "Single consultant only — no cross-model validation" |
-| 0/4 | Abort with error: "Council unavailable - all consultants failed" |
+| $k = N_{\text{enabled}}$ ($k > 0$) | Full synthesis |
+| $k / N_{\text{enabled}} \ge 0.66$ | Proceed with note: "[X] consultant unavailable" |
+| $k / N_{\text{enabled}} \ge 0.50$ | Proceed with warning: "Limited council - only $k/$N responses" |
+| $k = 1$ ($N_{\text{enabled}} > 1$) | Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation" |
+| $k = 0$ ($N_{\text{enabled}} > 0$) | Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error |
+| $N_{\text{enabled}} = 0$ | External layer skipped by config. Proceed with Layer 2 (Claude subagents) only |
 
 ### Structured Response Format
 
@@ -230,7 +249,10 @@ IF layer2_success == 0 AND mode == "full" (Pattern B):
   → Proceed with Layer 1 findings only
 
 IF layer1_success == 0 AND layer2_success > 0 AND mode == "full" (Pattern B):
-  WARN: "Layer 1 (external consultants) returned no valid results — review lacks model diversity"
+  IF N_enabled > 0:
+    WARN: "Layer 1 (external consultants) returned no valid results — review lacks model diversity"
+  ELSE:
+    NOTE: "Layer 1 skipped (all external consultants disabled in config) — review conducted via Layer 2 Claude subagents"
   → Proceed with Layer 2 findings only
 ```
 
@@ -403,31 +425,25 @@ See "Dual-Layer Architecture" section above and WORKFLOWS.md Workflow B for deta
 
 ### Pattern C: Parallel Triage (Efficient)
 
-Quick mode runs **exactly these 2 agents**:
+Quick mode runs **exactly 2 agents** — one external consultant (for fast external perspective) and one Claude subagent (for codebase depth):
 
-| Agent | Model | Role | Why included |
-|-------|-------|------|--------------|
-| `council:gemini-consultant` | Gemini 3.8 Flash (`google-antigravity/gemini-3.8-flash`) | Fast external perspective | Fastest external model, broad coverage |
-| `council:claude-codebase-context` | Sonnet | Codebase-aware depth | Native tool access, CLAUDE.md compliance, git history |
+1. **External Slot Selection** (dynamic based on config):
+   - Pick the first enabled external consultant from priority order: `gemini` $\to$ `codex` $\to$ `glm` $\to$ `kimi`.
+   - Default when Gemini is enabled: `council:gemini-consultant` (Gemini 3.8 Flash).
+   - Fallback if Gemini is disabled: Next enabled external consultant (e.g. `council:codex-consultant`).
+   - Fallback if $N_{\text{enabled}} = 0$: Fall back to `council:claude-deep-review` (opus) + `council:claude-codebase-context` (sonnet) for all-internal dual-perspective triage.
 
-Quick mode **does NOT run** these agents:
-
-| Agent | Why skipped |
-|-------|-------------|
-| `council:codex-consultant` | Cost/time — covered by escalation if needed |
-| `council:glm-consultant` | Cost/time — covered by escalation if needed |
-| `council:kimi-consultant` | Cost/time — covered by escalation if needed |
-| `council:claude-deep-review` | Opus cost — reserved for full review |
-| `council:review-scorer` | Not needed unless escalating to full council |
+2. **Codebase Depth Slot**:
+   - Always `council:claude-codebase-context` (sonnet) with native tool access.
 
 ```text
 1. Log agent selection:
-   "Quick mode: running council:gemini-consultant (Flash) + council:claude-codebase-context only.
-    Skipping 5 agents (codex, glm, kimi, claude-deep-review, review-scorer)."
+   "Quick mode: running [selected-external-consultant] + council:claude-codebase-context only.
+    Skipping other consultants and deep-review/scorer."
 
 2. Launch BOTH in parallel:
-   - council:gemini-consultant (omp google-antigravity/gemini-3.8-flash) — fastest external model
-   - council:claude-codebase-context (sonnet) — native codebase access
+   - [selected external consultant]
+   - council:claude-codebase-context (sonnet)
 
 3. Validate both responses (see Response Validation above)
    - Mark invalid responses as failed
@@ -437,7 +453,7 @@ Quick mode **does NOT run** these agents:
    → DONE (synthesize dual-perspective report)
 
 5. If either invalid, confidence < 0.7, disagreement, OR severity == "critical":
-   → Escalate to full council (all 4 external + 2 Claude subagents + scoring)
+   → Escalate to full council (all enabled external consultants + 2 Claude subagents + scoring)
 ```
 
 **Use for**: Quick validations, cost-sensitive reviews, time-critical decisions
@@ -445,19 +461,24 @@ Quick mode **does NOT run** these agents:
 
 ### Pattern D: Adversarial Review (Thorough)
 
-```
+Dynamic team assignment based on enabled external consultants ($N_{\text{enabled}}$):
+
+```text
 1. Assign roles:
    - Advocate: "Find every reason this SHOULD be approved"
    - Critic: "Find every reason this SHOULD NOT be approved"
-2. Pair consultants:
-   - Gemini + Kimi as Advocates
-   - Codex + GLM as Critics
+
+2. Team pairing:
+   - If N_enabled >= 4: Split enabled list evenly (first half Advocates, second half Critics)
+   - If N_enabled == 2 (e.g. Gemini + Codex): Consultant 1 as Advocate, Consultant 2 as Critic
+   - If N_enabled == 1: Single external consultant as Advocate, claude-deep-review as Critic
+   - If N_enabled == 0: claude-codebase-context as Advocate, claude-deep-review as Critic
+
 3. Present both perspectives
 4. User decides based on trade-offs
 ```
 
 **Use for**: Critical decisions, security reviews, architecture choices
-
 ### Pattern E: Sequential Rounds (Consensus)
 
 ```
@@ -494,10 +515,8 @@ Example for security finding:
 ## Council Review Summary
 
 ### Pre-Flight Status
-- Gemini: ✓ Available
-- Codex: ✓ Available
-- GLM: ✗ Timeout (proceeded with 3/4)
-- Kimi: ✓ Available
+(Lists status for each enabled external consultant from config, plus Claude subagents)
+- [Consultant]: ✓ Available | ✗ Unavailable / Timeout
 
 ### Consensus (All Available Agree)
 - [Weighted findings where all agree]
@@ -506,9 +525,10 @@ Example for security finding:
 - [Findings with strong weighted agreement]
 
 ### Divergent Views
-| Finding | Gemini | Codex | GLM | Kimi | Weighted |
-|---------|--------|-------|-----|------|----------|
-| [Issue] | [View] | [View] | N/A | [View] | [Score] |
+Column headers adapt to currently enabled consultants:
+| Finding | [Consultant 1] | [Consultant 2] | ... | Weighted |
+|---------|----------------|----------------|-----|----------|
+| [Issue] | [View]         | [View]         | ... | [Score]  |
 
 ### Critical Issues (Any Consultant, severity=critical)
 - [Always include - err on caution]
@@ -518,10 +538,9 @@ Example for security finding:
 2. [Include dissenting rationale for user decision]
 
 ### Confidence Level
-- High (4/4 available, weighted agreement > 0.8): ✓
-- Medium (2-3/4 available OR agreement 0.6-0.8): ~
-- Low (1/4 available OR agreement < 0.6): User must decide
-
+- High (all enabled available, weighted agreement > 0.8): ✓
+- Medium (majority available OR agreement 0.6-0.8): ~
+- Low (<=1 available OR agreement < 0.6): User must decide
 ### Rate Limit Status
 - Retries: 0
 - Skipped due to limits: None

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -428,10 +428,11 @@ See "Dual-Layer Architecture" section above and WORKFLOWS.md Workflow B for deta
 Quick mode runs **exactly 2 agents** — one external consultant (for fast external perspective) and one Claude subagent (for codebase depth):
 
 1. **External Slot Selection** (dynamic based on config):
-   - Pick the first enabled external consultant from priority order: `gemini` $\to$ `codex` $\to$ `glm` $\to$ `kimi`.
-   - Default when Gemini is enabled: `council:gemini-consultant` (Gemini 3.8 Flash).
-   - Fallback if Gemini is disabled: Next enabled external consultant (e.g. `council:codex-consultant`).
-   - Fallback if $N_{\text{enabled}} = 0$: Fall back to `council:claude-deep-review` (opus) + `council:claude-codebase-context` (sonnet) for all-internal dual-perspective triage.
+   - Run `"${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-quick`.
+   - The command resolves the configured `settings.quick_consultant` (`auto`, `gemini`, `codex`, `glm`, or `kimi`) against enabled consultants and installed CLIs.
+   - `auto` selects the first enabled consultant in priority order: `gemini` → `codex` → `glm` → `kimi`.
+   - An explicit consultant that is disabled or unavailable falls back to the same `auto` resolution.
+   - If resolution returns `none`, use `council:claude-deep-review` (opus) + `council:claude-codebase-context` (sonnet) for all-internal dual-perspective triage.
 
 2. **Codebase Depth Slot**:
    - Always `council:claude-codebase-context` (sonnet) with native tool access.

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -37,7 +37,11 @@ else
   command -v codex >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} codex"
   SUBAGENT_BACKEND="native"
   DEEP_MODEL="opus"
-  ENABLED_SUBAGENTS="claude-deep-review claude-codebase-context review-scorer"
+  if [ -d "${CLAUDE_SKILL_DIR}/../../agents" ]; then
+    ENABLED_SUBAGENTS="claude-deep-review claude-codebase-context review-scorer"
+  else
+    ENABLED_SUBAGENTS=""
+  fi
 fi
 ```
 

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -46,7 +46,7 @@ If the user explicitly invoked `/council config`, execute the configuration mana
 ### Step 1: Check CLI Availability for Enabled Consultants
 
 ```bash
-if [ -x "$CONFIG_SCRIPT" ]; then
+if [ -x "$CONFIG_SCRIPT" ] && (command -v jq >/dev/null 2>&1 || command -v jaq >/dev/null 2>&1); then
   "$CONFIG_SCRIPT" check-cli || true
 fi
 ```

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -50,6 +50,7 @@ If the user explicitly invoked `/council config`, execute the configuration mana
 ### Step 1: Check CLI Availability for Enabled Consultants
 
 ```bash
+CONFIG_SCRIPT="${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh"
 if [ -x "$CONFIG_SCRIPT" ] && (command -v jq >/dev/null 2>&1 || command -v jaq >/dev/null 2>&1); then
   "$CONFIG_SCRIPT" check-cli || true
 fi

--- a/plugins/council/skills/council/SKILL.md
+++ b/plugins/council/skills/council/SKILL.md
@@ -29,6 +29,7 @@ if [ -x "$CONFIG_SCRIPT" ] && (command -v jq >/dev/null 2>&1 || command -v jaq >
   SUBAGENT_BACKEND=$("$CONFIG_SCRIPT" get-subagent-backend)
   DEEP_MODEL=$("$CONFIG_SCRIPT" get-deep-model)
   ENABLED_SUBAGENTS=$("$CONFIG_SCRIPT" get-enabled-subagents)
+  TIMEOUT=$("$CONFIG_SCRIPT" get-timeout)
 else
   echo "Notice: council-config.sh or jq/jaq unavailable (skill-only install). Using default consultants and models."
   ENABLED_CONSULTANTS="gemini codex"
@@ -37,6 +38,7 @@ else
   command -v codex >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} codex"
   SUBAGENT_BACKEND="native"
   DEEP_MODEL="opus"
+  TIMEOUT="120"
   if [ -d "${CLAUDE_SKILL_DIR}/../../agents" ]; then
     ENABLED_SUBAGENTS="claude-deep-review claude-codebase-context review-scorer"
   else

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -460,12 +460,12 @@ fi
 
 1. **Assign Adversarial Roles Dynamically**
 
-   Pairings adapt based on enabled external consultants ($N_{\text{enabled}}$):
-   - **$N_{\text{enabled}} \ge 4$**: Split enabled list evenly (first half Advocates, second half Critics)
-   - **$N_{\text{enabled}} == 3$**: Consultant 1 and 2 as Advocates, Consultant 3 as Critic
-   - **$N_{\text{enabled}} == 2$** (e.g. Gemini + Codex): Consultant 1 as Advocate, Consultant 2 as Critic
-   - **$N_{\text{enabled}} == 1$**: Single external consultant as Advocate, `claude-deep-review` as Critic
-   - **$N_{\text{enabled}} == 0$**: `claude-codebase-context` as Advocate, `claude-deep-review` as Critic
+   Pairings adapt based on available external consultants (N_available):
+   - **N_available >= 4**: Split available list evenly (first half Advocates, second half Critics)
+   - **N_available == 3**: Consultant 1 and 2 as Advocates, Consultant 3 as Critic
+   - **N_available == 2** (e.g. Gemini + Codex): Consultant 1 as Advocate, Consultant 2 as Critic
+   - **N_available == 1**: Single external consultant as Advocate, `claude-deep-review` as Critic
+   - **N_available == 0**: `claude-codebase-context` as Advocate, `claude-deep-review` as Critic
 2. **Frame Prompts**
    ```
    ADVOCATES:

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -331,20 +331,22 @@ echo "Enabled consultants: ${ENABLED_CONSULTANTS}"
 
 ### Step-by-Step
 
-1. **Log Agent Selection and Launch Both in Parallel**
+1. **Resolve Quick Consultant and Launch Both in Parallel**
 
-   Quick mode runs exactly 2 agents: one external consultant (selected dynamically from enabled consultants in priority order `gemini` $\to$ `codex` $\to$ `glm` $\to$ `kimi`, or `claude-deep-review` if all external are disabled) plus `council:claude-codebase-context`.
+   Run `"${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-quick`. This resolves `settings.quick_consultant` against enabled consultants and installed CLIs. An explicit unavailable or disabled choice falls back to `auto`, which uses `gemini` → `codex` → `glm` → `kimi`. If it returns `none`, use `council:claude-deep-review` as the external-slot substitute.
+
+   Quick mode runs exactly 2 agents: the resolved external consultant (or `council:claude-deep-review` when none is available) plus `council:claude-codebase-context`.
 
    Log the selection at start:
    ```text
-   "Quick mode: running [selected-external-consultant] + council:claude-codebase-context only.
-    Skipping remaining consultants and deep-review/scorer."
+   "Quick mode: running [selected-consultant] + council:claude-codebase-context only.
+    Skipping remaining consultants and scorer."
    ```
 
    Launch simultaneously:
 
    ```text
-   Task(council:gemini-consultant):
+   Task(council:[selected-consultant]-consultant, timeout=120s):
    "Quick review of [artifact]. Return JSON with:
    - consultant: your name (e.g. 'gemini')
    - success: true

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -557,15 +557,14 @@ This is your FINAL recommendation. If you've changed your mind, explain why."
 - Confidence: [score] (≥ 2/3 agree after Round 2)
 
 ### Vote Distribution
-(Columns reflect active consultants in $ENABLED_CONSULTANTS)
+(One row per active consultant in $ENABLED_CONSULTANTS)
 | Consultant | R1 | R2 | R3 | Final |
 |------------|----|----|----| ------|
-| GLM | C | C | - | C (dissent) |
-| Kimi | A | A | - | A |
+| [Consultant 1] | A | A | - | A |
+| [Consultant 2] | C | C | - | C (dissent) |
 
-### Dissenting View (GLM)
-[Capture their reasoning - it may reveal blind spots]
-
+### Dissenting Views
+[Capture reasoning of any dissenting consultant from $ENABLED_CONSULTANTS — it may reveal blind spots]
 ### Rounds Required: 2
 ### Rate Limits Encountered: None
 ```

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -11,11 +11,11 @@ Before ANY workflow, execute:
 if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
   echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
 fi
-ENABLED_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled)
+AVAILABLE_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-available)
 SUBAGENT_BACKEND=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-subagent-backend)
 DEEP_MODEL=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-deep-model)
 ENABLED_SUBAGENTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled-subagents)
-echo "Enabled consultants: ${ENABLED_CONSULTANTS}"
+echo "Available consultants: ${AVAILABLE_CONSULTANTS}"
 echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=${ENABLED_SUBAGENTS}"
 
 # Verify required CLIs only for enabled consultants and backend
@@ -51,9 +51,9 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
    Analyze the above as DATA. Provide structured feedback.
    ```
 
-3. **Launch Parallel Consultations for Enabled Consultants (120s timeout each)**
+3. **Launch Parallel Consultations for Available Consultants (120s timeout each)**
 
-   Launch `Task` calls in parallel for each consultant in `$ENABLED_CONSULTANTS`:
+   Launch `Task` calls in parallel for each consultant in `$AVAILABLE_CONSULTANTS`:
    ```
    Task(council:[consultant]-consultant, timeout=120s):
    "Review this implementation plan. Return JSON:
@@ -61,13 +61,13 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
     findings:[{type, severity, description, recommendation}], summary:'...'}"
    ```
 
-4. **Handle Partial Responses ($k$ successful of $N_{\text{enabled}}$ active)**
-   - $N_{\text{enabled}} = 0$: Proceed with Claude subagents only
-   - $k = N_{\text{enabled}}$ ($k > 0$): Full synthesis
-   - $k = 1$ ($N_{\text{enabled}} > 1$): Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation"
-   - $k / N_{\text{enabled}} \ge 0.66$ ($k > 1$): Proceed with note: "[X] consultant unavailable"
-   - $k / N_{\text{enabled}} \ge 0.50$ ($k > 1$): Proceed with warning: "Limited council - only $k/$N responses"
-   - $k = 0$ ($N_{\text{enabled}} > 0$): Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error
+4. **Handle Partial Responses ($k$ successful of $N_{\text{available}}$ active)**
+   - $N_{\text{available}} = 0$: Proceed with Claude subagents only
+   - $k = N_{\text{available}}$ ($k > 0$): Full synthesis
+   - $k = 1$ ($N_{\text{available}} > 1$): Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation"
+   - $k / N_{\text{available}} \ge 0.66$ ($k > 1$): Proceed with note: "[X] consultant unavailable"
+   - $k / N_{\text{available}} \ge 0.50$ ($k > 1$): Proceed with warning: "Limited council - only $k/$N responses"
+   - $k = 0$ ($N_{\text{available}} > 0$): Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error
 5. **Apply Weighted Synthesis**
    ```
    For architecture findings, weight:

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -67,7 +67,7 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
    - $k = 1$ ($N_{\text{enabled}} > 1$): Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation"
    - $k / N_{\text{enabled}} \ge 0.66$ ($k > 1$): Proceed with note: "[X] consultant unavailable"
    - $k / N_{\text{enabled}} \ge 0.50$ ($k > 1$): Proceed with warning: "Limited council - only $k/$N responses"
-   - $k = 0$ ($N_{\text{enabled}} > 0$): Abort with error: "Council unavailable - all active consultants failed"
+   - $k = 0 ($N_{\text{enabled}} > 0$): Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error
 5. **Apply Weighted Synthesis**
    ```
    For architecture findings, weight:
@@ -505,7 +505,7 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
 ### Round 1: Independent Opinions
 
 ```
-Task(all consultants):
+Task(active consultants in $ENABLED_CONSULTANTS):
 "We need to decide: [decision question]
 
 Options:
@@ -521,12 +521,9 @@ Return: {choice: 'A|B|C', confidence: 0-1, reasoning: '...'}"
 ### Round 2: Cross-Examination
 
 ```
-Task(all consultants):
+Task(active consultants in $ENABLED_CONSULTANTS):
 "Round 1 results:
-- Gemini chose [X] because [reason]
-- Codex chose [Y] because [reason]
-- GLM chose [W] because [reason]
-- Kimi chose [Z] because [reason]
+[summary of choices and reasoning from active consultants]
 
 Review these perspectives:
 1. Which reasoning do you find most compelling?
@@ -542,7 +539,7 @@ Review these perspectives:
 - Disagreement is on preferences, not facts
 - More rounds won't produce new information
 ```
-Task(all consultants):
+Task(active consultants in $ENABLED_CONSULTANTS):
 "The council remains split after cross-examination.
 
 Agreement: [list]
@@ -557,13 +554,12 @@ This is your FINAL recommendation. If you've changed your mind, explain why."
 ## Consensus Result: [Topic]
 
 ### Final Recommendation: [Option X]
-- Confidence: 0.78 (3/4 agree after Round 2)
+- Confidence: [score] (≥ 2/3 agree after Round 2)
 
 ### Vote Distribution
+(Columns reflect active consultants in $ENABLED_CONSULTANTS)
 | Consultant | R1 | R2 | R3 | Final |
 |------------|----|----|----| ------|
-| Gemini | A | A | - | A |
-| Codex | B | A | - | A |
 | GLM | C | C | - | C (dissent) |
 | Kimi | A | A | - | A |
 

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -12,11 +12,15 @@ if ! "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" exists; then
 fi
 
 ENABLED_CONSULTANTS=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-enabled)
+SUBAGENT_BACKEND=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-subagent-backend)
+DEEP_MODEL=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-deep-model)
+ENABLED_SUBAGENTS=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-enabled-subagents)
 echo "Enabled consultants: ${ENABLED_CONSULTANTS}"
+echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=${ENABLED_SUBAGENTS}"
 
-# Verify required CLIs only for enabled consultants
+# Verify required CLIs only for enabled consultants and backend
 "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" check-cli || {
-  echo "WARN: Missing CLIs for some enabled consultants. Proceeding with available ones."
+  echo "WARN: Missing CLIs for some enabled consultants/backend. Proceeding with available ones."
 }
 ```
 
@@ -189,21 +193,26 @@ echo "Enabled consultants: ${ENABLED_CONSULTANTS}"
 
    **Layer 2: Claude Subagents (parallel, 120s timeout each)**
 
-   Each runs a DIFFERENT concern domain with native tool access:
-   ```
-   Task(council:claude-deep-review, model=opus):     "Review for security, bugs, and performance. Trace input paths, follow call chains, profile hot paths."
-   Task(council:claude-codebase-context, model=sonnet): "Check quality patterns, CLAUDE.md compliance, git history, and documentation. Compare against codebase conventions."
-   ```
+   Launches enabled subagents from `$ENABLED_SUBAGENTS` via `$SUBAGENT_BACKEND`:
 
-   If `--blind` flag is set, invoke Claude subagents via CLI instead:
-   ```bash
-   claude -p "Review for security, bugs, and performance: [diff content]"
-   claude -p "Review for quality, compliance, history, and documentation: [diff content]"
-   # No tool access, same constraints as external consultants
-   ```
+   - **`native`** backend (default):
+     ```text
+     # Deep review uses configured model ($DEEP_MODEL: opus or sonnet)
+     Task(council:claude-deep-review, model=$DEEP_MODEL): "Review for security, bugs, performance."
+     Task(council:claude-codebase-context, model=sonnet): "Check quality, CLAUDE.md, git history, docs."
+     ```
+   - **`omp`** backend (utilizes OMP Anthropic quota or profile):
+     ```bash
+     omp -p --model "anthropic/claude-${DEEP_MODEL}" "Review for security, bugs, performance @\"$sandbox/diff\""
+     omp -p --model "anthropic/claude-sonnet" "Check quality, compliance, git history @\"$sandbox/diff\""
+     ```
+   - **`claude-cli`** backend (CLI blind mode, or `--blind` flag):
+     ```bash
+     claude -p --model "$DEEP_MODEL" "Review for security, bugs, performance: [diff]"
+     claude -p --model "sonnet" "Check quality, compliance, history: [diff]"
+     ```
 
-   All 6 agents (4 external + 2 Claude) run simultaneously.
-   Each MUST return findings with mandatory `location` field (`file:line`).
+   All active external consultants and enabled Claude subagents run simultaneously.
 
 8. **Auto-Escalation (Broad Pass Only)**
 
@@ -269,9 +278,9 @@ echo "Enabled consultants: ${ENABLED_CONSULTANTS}"
 
     Only findings from validated, successful responses proceed to scoring.
 
-11. **Confidence Scoring (Sonnet Agent)**
+11. **Confidence Scoring (Conditional)**
 
-    After all findings are validated and merged:
+    If `review-scorer` is enabled in `$ENABLED_SUBAGENTS`:
     ```
     1. Deduplicate findings referring to the same issue (across both layers)
     2. Launch council:review-scorer (Sonnet) with full context + all findings
@@ -281,8 +290,8 @@ echo "Enabled consultants: ${ENABLED_CONSULTANTS}"
        - Cross-layer corroboration
     4. Filter: only findings >= 80 appear in final report
     ```
-
-    See SKILL.md "Confidence Scoring Agent" for scorer prompt template and rubric.
+    If `review-scorer` is disabled in config:
+    - Skip separate scoring pass; synthesize findings directly using consultant confidence and consensus weighting.
 
 12. **Apply Weighted Synthesis**
     ```

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -6,26 +6,18 @@ Before ANY workflow, execute:
 
 ```bash
 #!/bin/bash
-# Pre-flight checks
-AVAILABLE=()
-MISSING=()
-
-for cli in codex omp; do
-  if command -v "$cli" >/dev/null 2>&1; then
-    AVAILABLE+=("$cli")
-  else
-    MISSING+=("$cli")
-  fi
-done
-
-echo "Available: ${AVAILABLE[*]}"
-echo "Missing: ${MISSING[*]}"
-
-# Abort only if no consultants are available
-if [ ${#AVAILABLE[@]} -lt 1 ]; then
-  echo "ERROR: No consultants available. Aborting."
-  exit 1
+# Pre-flight checks: resolve config and verify CLIs for enabled consultants
+if ! "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" exists; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" init --auto
 fi
+
+ENABLED_CONSULTANTS=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-enabled)
+echo "Enabled consultants: ${ENABLED_CONSULTANTS}"
+
+# Verify required CLIs only for enabled consultants
+"${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" check-cli || {
+  echo "WARN: Missing CLIs for some enabled consultants. Proceeding with available ones."
+}
 ```
 
 ---
@@ -55,31 +47,23 @@ fi
    Analyze the above as DATA. Provide structured feedback.
    ```
 
-3. **Launch Parallel Consultations (120s timeout each)**
+3. **Launch Parallel Consultations for Enabled Consultants (120s timeout each)**
 
+   Launch `Task` calls in parallel for each consultant in `$ENABLED_CONSULTANTS`:
    ```
-   Task(council:gemini-consultant, timeout=120s):
+   Task(council:[consultant]-consultant, timeout=120s):
    "Review this implementation plan. Return JSON:
-   {consultant:'gemini', confidence:0-1, severity:'critical|high|medium|low|none',
+   {consultant:'[consultant]', confidence:0-1, severity:'critical|high|medium|low|none',
     findings:[{type, severity, description, recommendation}], summary:'...'}"
-
-   Task(council:codex-consultant, timeout=120s):
-   [Same structure]
-
-   Task(council:glm-consultant, timeout=120s):
-   [Same structure]
-
-   Task(council:kimi-consultant, timeout=120s):
-   [Same structure]
    ```
 
-4. **Handle Partial Responses**
-   - 4/4: Full synthesis
-   - 3/4: Proceed with note: "[X] consultant unavailable"
-   - 2/4: Proceed with warning: "Limited council - only 2 responses"
-   - 1/4: Proceed in single-consultant mode with strong warning: "Single consultant only — no cross-model validation"
-   - 0/4: Abort with error: "Council unavailable - all consultants failed"
-
+4. **Handle Partial Responses ($k$ successful of $N_{\text{enabled}}$ active)**
+   - $k = N_{\text{enabled}}$: Full synthesis
+   - $k / N_{\text{enabled}} \ge 0.66$: Proceed with note: "[X] consultant unavailable"
+   - $k / N_{\text{enabled}} \ge 0.50$: Proceed with warning: "Limited council - only $k/$N responses"
+   - $k = 1$ ($N_{\text{enabled}} > 1$): Proceed in single-consultant mode with strong warning
+   - $k = 0$: Abort with error: "Council unavailable - all active consultants failed"
+   - $N_{\text{enabled}} = 0$: Proceed with Claude subagents only
 5. **Apply Weighted Synthesis**
    ```
    For architecture findings, weight:
@@ -349,23 +333,13 @@ fi
 
 1. **Log Agent Selection and Launch Both in Parallel**
 
-   Quick mode runs exactly 2 agents. Log the selection at start:
+   Quick mode runs exactly 2 agents: one external consultant (selected dynamically from enabled consultants in priority order `gemini` $\to$ `codex` $\to$ `glm` $\to$ `kimi`, or `claude-deep-review` if all external are disabled) plus `council:claude-codebase-context`.
+
+   Log the selection at start:
    ```text
-   "Quick mode: running council:gemini-consultant (Flash) + council:claude-codebase-context only.
-    Skipping 5 agents (codex, glm, kimi, claude-deep-review, review-scorer)."
+   "Quick mode: running [selected-external-consultant] + council:claude-codebase-context only.
+    Skipping remaining consultants and deep-review/scorer."
    ```
-
-   **Running:**
-
-   | Agent | Model | Role |
-   |-------|-------|------|
-   | `council:gemini-consultant` | Gemini 3.8 Flash (`google-antigravity/gemini-3.8-flash`) | Fast external perspective |
-   | `council:claude-codebase-context` | Sonnet | Codebase-aware depth (native tool access) |
-
-   **Skipped** (reserved for full council escalation):
-   - `council:codex-consultant`, `council:glm-consultant`, `council:kimi-consultant` — cost/time
-   - `council:claude-deep-review` — opus cost, reserved for full review
-   - `council:review-scorer` — not needed unless escalating
 
    Launch simultaneously:
 
@@ -454,16 +428,13 @@ fi
 
 ### Step-by-Step
 
-1. **Assign Adversarial Roles**
+1. **Assign Adversarial Roles Dynamically**
 
-   **Advocates** (find reasons to APPROVE):
-   - Gemini: Focus on architectural soundness
-   - Kimi: Focus on implementation correctness
-
-   **Critics** (find reasons to REJECT):
-   - Codex: Focus on bugs, security holes
-   - GLM: Challenge assumptions, find alternatives
-
+   Pairings adapt based on enabled external consultants ($N_{\text{enabled}}$):
+   - **$N_{\text{enabled}} \ge 4$**: Split enabled list evenly (first half Advocates, second half Critics)
+   - **$N_{\text{enabled}} == 2$** (e.g. Gemini + Codex): Consultant 1 as Advocate, Consultant 2 as Critic
+   - **$N_{\text{enabled}} == 1$**: Single external consultant as Advocate, `claude-deep-review` as Critic
+   - **$N_{\text{enabled}} == 0$**: `claude-codebase-context` as Advocate, `claude-deep-review` as Critic
 2. **Frame Prompts**
    ```
    ADVOCATES:

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -62,12 +62,12 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
    ```
 
 4. **Handle Partial Responses ($k$ successful of $N_{\text{enabled}}$ active)**
-   - $k = N_{\text{enabled}}$: Full synthesis
-   - $k / N_{\text{enabled}} \ge 0.66$: Proceed with note: "[X] consultant unavailable"
-   - $k / N_{\text{enabled}} \ge 0.50$: Proceed with warning: "Limited council - only $k/$N responses"
-   - $k = 1$ ($N_{\text{enabled}} > 1$): Proceed in single-consultant mode with strong warning
-   - $k = 0$: Abort with error: "Council unavailable - all active consultants failed"
    - $N_{\text{enabled}} = 0$: Proceed with Claude subagents only
+   - $k = N_{\text{enabled}}$ ($k > 0$): Full synthesis
+   - $k = 1$ ($N_{\text{enabled}} > 1$): Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation"
+   - $k / N_{\text{enabled}} \ge 0.66$ ($k > 1$): Proceed with note: "[X] consultant unavailable"
+   - $k / N_{\text{enabled}} \ge 0.50$ ($k > 1$): Proceed with warning: "Limited council - only $k/$N responses"
+   - $k = 0$ ($N_{\text{enabled}} > 0$): Abort with error: "Council unavailable - all active consultants failed"
 5. **Apply Weighted Synthesis**
    ```
    For architecture findings, weight:
@@ -197,21 +197,29 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
 
    - **`native`** backend (default):
      ```text
-     # Deep review uses configured model ($DEEP_MODEL: opus or sonnet)
+     # Launch only if present in $ENABLED_SUBAGENTS:
      Task(council:claude-deep-review, model=$DEEP_MODEL): "Review for security, bugs, performance."
      Task(council:claude-codebase-context, model=sonnet): "Check quality, CLAUDE.md, git history, docs."
      ```
-   - **`omp`** backend (utilizes OMP Anthropic quota or profile):
+   - **`omp`** backend (utilizes OMP Anthropic quota or profile; requires isolated sandbox and --no-tools):
      ```bash
-     omp -p --model "anthropic/claude-${DEEP_MODEL}" "Review for security, bugs, performance @\"$sandbox/diff\""
-     omp -p --model "anthropic/claude-sonnet" "Check quality, compliance, git history @\"$sandbox/diff\""
+     (
+       repo="$PWD"; sandbox=$(mktemp -d); trap 'rm -rf "$sandbox"' EXIT
+       git diff main...HEAD > "$sandbox/changes.diff"
+       cd "$sandbox"
+       # If claude-deep-review enabled in $ENABLED_SUBAGENTS:
+       omp -p --no-tools --model "anthropic/claude-${DEEP_MODEL}" "Review for security, bugs, performance @\"$sandbox/changes.diff\""
+       # If claude-codebase-context enabled in $ENABLED_SUBAGENTS:
+       omp -p --no-tools --model "anthropic/claude-sonnet" "Check quality, compliance, history @\"$sandbox/changes.diff\""
+     )
      ```
    - **`claude-cli`** backend (CLI blind mode, or `--blind` flag):
      ```bash
+     # If claude-deep-review enabled in $ENABLED_SUBAGENTS:
      claude -p --model "$DEEP_MODEL" "Review for security, bugs, performance: [diff]"
+     # If claude-codebase-context enabled in $ENABLED_SUBAGENTS:
      claude -p --model "sonnet" "Check quality, compliance, history: [diff]"
      ```
-
    All active external consultants and enabled Claude subagents run simultaneously.
    Each MUST return findings with mandatory `location` field (`file:line`).
 
@@ -343,34 +351,37 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
 
 1. **Resolve Quick Consultant and Launch Both in Parallel**
 
-   Run `"${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-quick`. This resolves `settings.quick_consultant` against enabled consultants and installed CLIs. An explicit unavailable or disabled choice falls back to `auto`, which uses `gemini` → `codex` → `glm` → `kimi`. If it returns `none`, use `council:claude-deep-review` as the external-slot substitute.
+   Run `"${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-quick`. This resolves `settings.quick_consultant` against enabled consultants and installed CLIs. An explicit unavailable or disabled choice falls back to `auto`, which uses `gemini` → `codex` → `glm` → `kimi`.
 
-   Quick mode runs exactly 2 agents: the resolved external consultant (or `council:claude-deep-review` when none is available) plus `council:claude-codebase-context`.
+   Quick mode runs up to 2 enabled agents:
+   - **External Slot**:
+     - If `get-quick` returns an external consultant name (`gemini`, `codex`, `glm`, `kimi`): launch `Task(council:[name]-consultant, timeout=120s)`.
+     - If `get-quick` returns `none`: if `claude-deep-review` is enabled in `$ENABLED_SUBAGENTS`, launch `Task(council:claude-deep-review, model=$DEEP_MODEL, timeout=120s)` as the external substitute.
+   - **Codebase Depth Slot**:
+     - Launch `Task(council:claude-codebase-context, model=sonnet)` only if enabled in `$ENABLED_SUBAGENTS`.
+   - If neither participant is enabled, abort with: "No external consultants or Claude subagents enabled for quick triage."
 
    Log the selection at start:
    ```text
-   "Quick mode: running [selected-consultant] + council:claude-codebase-context only.
+   "Quick mode: running [selected participants from ENABLED_SUBAGENTS].
     Skipping remaining consultants and scorer."
    ```
 
-   Launch simultaneously:
+   Launch enabled participants simultaneously:
 
    ```text
+   # External slot (if resolved to external consultant):
    Task(council:[selected-consultant]-consultant, timeout=120s):
-   "Quick review of [artifact]. Return JSON with:
-   - consultant: your name (e.g. 'gemini')
-   - success: true
-   - confidence: 0-1
-   - severity: none|low|medium|high|critical
-   - findings: [{type, severity, description, recommendation}]
-   - summary: 1-3 sentence overview"
+   "Quick review of [artifact]. Return JSON: {consultant, success, confidence, severity, findings, summary}"
 
+   # Or External slot (if fallback to claude-deep-review):
+   Task(council:claude-deep-review, model=$DEEP_MODEL, timeout=120s):
+   "Quick review of [artifact] for security, bugs, performance. Return JSON."
+
+   # Codebase depth slot (if enabled in $ENABLED_SUBAGENTS):
    Task(council:claude-codebase-context, model=sonnet):
-   "Quick review of [artifact]. Use tool access to check against
-   codebase conventions, CLAUDE.md rules, git history, and documentation.
-   Return JSON with same structure (consultant, success, confidence, severity, findings, summary)."
+   "Quick review of [artifact] against conventions, CLAUDE.md, git history. Return JSON."
    ```
-
 2. **Validate Responses and Evaluate**
 
    First, validate both responses (see SKILL.md "Response Validation" for full algorithm):
@@ -389,17 +400,14 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
       OR they disagree on severity for the same finding:
      → Escalate to Step 3
    ```
-
-3. **Full Council (Rare)**
+3. **Full Council Escalation (Rare)**
 
    ```text
-   → Launch full council (all 4 external + 2 Claude subagents + scoring)
+   → Launch full council: all enabled external consultants from $ENABLED_CONSULTANTS
+     + enabled Layer 2 Claude subagents from $ENABLED_SUBAGENTS
+     + review-scorer (only if enabled in $ENABLED_SUBAGENTS)
    → Or escalate to human decision
    ```
-
-   If 2 independent perspectives (fast external + codebase-aware internal)
-   can't resolve it, escalate to the complete review pipeline.
-
 ### Decision Tree
 
 ```
@@ -444,6 +452,7 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
 
    Pairings adapt based on enabled external consultants ($N_{\text{enabled}}$):
    - **$N_{\text{enabled}} \ge 4$**: Split enabled list evenly (first half Advocates, second half Critics)
+   - **$N_{\text{enabled}} == 3$**: Consultant 1 and 2 as Advocates, Consultant 3 as Critic
    - **$N_{\text{enabled}} == 2$** (e.g. Gemini + Codex): Consultant 1 as Advocate, Consultant 2 as Critic
    - **$N_{\text{enabled}} == 1$**: Single external consultant as Advocate, `claude-deep-review` as Critic
    - **$N_{\text{enabled}} == 0$**: `claude-codebase-context` as Advocate, `claude-deep-review` as Critic

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -7,10 +7,10 @@ Before ANY workflow, execute:
 ```bash
 #!/bin/bash
 # Pre-flight checks: resolve config and verify CLIs for enabled consultants
+# council-config.sh automatically falls back to defaults if unconfigured
 if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
-  "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" init --auto
+  echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
 fi
-
 ENABLED_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled)
 SUBAGENT_BACKEND=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-subagent-backend)
 DEEP_MODEL=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-deep-model)

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -7,21 +7,31 @@ Before ANY workflow, execute:
 ```bash
 #!/bin/bash
 # Pre-flight checks: resolve config and verify CLIs for enabled consultants
-# council-config.sh automatically falls back to defaults if unconfigured
-if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
-  echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
+CONFIG_SCRIPT="${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh"
+if [ -x "$CONFIG_SCRIPT" ] && (command -v jq >/dev/null 2>&1 || command -v jaq >/dev/null 2>&1); then
+  if ! "$CONFIG_SCRIPT" exists; then
+    echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
+  fi
+  AVAILABLE_CONSULTANTS=$("$CONFIG_SCRIPT" get-available)
+  SUBAGENT_BACKEND=$("$CONFIG_SCRIPT" get-subagent-backend)
+  DEEP_MODEL=$("$CONFIG_SCRIPT" get-deep-model)
+  ENABLED_SUBAGENTS=$("$CONFIG_SCRIPT" get-enabled-subagents)
+else
+  AVAILABLE_CONSULTANTS=""
+  command -v omp >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} gemini"
+  command -v codex >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} codex"
+  SUBAGENT_BACKEND="native"
+  DEEP_MODEL="opus"
+  ENABLED_SUBAGENTS="claude-deep-review claude-codebase-context review-scorer"
 fi
-AVAILABLE_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-available)
-SUBAGENT_BACKEND=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-subagent-backend)
-DEEP_MODEL=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-deep-model)
-ENABLED_SUBAGENTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled-subagents)
 echo "Available consultants: ${AVAILABLE_CONSULTANTS}"
 echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=${ENABLED_SUBAGENTS}"
 
-# Verify required CLIs only for enabled consultants and backend
-"${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" check-cli || {
-  echo "WARN: Missing CLIs for some enabled consultants/backend. Proceeding with available ones."
-}
+if [ -x "$CONFIG_SCRIPT" ]; then
+  "$CONFIG_SCRIPT" check-cli || {
+    echo "WARN: Missing CLIs for some enabled consultants/backend. Proceeding with available ones."
+  }
+fi
 ```
 
 ---

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -7,19 +7,19 @@ Before ANY workflow, execute:
 ```bash
 #!/bin/bash
 # Pre-flight checks: resolve config and verify CLIs for enabled consultants
-if ! "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" exists; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" init --auto
+if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
+  "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" init --auto
 fi
 
-ENABLED_CONSULTANTS=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-enabled)
-SUBAGENT_BACKEND=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-subagent-backend)
-DEEP_MODEL=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-deep-model)
-ENABLED_SUBAGENTS=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-enabled-subagents)
+ENABLED_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled)
+SUBAGENT_BACKEND=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-subagent-backend)
+DEEP_MODEL=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-deep-model)
+ENABLED_SUBAGENTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled-subagents)
 echo "Enabled consultants: ${ENABLED_CONSULTANTS}"
 echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=${ENABLED_SUBAGENTS}"
 
 # Verify required CLIs only for enabled consultants and backend
-"${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" check-cli || {
+"${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" check-cli || {
   echo "WARN: Missing CLIs for some enabled consultants/backend. Proceeding with available ones."
 }
 ```

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -403,7 +403,7 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
 3. **Full Council Escalation (Rare)**
 
    ```text
-   → Launch full council: all enabled external consultants from $ENABLED_CONSULTANTS
+   → Launch full council: all available external consultants from $AVAILABLE_CONSULTANTS
      + enabled Layer 2 Claude subagents from $ENABLED_SUBAGENTS
      + review-scorer (only if enabled in $ENABLED_SUBAGENTS)
    → Or escalate to human decision
@@ -505,7 +505,7 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
 ### Round 1: Independent Opinions
 
 ```
-Task(active consultants in $ENABLED_CONSULTANTS):
+Task(active consultants in $AVAILABLE_CONSULTANTS):
 "We need to decide: [decision question]
 
 Options:
@@ -521,7 +521,7 @@ Return: {choice: 'A|B|C', confidence: 0-1, reasoning: '...'}"
 ### Round 2: Cross-Examination
 
 ```
-Task(active consultants in $ENABLED_CONSULTANTS):
+Task(active consultants in $AVAILABLE_CONSULTANTS):
 "Round 1 results:
 [summary of choices and reasoning from active consultants]
 
@@ -539,7 +539,7 @@ Review these perspectives:
 - Disagreement is on preferences, not facts
 - More rounds won't produce new information
 ```
-Task(active consultants in $ENABLED_CONSULTANTS):
+Task(active consultants in $AVAILABLE_CONSULTANTS):
 "The council remains split after cross-examination.
 
 Agreement: [list]
@@ -557,14 +557,14 @@ This is your FINAL recommendation. If you've changed your mind, explain why."
 - Confidence: [score] (≥ 2/3 agree after Round 2)
 
 ### Vote Distribution
-(One row per active consultant in $ENABLED_CONSULTANTS)
+(One row per active consultant in $AVAILABLE_CONSULTANTS)
 | Consultant | R1 | R2 | R3 | Final |
 |------------|----|----|----| ------|
 | [Consultant 1] | A | A | - | A |
 | [Consultant 2] | C | C | - | C (dissent) |
 
 ### Dissenting Views
-[Capture reasoning of any dissenting consultant from $ENABLED_CONSULTANTS — it may reveal blind spots]
+[Capture reasoning of any dissenting consultant from $AVAILABLE_CONSULTANTS — it may reveal blind spots]
 ### Rounds Required: 2
 ### Rate Limits Encountered: None
 ```

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -67,7 +67,7 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
    - $k = 1$ ($N_{\text{enabled}} > 1$): Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation"
    - $k / N_{\text{enabled}} \ge 0.66$ ($k > 1$): Proceed with note: "[X] consultant unavailable"
    - $k / N_{\text{enabled}} \ge 0.50$ ($k > 1$): Proceed with warning: "Limited council - only $k/$N responses"
-   - $k = 0 ($N_{\text{enabled}} > 0$): Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error
+   - $k = 0$ ($N_{\text{enabled}} > 0$): Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error
 5. **Apply Weighted Synthesis**
    ```
    For architecture findings, weight:

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -345,7 +345,7 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
 ### When to Use
 - Quick validations (`/council quick`)
 - Time-critical decisions
-- Cost-sensitive reviews (always 2 calls, rarely more)
+- Cost-sensitive reviews (up to 2 calls, rarely more)
 
 ### Step-by-Step
 

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -71,13 +71,13 @@ fi
     findings:[{type, severity, description, recommendation}], summary:'...'}"
    ```
 
-4. **Handle Partial Responses ($k$ successful of $N_{\text{available}}$ active)**
-   - $N_{\text{available}} = 0$: Proceed with Claude subagents only
-   - $k = N_{\text{available}}$ ($k > 0$): Full synthesis
-   - $k = 1$ ($N_{\text{available}} > 1$): Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation"
-   - $k / N_{\text{available}} \ge 0.66$ ($k > 1$): Proceed with note: "[X] consultant unavailable"
-   - $k / N_{\text{available}} \ge 0.50$ ($k > 1$): Proceed with warning: "Limited council - only $k/$N responses"
-   - $k = 0$ ($N_{\text{available}} > 0$): Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error
+4. **Handle Partial Responses (k successful of N_available active)**
+   - N_available == 0: Proceed with Claude subagents only
+   - k == N_available (k > 0): Full synthesis
+   - k == 1 (N_available > 1): Proceed in single-consultant mode with strong warning: "Single external consultant only — no cross-model validation"
+   - k / N_available >= 0.66 (k > 1): Proceed with note: "[X] consultant unavailable"
+   - k / N_available >= 0.50 (k > 1): Proceed with warning: "Limited council - only k/N_available responses"
+   - k == 0 (N_available > 0): Layer 1 failed. If Layer 2 (Claude subagents) available, proceed with Layer 2 only; else abort with error
 5. **Apply Weighted Synthesis**
    ```
    For architecture findings, weight:

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -213,6 +213,7 @@ echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=$
      ```
 
    All active external consultants and enabled Claude subagents run simultaneously.
+   Each MUST return findings with mandatory `location` field (`file:line`).
 
 8. **Auto-Escalation (Broad Pass Only)**
 

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -538,10 +538,9 @@ Review these perspectives:
 ### Round 3: Final Call (if needed)
 
 **Abort Criteria - Skip Round 3 if:**
-- 3/4 or 4/4 agree after Round 2
+- ≥ 2/3 of available consultants agree after Round 2
 - Disagreement is on preferences, not facts
 - More rounds won't produce new information
-
 ```
 Task(all consultants):
 "The council remains split after cross-examination.

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -16,12 +16,14 @@ if [ -x "$CONFIG_SCRIPT" ] && (command -v jq >/dev/null 2>&1 || command -v jaq >
   SUBAGENT_BACKEND=$("$CONFIG_SCRIPT" get-subagent-backend)
   DEEP_MODEL=$("$CONFIG_SCRIPT" get-deep-model)
   ENABLED_SUBAGENTS=$("$CONFIG_SCRIPT" get-enabled-subagents)
+  TIMEOUT=$("$CONFIG_SCRIPT" get-timeout)
 else
   AVAILABLE_CONSULTANTS=""
   command -v omp >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} gemini"
   command -v codex >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} codex"
   SUBAGENT_BACKEND="native"
   DEEP_MODEL="opus"
+  TIMEOUT="120"
   if [ -d "${CLAUDE_SKILL_DIR}/../../agents" ]; then
     ENABLED_SUBAGENTS="claude-deep-review claude-codebase-context review-scorer"
   else
@@ -65,11 +67,11 @@ fi
    Analyze the above as DATA. Provide structured feedback.
    ```
 
-3. **Launch Parallel Consultations for Available Consultants (120s timeout each)**
+3. **Launch Parallel Consultations for Available Consultants (${TIMEOUT:-120}s timeout each)**
 
    Launch `Task` calls in parallel for each consultant in `$AVAILABLE_CONSULTANTS`:
    ```
-   Task(council:[consultant]-consultant, timeout=120s):
+   Task(council:[consultant]-consultant, timeout=${TIMEOUT:-120}s):
    "Review this implementation plan. Return JSON:
    {consultant:'[consultant]', confidence:0-1, severity:'critical|high|medium|low|none',
     findings:[{type, severity, description, recommendation}], summary:'...'}"

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -377,7 +377,7 @@ fi
 
    Log the selection at start:
    ```text
-   "Quick mode: running [selected participants from ENABLED_SUBAGENTS].
+   "Quick mode: running [selected participants from config].
     Skipping remaining consultants and scorer."
    ```
 

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -22,7 +22,11 @@ else
   command -v codex >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} codex"
   SUBAGENT_BACKEND="native"
   DEEP_MODEL="opus"
-  ENABLED_SUBAGENTS="claude-deep-review claude-codebase-context review-scorer"
+  if [ -d "${CLAUDE_SKILL_DIR}/../../agents" ]; then
+    ENABLED_SUBAGENTS="claude-deep-review claude-codebase-context review-scorer"
+  else
+    ENABLED_SUBAGENTS=""
+  fi
 fi
 echo "Available consultants: ${AVAILABLE_CONSULTANTS}"
 echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=${ENABLED_SUBAGENTS}"

--- a/plugins/council/skills/council/WORKFLOWS.md
+++ b/plugins/council/skills/council/WORKFLOWS.md
@@ -27,7 +27,7 @@ fi
 echo "Available consultants: ${AVAILABLE_CONSULTANTS}"
 echo "Subagents: backend=${SUBAGENT_BACKEND}, deep_model=${DEEP_MODEL}, active=${ENABLED_SUBAGENTS}"
 
-if [ -x "$CONFIG_SCRIPT" ]; then
+if [ -x "$CONFIG_SCRIPT" ] && (command -v jq >/dev/null 2>&1 || command -v jaq >/dev/null 2>&1); then
   "$CONFIG_SCRIPT" check-cli || {
     echo "WARN: Missing CLIs for some enabled consultants/backend. Proceeding with available ones."
   }

--- a/plugins/council/skills/review-plan/SKILL.md
+++ b/plugins/council/skills/review-plan/SKILL.md
@@ -94,25 +94,23 @@ Resolve active consultants based on configuration and CLI availability:
 if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
   "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" init --auto
 fi
-ENABLED_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled)
+AVAILABLE_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-available)
+ENABLED_SUBAGENTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled-subagents)
 DEEP_MODEL=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-deep-model)
-
-# Filter enabled consultants by CLI availability
-AVAILABLE_CONSULTANTS=""
-for c in $ENABLED_CONSULTANTS; do
-  case "$c" in
-    codex) command -v codex >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} $c" ;;
-    gemini|glm|kimi) command -v omp >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} $c" ;;
-  esac
-done
 ```
 
 **Consultant Selection**:
-- If 2 or more external consultants are available: Launch the first 2 from `$AVAILABLE_CONSULTANTS` (e.g. `gemini` and `codex`).
-- If only 1 external consultant is available: Launch that external consultant and pair with `council:claude-deep-review` (model: `$DEEP_MODEL`).
-- If 0 external consultants are available: Launch `council:claude-deep-review` (model: `$DEEP_MODEL`) and `council:claude-codebase-context` (sonnet).
+- **If 2 or more external consultants are available**: Launch the first 2 from `$AVAILABLE_CONSULTANTS` (e.g. `gemini` and `codex`).
+- **If only 1 external consultant is available**:
+  - Launch that 1 external consultant.
+  - Pair with `council:claude-deep-review` (model: `$DEEP_MODEL`) if enabled in `$ENABLED_SUBAGENTS`.
+  - Otherwise, pair with `council:claude-codebase-context` (model: `sonnet`) if enabled in `$ENABLED_SUBAGENTS`.
+- **If 0 external consultants are available**:
+  - If both `claude-deep-review` and `claude-codebase-context` are enabled in `$ENABLED_SUBAGENTS`: Launch `council:claude-deep-review` (model: `$DEEP_MODEL`) and `council:claude-codebase-context` (sonnet).
+  - If only one is enabled: Launch that single enabled subagent.
+  - If neither is enabled: Abort plan review with message: "No external consultants or Claude subagents enabled for plan review."
 
-Launch both consultants in parallel using the Task tool. Both receive the **same prompt**.
+Launch available consultants in parallel using the Task tool. Both receive the **same prompt**.
 #### Secret-Scanning Gate
 
 Before sending plan content to external consultants, check for secrets:

--- a/plugins/council/skills/review-plan/SKILL.md
+++ b/plugins/council/skills/review-plan/SKILL.md
@@ -92,7 +92,7 @@ Resolve active consultants based on configuration and CLI availability:
 
 ```bash
 if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
-  "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" init --auto
+  echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
 fi
 AVAILABLE_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-available)
 ENABLED_SUBAGENTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled-subagents)
@@ -110,7 +110,7 @@ DEEP_MODEL=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-deep-mode
   - If only one is enabled: Launch that single enabled subagent.
   - If neither is enabled: Abort plan review with message: "No external consultants or Claude subagents enabled for plan review."
 
-Launch available consultants in parallel using the Task tool. Both receive the **same prompt**.
+Launch available consultants in parallel using the Task tool. All launched consultants receive the **same prompt**.
 #### Secret-Scanning Gate
 
 Before sending plan content to external consultants, check for secrets:

--- a/plugins/council/skills/review-plan/SKILL.md
+++ b/plugins/council/skills/review-plan/SKILL.md
@@ -22,7 +22,7 @@ digraph review_plan {
 
   locate [label="Step 1: Locate Plan"];
   verify [label="Step 2: Codebase Verification"];
-  launch [label="Step 3: Launch Consultants\n(gemini + codex in parallel)"];
+  launch [label="Step 3: Launch Consultants\n(2 consultants in parallel)"];
   synthesize [label="Step 4: Deduplicate & Synthesize"];
   present [label="Step 5: Present Structured Output"];
   decide [label="Step 6: User Decision"];
@@ -88,8 +88,21 @@ Collect all verification results into a structured report:
 
 ### Step 3: Launch Consultants
 
-Launch `council:gemini-consultant` and `council:codex-consultant` in parallel using the Task tool. Both receive the **same prompt**.
+Resolve active consultants based on configuration:
 
+```bash
+if ! "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" exists; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" init --auto
+fi
+ENABLED_CONSULTANTS=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-enabled)
+```
+
+**Consultant Selection**:
+- If 2 or more external consultants are enabled: Launch the first 2 (e.g. `gemini` and `codex`).
+- If only 1 external consultant is enabled: Launch that external consultant and pair with `council:claude-deep-review` (opus).
+- If 0 external consultants are enabled: Launch `council:claude-deep-review` (opus) and `council:claude-codebase-context` (sonnet).
+
+Launch both consultants in parallel using the Task tool. Both receive the **same prompt**.
 #### Secret-Scanning Gate
 
 Before sending plan content to external consultants, check for secrets:

--- a/plugins/council/skills/review-plan/SKILL.md
+++ b/plugins/council/skills/review-plan/SKILL.md
@@ -88,19 +88,29 @@ Collect all verification results into a structured report:
 
 ### Step 3: Launch Consultants
 
-Resolve active consultants based on configuration:
+Resolve active consultants based on configuration and CLI availability:
 
 ```bash
-if ! "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" exists; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" init --auto
+if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
+  "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" init --auto
 fi
-ENABLED_CONSULTANTS=$("${CLAUDE_PLUGIN_ROOT}/scripts/council-config.sh" get-enabled)
+ENABLED_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled)
+DEEP_MODEL=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-deep-model)
+
+# Filter enabled consultants by CLI availability
+AVAILABLE_CONSULTANTS=""
+for c in $ENABLED_CONSULTANTS; do
+  case "$c" in
+    codex) command -v codex >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} $c" ;;
+    gemini|glm|kimi) command -v omp >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} $c" ;;
+  esac
+done
 ```
 
 **Consultant Selection**:
-- If 2 or more external consultants are enabled: Launch the first 2 (e.g. `gemini` and `codex`).
-- If only 1 external consultant is enabled: Launch that external consultant and pair with `council:claude-deep-review` (opus).
-- If 0 external consultants are enabled: Launch `council:claude-deep-review` (opus) and `council:claude-codebase-context` (sonnet).
+- If 2 or more external consultants are available: Launch the first 2 from `$AVAILABLE_CONSULTANTS` (e.g. `gemini` and `codex`).
+- If only 1 external consultant is available: Launch that external consultant and pair with `council:claude-deep-review` (model: `$DEEP_MODEL`).
+- If 0 external consultants are available: Launch `council:claude-deep-review` (model: `$DEEP_MODEL`) and `council:claude-codebase-context` (sonnet).
 
 Launch both consultants in parallel using the Task tool. Both receive the **same prompt**.
 #### Secret-Scanning Gate

--- a/plugins/council/skills/review-plan/SKILL.md
+++ b/plugins/council/skills/review-plan/SKILL.md
@@ -89,16 +89,22 @@ Collect all verification results into a structured report:
 ### Step 3: Launch Consultants
 
 Resolve active consultants based on configuration and CLI availability:
-
 ```bash
-if ! "${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" exists; then
-  echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
+CONFIG_SCRIPT="${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh"
+if [ -x "$CONFIG_SCRIPT" ]; then
+  if ! "$CONFIG_SCRIPT" exists; then
+    echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
+  fi
+  AVAILABLE_CONSULTANTS=$("$CONFIG_SCRIPT" get-available)
+  ENABLED_SUBAGENTS=$("$CONFIG_SCRIPT" get-enabled-subagents)
+  DEEP_MODEL=$("$CONFIG_SCRIPT" get-deep-model)
+else
+  echo "Notice: council-config.sh not found (standalone skill install). Using default consultants and models."
+  AVAILABLE_CONSULTANTS="gemini codex"
+  ENABLED_SUBAGENTS="claude-deep-review claude-codebase-context review-scorer"
+  DEEP_MODEL="opus"
 fi
-AVAILABLE_CONSULTANTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-available)
-ENABLED_SUBAGENTS=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-enabled-subagents)
-DEEP_MODEL=$("${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh" get-deep-model)
 ```
-
 **Consultant Selection**:
 - **If 2 or more external consultants are available**: Launch the first 2 from `$AVAILABLE_CONSULTANTS` (e.g. `gemini` and `codex`).
 - **If only 1 external consultant is available**:

--- a/plugins/council/skills/review-plan/SKILL.md
+++ b/plugins/council/skills/review-plan/SKILL.md
@@ -103,8 +103,12 @@ else
   AVAILABLE_CONSULTANTS=""
   command -v omp >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} gemini"
   command -v codex >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} codex"
-  ENABLED_SUBAGENTS="claude-deep-review claude-codebase-context review-scorer"
   DEEP_MODEL="opus"
+  if [ -d "${CLAUDE_SKILL_DIR}/../../agents" ]; then
+    ENABLED_SUBAGENTS="claude-deep-review claude-codebase-context review-scorer"
+  else
+    ENABLED_SUBAGENTS=""
+  fi
 fi
 ```
 **Consultant Selection**:

--- a/plugins/council/skills/review-plan/SKILL.md
+++ b/plugins/council/skills/review-plan/SKILL.md
@@ -91,7 +91,7 @@ Collect all verification results into a structured report:
 Resolve active consultants based on configuration and CLI availability:
 ```bash
 CONFIG_SCRIPT="${CLAUDE_SKILL_DIR}/../../scripts/council-config.sh"
-if [ -x "$CONFIG_SCRIPT" ]; then
+if [ -x "$CONFIG_SCRIPT" ] && (command -v jq >/dev/null 2>&1 || command -v jaq >/dev/null 2>&1); then
   if ! "$CONFIG_SCRIPT" exists; then
     echo "Notice: Council running with defaults. Run /council:config to customize active consultants."
   fi

--- a/plugins/council/skills/review-plan/SKILL.md
+++ b/plugins/council/skills/review-plan/SKILL.md
@@ -99,8 +99,10 @@ if [ -x "$CONFIG_SCRIPT" ] && (command -v jq >/dev/null 2>&1 || command -v jaq >
   ENABLED_SUBAGENTS=$("$CONFIG_SCRIPT" get-enabled-subagents)
   DEEP_MODEL=$("$CONFIG_SCRIPT" get-deep-model)
 else
-  echo "Notice: council-config.sh not found (standalone skill install). Using default consultants and models."
-  AVAILABLE_CONSULTANTS="gemini codex"
+  echo "Notice: council-config.sh or jq/jaq unavailable (standalone skill install). Using default consultants and models."
+  AVAILABLE_CONSULTANTS=""
+  command -v omp >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} gemini"
+  command -v codex >/dev/null 2>&1 && AVAILABLE_CONSULTANTS="${AVAILABLE_CONSULTANTS} codex"
   ENABLED_SUBAGENTS="claude-deep-review claude-codebase-context review-scorer"
   DEEP_MODEL="opus"
 fi


### PR DESCRIPTION
## Summary

Adds configurable consultant enablement and runtime configuration to the Council plugin, allowing users to enable/disable external consultants and Claude subagents based on active subscriptions, configure preferred quick-triage models, and manage settings project-locally in `.dev/council/config.json` or globally in `~/.config/council/config.json`.

### Key Features

1. **Configuration Engine (`plugins/council/scripts/council-config.sh`)**:
   - Resolves configuration hierarchy: project-local `.dev/council/config.json` (gitignored) $\to$ user-global `~/.config/council/config.json` $\to$ defaults.
   - Probes active subscriptions and installed CLIs:
     - `codex`: checks `command -v codex` and `codex login status` / `OPENAI_API_KEY`.
     - `gemini`: checks `omp usage` for Google Antigravity / `GEMINI_API_KEY`.
     - `glm`: checks `omp usage` for Z.AI / `ZAI_API_KEY`.
     - `kimi`: checks `omp usage` for Kimi Code / `KIMI_API_KEY`.
   - Selective CLI checks: `check-cli` only validates binaries required by currently *enabled* consultants and subagent backends.

2. **Configuration Command (`/council:config` in `commands/config.md`)**:
   - Interactive setup wizard with auto-detection.
   - Subcommands: `show`, `enable <consultant>`, `disable <consultant>`, `quick <consultant|auto>`, `detect`, `init [--auto]`.
   - Subagent controls: `subagent backend <native|omp|claude-cli>`, `subagent model <opus|sonnet>`, `subagent enable <name>`, `subagent disable <name>`.
   - `--global` flag to persist settings across repositories.

3. **SessionStart Preflight Hook (`preflight.sh`)**:
   - Detects unconfigured state and outputs a non-blocking hint: `Council plugin: no config found. Run /council:config to set active consultants.`
   - Verifies CLIs solely for enabled consultants and configured backend.

4. **Dynamic Workflow Adaptations**:
   - **Step 0 Config Gate**: Skills read configuration at invocation start; auto-initializes on first run.
   - **Dynamic Partial Success**: Ratios evaluated against $N_{\text{enabled}}$ (e.g. 2/2 is full consensus; 1/2 is limited council). If $N_{\text{enabled}} = 0$, proceeds with Layer 2 Claude subagents with advisory note.
   - **Configurable Quick Mode**: `get-quick` resolves preferred external consultant with priority fallback to `auto`.
   - **Subagent Backends & Model Overrides**: Supports `native` (host Task tool), `omp` (utilizing OMP profile/quota), or `claude-cli` (blind mode). Deep review model tier configurable to `opus` or `sonnet`.
   - **Dynamic Adversarial Pairing**: Teams split evenly across $N_{\text{enabled}}$ (or pair with subagents if $N < 2$).
   - **`review-plan` Skill**: Dynamically pairs the top 2 enabled external consultants or falls back to subagents.

### Verification

- `bun scripts/validate-plugins.mjs` passed.
- `bash -n` syntax check passed on all scripts.
- Unit tested `council-config.sh` across defaults, capability detection, toggling, quick consultant resolution, and subagent controls in isolated test repositories.
- Verified missing CLI simulation: warnings fire only when the missing tool belongs to an enabled consultant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/council:config` for managing consultants, scopes, quick mode, Claude subagents, models, and optional scoring.
  * Added dynamic consultant selection and configurable Claude subagent backends.
  * Added the `config` trigger to the Council skill.

* **Improvements**
  * Reviews now adapt to available consultants and support partial results.
  * Preflight checks provide clearer guidance when configuration tools are unavailable.
  * Configuration initialization supports global scope, automatic setup, and forced updates.

* **Documentation**
  * Updated setup, structure, workflows, badges, prerequisites, and command usage documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->